### PR TITLE
revert: drop OIDC admin_groups wiring (GitLab CE silently ignores it)

### DIFF
--- a/kubernetes/apps/default/authentik/app/blueprints/gitlab.yaml
+++ b/kubernetes/apps/default/authentik/app/blueprints/gitlab.yaml
@@ -14,42 +14,21 @@ context:
       authentik_flows.flow,
       [slug, default-provider-invalidation-flow],
     ]
+  # GitLab CE silently ignores admin_groups (EE-only feature). Use
+  # `bin/rails runner "u=User.find_by_username(...); u.admin=true; u.save!"`
+  # against the gitlab-webservice pod for admin promotion. See debug session
+  # gitlab-sso-not-admin. Do not re-add a groups scope mapping until the
+  # GitLab Helm release is switched to the EE edition.
   property_mappings: &property_mappings
     - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
     - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
     - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
-  groups_scope_mapping: &groups_scope_mapping
-    - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
-    - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
-    - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
-    - !KeyOf gitlab-groups-scope
   signing_key:
     !Find &signing_key [
       authentik_crypto.certificatekeypair,
       [name, authentik Self-signed Certificate],
     ]
 entries:
-  # Custom scope mapping to emit groups claim
-  - model: authentik_providers_oauth2.scopemapping
-    id: gitlab-groups-scope
-    identifiers:
-      name: gitlab-groups
-    attrs:
-      name: gitlab-groups
-      scope_name: groups
-      expression: |
-        return {
-          "groups": [group.name for group in user.ak_groups.all()]
-        }
-
-  # GitLab administrators group
-  - model: authentik_core.group
-    id: gitlab-admins-group
-    identifiers:
-      name: gitlab-admins
-    attrs:
-      name: gitlab-admins
-
   # OAuth2 Provider for GitLab
   - model: authentik_providers_oauth2.oauth2provider
     identifiers:
@@ -64,7 +43,7 @@ entries:
       redirect_uris:
         - url: "https://gitlab.melotic.dev/users/auth/openid_connect/callback"
           matching_mode: strict
-      property_mappings: *groups_scope_mapping
+      property_mappings: *property_mappings
       signing_key: *signing_key
 
   # Application for GitLab

--- a/kubernetes/apps/gitlab/gitlab/app/externalsecret.yaml
+++ b/kubernetes/apps/gitlab/gitlab/app/externalsecret.yaml
@@ -94,7 +94,10 @@ spec:
           label: Authentik
           args:
             name: openid_connect
-            scope: [openid, profile, email, groups]
+            # GitLab CE silently ignores admin_groups (EE-only feature). Use
+            # `bin/rails runner "u=User.find_by_username(...); u.admin=true; u.save!"`
+            # for admin promotion. See debug session gitlab-sso-not-admin.
+            scope: [openid, profile, email]
             response_type: code
             issuer: https://sso.melotic.dev/application/o/gitlab/
             discovery: true
@@ -104,8 +107,6 @@ spec:
               identifier: {{ .client_id | quote }}
               secret: {{ .client_secret | quote }}
               redirect_uri: https://gitlab.melotic.dev/users/auth/openid_connect/callback
-            gitlab:
-              admin_groups: ["gitlab-admins"]
   data:
     - secretKey: client_id
       remoteRef:


### PR DESCRIPTION
## Why

PR #929 wired `args.gitlab.admin_groups: ["gitlab-admins"]` + a `groups` scope into the GitLab OmniAuth OIDC provider, expecting Authentik group membership to auto-promote SSO users to GitLab admin. After merge, the user remained non-admin even with the `groups: ["gitlab-admins"]` claim correctly present in the ID token.

## Root cause

GitLab **Community Edition** v18.11.1 (the deployed edition: helm `edition: ce`, image `gitlab-webservice-ce:v18.11.1`) does **not** implement OIDC group sync. Verified by reading `/srv/gitlab/lib/gitlab/auth/o_auth/user.rb` and grepping `/srv/gitlab/lib/gitlab/auth` + `/srv/gitlab/app` in the running webservice pod:

- No `admin_groups` / `groups_attribute` / `update_admin_status` handler exists in any OAuth/OIDC code path
- Matches exist **only** for SAML (`saml/config.rb`) and LDAP (`ldap/config.rb`)
- No `/srv/gitlab/ee` directory in the pod (CE-only build)
- GitLab callback log confirms: `(OAuth) saving user hi@melotic.xyz from login with admin => false` — config is parsed but never read

OIDC group sync is GitLab Premium/Ultimate (EE) only. The `/doc/administration/auth/oidc.md` page bundled with the CE image documents EE-only behaviour, which is what made PR #929's approach look plausible.

## What this PR does

- Drops `args.gitlab.admin_groups` and `groups` from `scope` in `kubernetes/apps/gitlab/gitlab/app/externalsecret.yaml`
- Drops the `gitlab-admins` group, the `gitlab-groups` scope mapping, and the `groups_scope_mapping` alias from `kubernetes/apps/default/authentik/app/blueprints/gitlab.yaml`
- Restores the OAuth2 provider's `property_mappings` to the original `*property_mappings` alias (openid + email + profile only)
- Adds inline `# GitLab CE silently ignores admin_groups (EE-only feature)` tripwire comments in both files

## Admin promotion (interim, until EE migration)

Done out-of-band via:

```
KUBECONFIG=./kubeconfig kubectl -n gitlab exec gitlab-webservice-default-<pod> -c webservice -- \
  bash -lc 'cd /srv/gitlab && bin/rails runner "u=User.find_by_username(\"<username>\"); u.admin=true; u.save!"'
```

(`gitlab-rake gitlab:user:make_admin[...]` does not exist in this version. The toolbox pod OOM-killed under `gitlab-rails runner`; the webservice pod has the headroom.)

## Out of scope (separate future work)

Switching the GitLab Helm release to `edition: ee` (`gitlab-webservice-ee` / `gitlab-workhorse-ee` images) would unlock OIDC group sync, but `admin_groups` requires a Premium/Ultimate licence to actually function. Tracked separately — do not re-add this configuration before that licence + edition swap lands.

## Evidence

Full 10-link evidence chain in `.planning/debug/gitlab-sso-not-admin.md` (gitignored, local only).

## Verification after merge

- Re-run Phase 3 UAT Test 6 via `/gsd-verify-work 3`. Expected pass note: *"admin granted via manual rake promotion; SSO group sync deferred to EE phase."*
- User to confirm `/admin` is reachable in the browser (already promoted via the rails runner command above).