### PR TITLE
fix: paperless-ngx deployment (authentik 2026.2.x compat + postgres dep)

### DIFF
--- a/kubernetes/apps/default/authentik/app/blueprints/paperless-ngx.yaml
+++ b/kubernetes/apps/default/authentik/app/blueprints/paperless-ngx.yaml
@@ -4,6 +4,7 @@ metadata:
   name: Paperless-ngx OAuth2 Provider and Application
 context:
   authorization_flow: &authorization_flow !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+  invalidation_flow: &invalidation_flow !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
   property_mappings: &property_mappings
     - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
     - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
@@ -16,11 +17,13 @@ entries:
     attrs:
       name: paperless-ngx
       authorization_flow: *authorization_flow
+      invalidation_flow: *invalidation_flow
       client_type: confidential
       client_id: !Env PAPERLESS_CLIENT_ID
       client_secret: !Env PAPERLESS_CLIENT_SECRET
-      redirect_uris: |
-        https://paperless.{{ env "SECRET_DOMAIN" }}/accounts/oidc/authentik/login/callback/
+      redirect_uris:
+        - url: "https://paperless.{{ env \"SECRET_DOMAIN\" }}/accounts/oidc/authentik/login/callback/"
+          matching_mode: strict
       property_mappings: *property_mappings
       signing_key: *signing_key
 

--- a/kubernetes/apps/default/paperless-ngx/ks.yaml
+++ b/kubernetes/apps/default/paperless-ngx/ks.yaml
@@ -18,6 +18,8 @@ spec:
       namespace: database
     - name: longhorn
       namespace: longhorn-system
+    - name: postgres
+      namespace: database
   interval: 1h
   path: ./kubernetes/apps/default/paperless-ngx/app
   postBuild:


### PR DESCRIPTION
Fixes broken Paperless-NGX deployment:

- Add missing `invalidation_flow` to Authentik OAuth2 blueprint (required since 2026.2.x)
- Update `redirect_uris` to new list-of-objects format
- Add missing postgres dependency to Kustomization

Without these changes, the Authentik blueprint fails to apply and Paperless can race ahead of the database.