### PR TITLE
fix(gitlab-runner): drop runner-registration-token to fix glrt- auth panic

### DIFF
--- a/kubernetes/apps/gitlab-runner/runner/app/externalsecret.yaml
+++ b/kubernetes/apps/gitlab-runner/runner/app/externalsecret.yaml
@@ -14,7 +14,11 @@ spec:
     template:
       type: Opaque
       data:
-        runner-registration-token: "{{ .registration_token }}"
+        # Only project runner-token. The chart entrypoint exports
+        # REGISTRATION_TOKEN whenever /secrets/runner-registration-token
+        # exists, which forces `gitlab-runner register` down the legacy
+        # registration-token path. With a modern `glrt-…` auth token that
+        # path panics with "The registration-token needs to be entered".
         runner-token: "{{ .runner_token }}"
   dataFrom:
     - extract:


### PR DESCRIPTION
## Problem

`gitlab-runner` pods (`gitlab-runner/gitlab-runner-*`) panic in a loop:

```
PANIC: The registration-token needs to be entered
Registration attempt N of 30
```

The 1Password `gitlab-runner` item holds a valid `glrt-…` auth token, and the ExternalSecret syncs it correctly — but the runner still fails.

## Root cause

The ExternalSecret template projects **both** keys with the `glrt-…` value:

```yaml
runner-registration-token: "{{ .registration_token }}"
runner-token:              "{{ .runner_token }}"
```

The chart's entrypoint (chart 0.88.1) unconditionally exports `REGISTRATION_TOKEN` whenever `/secrets/runner-registration-token` exists:

```bash
if [[ -f /secrets/runner-registration-token ]]; then
  export REGISTRATION_TOKEN=$(cat /secrets/runner-registration-token)
fi
if [[ -f /secrets/runner-token ]]; then
  export CI_SERVER_TOKEN=$(cat /secrets/runner-token)
fi
```

`gitlab-runner register --non-interactive` then sees `REGISTRATION_TOKEN` populated and takes the **legacy** registration path. The GitLab API rejects `glrt-…` as a registration token, the response is empty, and the binary panics with the message above.

## Fix

Project only `runner-token`. With `/secrets/runner-registration-token` absent, the entrypoint never exports `REGISTRATION_TOKEN`; `register` uses `CI_SERVER_TOKEN` (`--token`) and authenticates via the modern auth-token flow.

## Verification

After Flux reconciles, expect:
- `kubectl -n gitlab-runner get secret gitlab-runner-token -o jsonpath='{.data}'` to expose only `runner-token`
- Pod logs show no more `PANIC: The registration-token needs to be entered`
- `flux -n gitlab-runner get hr gitlab-runner` reaches Ready=True
- The runner appears online in GitLab → Admin → Runners

## Refs

- Closes Phase 03 UAT Test 6 gap (`.planning/phases/03-slim-gitlab-migration-local-ci/03-UAT.md`)