### PR TITLE
chore(gitlab-runner): set request_concurrency=4 to avoid long-poll bottleneck

### DIFF
--- a/kubernetes/apps/gitlab-runner/runner/app/helmrelease.yaml
+++ b/kubernetes/apps/gitlab-runner/runner/app/helmrelease.yaml
@@ -92,6 +92,8 @@ spec:
       config: |
         [[runners]]
           executor = "kubernetes"
+          # Avoid long-polling request bottleneck (chart logs WARNING when =1).
+          request_concurrency = 4
           environment = ["FF_USE_FASTZIP=true"]
           [runners.kubernetes]
             namespace = "gitlab-runner"


### PR DESCRIPTION
Addresses startup warning observed after PR #933 brought the runner online:

```
WARNING: CONFIGURATION: Long polling issues detected.
Issues found:
  - Request bottleneck: 1 runners have request_concurrency=1, causing job delays during long polling
Recommended solutions:
  1. Increase 'request_concurrency' to 2-4 for 1 runners currently using request_concurrency=1
```

Bumps per-runner `request_concurrency` from the chart default 1 to 4 (top of the chart-recommended 2–4 range) so the runner can long-poll for up to its concurrent job limit without serializing requests.

No security or RBAC impact.