### PR TITLE
fix(gitlab-runner): drop ALL caps on init-permissions container

### DIFF
--- a/kubernetes/apps/gitlab-runner/runner/app/helmrelease.yaml
+++ b/kubernetes/apps/gitlab-runner/runner/app/helmrelease.yaml
@@ -137,6 +137,17 @@ spec:
                 drop = ["ALL"]
               [runners.kubernetes.helper_container_security_context.seccomp_profile]
                 type = "RuntimeDefault"
+            # The auto-injected init-permissions container only drops NET_RAW by
+            # default, which violates the namespace's restricted PSS. Mirror the
+            # helper container's hardened context so build pods are admitted.
+            [runners.kubernetes.init_permissions_container_security_context]
+              allow_privilege_escalation = false
+              read_only_root_filesystem = true
+              run_as_non_root = true
+              [runners.kubernetes.init_permissions_container_security_context.capabilities]
+                drop = ["ALL"]
+              [runners.kubernetes.init_permissions_container_security_context.seccomp_profile]
+                type = "RuntimeDefault"
             [[runners.kubernetes.volumes.empty_dir]]
               name = "build-tmp"
               mount_path = "/builds"


### PR DESCRIPTION
## Problem

After PR #936 fixed the runner manager pod's `/tmp` issue, Test 7 (Harbor Kaniko CI) surfaced a second cascading failure. Build pods are rejected by the namespace's restricted PSS:

```
ERROR: Job failed (system failure): prepare environment: setting up build pod:
  pods "runner-..." is forbidden: violates PodSecurity "restricted:latest":
  unrestricted capabilities (container "init-permissions" must set
  securityContext.capabilities.drop=["ALL"])
```

## Root cause

The Kubernetes executor auto-injects an `init-permissions` init container into every build pod. Its security context is configured separately from `build_container_security_context` / `helper_container_security_context` and defaults to dropping only `NET_RAW` (see `executor.defaultCapDrop()` in gitlab-runner [v18.11.1](https://github.com/gitlabhq/gitlab-runner/blob/v18.11.1/executors/kubernetes/kubernetes.go#L2297-L2307)). This fails restricted PSS, which requires `drop: ["ALL"]`.

## Fix

Add `[runners.kubernetes.init_permissions_container_security_context]` to the runner TOML, mirroring the existing helper container hardening (drop ALL, no privilege escalation, runAsNonRoot, seccomp RuntimeDefault, RO root FS).

The init container only runs `touch` + `chmod 777` on its own log file in the emptyDir volume — it does not need any caps; pod-level `fs_group=1000` ensures the volume is writable as uid 1000.

## Verification

`flux-local build hr gitlab-runner` renders the new block correctly inside the runner config secret. Once merged + reconciled, retry the Kaniko pipeline (Phase 03 UAT Test 7).

Refs: Phase 03 UAT Test 7 (third attempt). Stacks on top of #936.