### PR TITLE
fix(volsync): disable pruning on PVCs

### DIFF
--- a/kubernetes/components/volsync/pvc.yaml
+++ b/kubernetes/components/volsync/pvc.yaml
@@ -4,6 +4,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: ${APP}
   labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled
     kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
 spec:
   accessModes:


### PR DESCRIPTION
Prevent Flux from deleting existing PVCs during volsync migration.