### PR TITLE
fix(gitlab): enable admin access via Authentik SSO groups

### DIFF
--- a/kubernetes/apps/default/authentik/app/blueprints/gitlab.yaml
+++ b/kubernetes/apps/default/authentik/app/blueprints/gitlab.yaml
@@ -18,12 +18,38 @@ context:
     - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
     - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
     - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+  groups_scope_mapping: &groups_scope_mapping
+    - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+    - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+    - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+    - !KeyOf gitlab-groups-scope
   signing_key:
     !Find &signing_key [
       authentik_crypto.certificatekeypair,
       [name, authentik Self-signed Certificate],
     ]
 entries:
+  # Custom scope mapping to emit groups claim
+  - model: authentik_providers_oauth2.scopemapping
+    id: gitlab-groups-scope
+    identifiers:
+      name: gitlab-groups
+    attrs:
+      name: gitlab-groups
+      scope_name: groups
+      expression: |
+        return {
+          "groups": [group.name for group in user.ak_groups.all()]
+        }
+
+  # GitLab administrators group
+  - model: authentik_core.group
+    id: gitlab-admins-group
+    identifiers:
+      name: gitlab-admins
+    attrs:
+      name: gitlab-admins
+
   # OAuth2 Provider for GitLab
   - model: authentik_providers_oauth2.oauth2provider
     identifiers:
@@ -38,7 +64,7 @@ entries:
       redirect_uris:
         - url: "https://gitlab.melotic.dev/users/auth/openid_connect/callback"
           matching_mode: strict
-      property_mappings: *property_mappings
+      property_mappings: *groups_scope_mapping
       signing_key: *signing_key
 
   # Application for GitLab

--- a/kubernetes/apps/gitlab/gitlab/app/externalsecret.yaml
+++ b/kubernetes/apps/gitlab/gitlab/app/externalsecret.yaml
@@ -94,7 +94,7 @@ spec:
           label: Authentik
           args:
             name: openid_connect
-            scope: [openid, profile, email]
+            scope: [openid, profile, email, groups]
             response_type: code
             issuer: https://sso.melotic.dev/application/o/gitlab/
             discovery: true
@@ -104,6 +104,8 @@ spec:
               identifier: {{ .client_id | quote }}
               secret: {{ .client_secret | quote }}
               redirect_uri: https://gitlab.melotic.dev/users/auth/openid_connect/callback
+            gitlab:
+              admin_groups: ["gitlab-admins"]
   data:
     - secretKey: client_id
       remoteRef:


### PR DESCRIPTION
Closes the Phase 3 UAT Test 6 gap: SSO-authenticated users could not be granted GitLab admin, so nobody could mint a runner registration token, leaving `gitlab-runner` in CrashLoopBackOff (`PANIC: The registration-token needs to be entered`) and blocking Test 7 (Harbor Kaniko CI job).

## Changes

### `kubernetes/apps/default/authentik/app/blueprints/gitlab.yaml`
- Define `gitlab-admins` Authentik group
- Add custom `groups` OAuth2 scope mapping that emits a `groups` claim listing the user's group names
- Wire the new scope into the GitLab OAuth2 provider's `property_mappings`

### `kubernetes/apps/gitlab/gitlab/app/externalsecret.yaml`
- Add `groups` to OmniAuth `args.scope`
- Add `args.gitlab.admin_groups: ["gitlab-admins"]` so members of that group are auto-promoted to GitLab admin on SSO login
- Existing keys (`client_id`, `client_secret`, `discovery`, etc.) preserved

`autoSignInWithProvider: openid_connect` is intentionally retained; break-glass to the `root` initial-password login is `https://gitlab.melotic.dev/users/sign_in?auto_sign_in=false`.

## Manual follow-up after merge + Flux reconcile

1. Authentik UI → assign your user to `gitlab-admins`
2. SSO into GitLab → Admin → CI/CD → Runners → mint fresh `glrt-…` token
3. 1Password: update item `gitlab-runner`, field `runner_token`
4. `kubectl -n gitlab-runner delete secret gitlab-runner-token` (forces ESO re-sync) and restart the runner Deployment
5. Verify runner shows online; run a trivial CI job to confirm Test 7

## Verification

`flux-local test` + `flux-local diff` will run on this PR. After merge, re-run `/gsd-verify-work 3` to flip Tests 6 & 7 green.