### PR TITLE
feat(gitlab): init container on webservice

### DIFF
--- a/kubernetes/apps/gitlab/gitlab/app/externalsecret.yaml
+++ b/kubernetes/apps/gitlab/gitlab/app/externalsecret.yaml
@@ -115,3 +115,25 @@ spec:
       remoteRef:
         key: authentik-oidc
         property: gitlab_client_secret
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gitlab-webservice-setup-script
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  refreshInterval: 5m
+  target:
+    name: gitlab-webservice-setup-script
+    template:
+      type: Opaque
+      data:
+        setup.sh: "{{ .setup_script }}"
+  data:
+    - secretKey: setup_script
+      remoteRef:
+        key: gitlab-minio
+        property: setup_script

--- a/kubernetes/apps/gitlab/gitlab/app/helmrelease.yaml
+++ b/kubernetes/apps/gitlab/gitlab/app/helmrelease.yaml
@@ -21,6 +21,39 @@ spec:
     cleanupOnFail: true
     remediation:
       retries: 3
+  postRenderers:
+    - kustomize:
+        patches:
+          # Inject postStart lifecycle hook on the webservice container to run
+          # the sensitive setup script against the same /srv/gitlab as puma.
+          # Must redeclare preStop so the strategic merge does not drop the
+          # chart's hardcoded graceful-shutdown hook.
+          - target:
+              kind: Deployment
+              name: gitlab-webservice-default
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: gitlab-webservice-default
+              spec:
+                template:
+                  spec:
+                    containers:
+                      - name: webservice
+                        lifecycle:
+                          postStart:
+                            exec:
+                              command:
+                                - /bin/bash
+                                - -c
+                                - bash /var/run/secrets/gitlab-setup/setup.sh
+                          preStop:
+                            exec:
+                              command:
+                                - /bin/bash
+                                - -c
+                                - pkill -SIGINT -o ruby
   values:
     global:
       edition: ee
@@ -151,6 +184,19 @@ spec:
           limits:
             cpu: 2
             memory: 3Gi
+        extraVolumes: |
+          - name: gitlab-setup-script
+            secret:
+              secretName: gitlab-webservice-setup-script
+              defaultMode: 0500
+              items:
+                - key: setup.sh
+                  path: setup.sh
+        extraVolumeMounts: |
+          - name: gitlab-setup-script
+            mountPath: /var/run/secrets/gitlab-setup/setup.sh
+            subPath: setup.sh
+            readOnly: true
       sidekiq:
         minReplicas: 1
         maxReplicas: 1


### PR DESCRIPTION
Adds a sensitive setup script that runs against the GitLab Rails context on the **webservice** main container, sourced from the `gitlab-minio` 1Password item (key `setup_script`).

## Approach

`lifecycle.postStart` hook on the main webservice container — same filesystem as puma, so any modifications the script makes to `/srv/gitlab` persist into the running Rails process.

## Changes

- New ExternalSecret `gitlab-webservice-setup-script` projects only the `setup_script` field into a Secret (`setup.sh` key).
- Webservice mounts that Secret with mode `0500` via `extraVolumes` + `extraVolumeMounts` at `/var/run/secrets/gitlab-setup/setup.sh`.
- Flux `postRenderers` Kustomize patch adds `lifecycle.postStart.exec` on the `webservice` container and re-declares the chart's hardcoded `preStop` (strategic merge replaces the lifecycle struct wholesale, so we must keep both).

## Pre-merge checklist

- [ ] Add the `setup_script` field to the `gitlab-minio` 1Password item before merging.

## Notes / trade-offs

- postStart races with puma startup. The script must be idempotent and safe to run while puma is initializing. If strict before-puma ordering is needed later, switch to an emptyDir-overlay init container pattern that mounts at `/srv/gitlab` in both the prep init and the main container.
- The script content itself never appears in this repo or in rendered manifests.