### PR TITLE
fix(gitlab-runner): mount token via secrets[] and set HOME for ROFS

### DIFF
--- a/kubernetes/apps/gitlab-runner/runner/app/helmrelease.yaml
+++ b/kubernetes/apps/gitlab-runner/runner/app/helmrelease.yaml
@@ -23,9 +23,25 @@ spec:
       retries: 3
   values:
     gitlabUrl: https://gitlab.melotic.dev/
-    secret: gitlab-runner-token
+    # The chart's singular `secret:` value does NOT mount the named Secret
+    # at /secrets/. Use the plural `secrets:` list (documented mechanism
+    # for projecting external secrets) so /secrets/runner-token is populated
+    # from the ExternalSecret-managed Secret. The entrypoint then exports
+    # CI_SERVER_TOKEN before calling `gitlab-runner register`.
+    secrets:
+      - name: gitlab-runner-token
     runnerRegistrationToken: ""
     runnerToken: ""
+
+    # The runner CLI is non-root (uid 1000) and resolves its default
+    # state_file and config.toml under $HOME/.gitlab-runner/. Without HOME
+    # set, it defaults to /.gitlab-runner/ which is blocked by
+    # readOnlyRootFilesystem: true (observed: "Couldn't save new system ID
+    # on state file" warning). The chart already mounts an emptyDir at
+    # /home/gitlab-runner/.gitlab-runner, so setting HOME there makes all
+    # default writes land on a writable volume — keeping ROFS enabled.
+    extraEnv:
+      HOME: /home/gitlab-runner
 
     rbac:
       create: true


### PR DESCRIPTION
## Summary

Two-part fix for the gitlab-runner pod restart-loop with `PANIC: The registration-token needs to be entered`. The runner has never successfully registered since initial Phase 03 deployment.

## Root cause

1. **Token was never mounted.** The chart's singular `secret:` value does *not* mount the named Secret at `/secrets/`. Confirmed via `helm template` — the chart only renders a `projected-secrets` volume when it creates its *own* generated Secret (driven by `runnerToken`/`runnerRegistrationToken` values). Since both were empty (correctly — the token comes from 1Password), no `/secrets/runner-token` file ever existed, so the entrypoint never exported `CI_SERVER_TOKEN`, and `gitlab-runner register` panicked. The plural `secrets:` list is the documented mechanism for projecting external secrets.

2. **ROFS blocked the runner CLI's default state writes.** With `readOnlyRootFilesystem: true` and no `HOME` env, the runner CLI resolved `state_file` and `config.toml` under `/.gitlab-runner/` (root-owned, ROFS-blocked). Pod logs showed the warning `Couldn't save new system ID on state file (state_file=/.gitlab-runner/.runner_system_id)`. The chart already mounts an emptyDir at `/home/gitlab-runner/.gitlab-runner`; setting `HOME=/home/gitlab-runner` makes all default writes land on that writable volume — ROFS stays enabled.

## Changes

`kubernetes/apps/gitlab-runner/runner/app/helmrelease.yaml`:
- Replace `secret: gitlab-runner-token` with `secrets: [{name: gitlab-runner-token}]`
- Add `extraEnv: { HOME: /home/gitlab-runner }`

## Verification plan

After Flux reconcile:
1. `kubectl -n gitlab-runner get hr gitlab-runner` → `Ready=True`
2. `kubectl -n gitlab-runner get deploy gitlab-runner -o yaml` → projected-secrets volume sourced from `gitlab-runner-token`; `HOME` env set
3. `kubectl -n gitlab-runner logs -l app=gitlab-runner` → no PANIC, no "Couldn't save new system ID" warning
4. GitLab Admin → Runners → runner appears online

Unblocks Phase 03 UAT Tests 6 + 7.