### PR TITLE
fix: disable intel-gpu health monitoring

### DIFF
--- a/kubernetes/apps/kube-system/intel-gpu-resource-driver/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/intel-gpu-resource-driver/app/helmrelease.yaml
@@ -13,3 +13,6 @@ spec:
     cdi:
       staticPath: /var/cdi/static
       dynamicPath: /var/cdi/dynamic
+    kubeletPlugin:
+      healthMonitoring:
+        enabled: false


### PR DESCRIPTION
v0.10.0 defaults healthMonitoring.enabled to true, which requires xpumd daemon. Nodes don't have it.