### PR TITLE
fix(gitlab-runner): set seccompProfile=RuntimeDefault for PodSecurity restricted

### DIFF
--- a/kubernetes/apps/gitlab-runner/runner/app/helmrelease.yaml
+++ b/kubernetes/apps/gitlab-runner/runner/app/helmrelease.yaml
@@ -55,6 +55,8 @@ spec:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
       capabilities:
         drop: [ALL]
 
@@ -87,20 +89,24 @@ spec:
               run_as_non_root = true
               run_as_user = 1000
               fs_group = 1000
+            [runners.kubernetes.pod_security_context.seccomp_profile]
+              type = "RuntimeDefault"
             [runners.kubernetes.build_container_security_context]
-              # Kaniko writes to /kaniko + /tmp, so build container is not RO.
-              # Helper container stays RO (see helper_container_security_context below).
               allow_privilege_escalation = false
               read_only_root_filesystem = false
               run_as_non_root = true
               [runners.kubernetes.build_container_security_context.capabilities]
                 drop = ["ALL"]
+              [runners.kubernetes.build_container_security_context.seccomp_profile]
+                type = "RuntimeDefault"
             [runners.kubernetes.helper_container_security_context]
               allow_privilege_escalation = false
               read_only_root_filesystem = true
               run_as_non_root = true
               [runners.kubernetes.helper_container_security_context.capabilities]
                 drop = ["ALL"]
+              [runners.kubernetes.helper_container_security_context.seccomp_profile]
+                type = "RuntimeDefault"
             [[runners.kubernetes.volumes.empty_dir]]
               name = "build-tmp"
               mount_path = "/builds"


### PR DESCRIPTION
## Summary

Phase 3 UAT (Test 6) caught: gitlab-runner controller ReplicaSet stuck at `FailedCreate` because pods violate the namespace's PodSecurity `restricted:latest` policy — `seccompProfile.type` was unset on both the controller pod and the K8s-executor build/helper containers.

## Fix

- Controller pod: `securityContext.seccompProfile.type=RuntimeDefault`
- Job pods (TOML config.toml): added `[runners.kubernetes.pod_security_context.seccomp_profile]`, `[runners.kubernetes.build_container_security_context.seccomp_profile]`, and `[runners.kubernetes.helper_container_security_context.seccomp_profile]` blocks with `type = "RuntimeDefault"`.

## Test plan

After merge + reconcile:
```
kubectl -n gitlab-runner get pods -w
```
Expect controller pod to reach Ready 1/1, no `FailedCreate` events on the ReplicaSet.

## Related

Phase 3 UAT gap. Test 5 (OIDC) is being debugged separately — it's a pre-existing Authentik blueprint worker issue, not a Phase 3 defect.