### PR TITLE
fix(gitlab-runner): mount /tmp emptyDir for job trace buffering

### DIFF
--- a/kubernetes/apps/gitlab-runner/runner/app/helmrelease.yaml
+++ b/kubernetes/apps/gitlab-runner/runner/app/helmrelease.yaml
@@ -79,6 +79,18 @@ spec:
     podAnnotations:
       reloader.stakater.com/auto: "true"
 
+    # readOnlyRootFilesystem: true blocks the runner manager from buffering
+    # job traces, which it writes under /tmp/trace* before shipping to the
+    # GitLab API. Without a writable /tmp, jobs fail with "create job trace:
+    # open /tmp/traceXXXX: read-only file system" and surface to the user as
+    # "There has been a runner system failure, please try again."
+    volumes:
+      - name: tmp
+        emptyDir: {}
+    volumeMounts:
+      - name: tmp
+        mountPath: /tmp
+
     resources:
       requests:
         cpu: 50m


### PR DESCRIPTION
## Problem

Every CI job on `gitlab-runner` fails immediately with the user-visible message:

> There has been a runner system failure, please try again

Runner manager logs reveal the actual cause:

```
WARNING: Failed to process runner   builds=0
error=create job trace: open /tmp/trace1298346762: read-only file system
executor=kubernetes max_builds=4
```

## Root cause

The runner manager pod runs with `readOnlyRootFilesystem: true` (correct per repo convention) but no writable `/tmp`. The runner buffers job traces under `/tmp/trace*` before shipping them to the GitLab API, so it cannot accept any job.

The build/job pods already have their own `/tmp` emptyDir via `runners.kubernetes.volumes.empty_dir` — only the manager pod was missing one.

## Fix

Add an emptyDir at `/tmp` on the manager pod via the chart's `volumes` + `volumeMounts` values. ROFS stays enabled.

## Verification

`flux-local` render confirms the manager Deployment now has:

```
Volumes: ['runner-secrets', 'etc-gitlab-runner', 'projected-secrets', 'configmaps', 'tmp']
Mounts: [..., ('tmp', '/tmp')]
ROFS: True
```

After merge, this unblocks **Phase 03 UAT Test 7** (Harbor Kaniko CI pipeline).