### PR TITLE
fix(forejo): set storageClass on shared PVC to match existing claim

### DIFF
--- a/kubernetes/apps/default/forejo/app/helmrelease.yaml
+++ b/kubernetes/apps/default/forejo/app/helmrelease.yaml
@@ -37,6 +37,7 @@ spec:
     persistence:
       enabled: true
       existingClaim: forejo
+      storageClass: longhorn
 
     deployment:
       env:


### PR DESCRIPTION
Flux re-render after #755 merge hits PVC immutability error: chart templates storageClassName as null but existing PVC has longhorn.