### PR TITLE
fix(slskd): add upgrade remediation and increase Helm timeout

### DIFF
--- a/kubernetes/apps/default/slskd/app/helmrelease.yaml
+++ b/kubernetes/apps/default/slskd/app/helmrelease.yaml
@@ -9,9 +9,18 @@ spec:
     kind: OCIRepository
     name: slskd
   interval: 1h
+  timeout: 10m
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
   values:
     controllers:
       slskd:
+        strategy: Recreate
         annotations:
           reloader.stakater.com/auto: "true"
         containers:


### PR DESCRIPTION
Adjust the HelmRelease timeout and remediation settings so slskd rollouts do not wedge after a single timeout.