### PR TITLE
fix(sabnzbd): reduce memory request/limit for scheduling

### DIFF
--- a/kubernetes/apps/default/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/default/sabnzbd/app/helmrelease.yaml
@@ -39,8 +39,9 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                memory: 512Mi
               limits:
-                memory: 8Gi
+                memory: 4Gi
     defaultPodOptions:
       automountServiceAccountToken: false
       securityContext:


### PR DESCRIPTION
Reduces memory limit from 8Gi to 4Gi and adds 512Mi request based on VictoriaMetrics usage data.