### PR TITLE
fix(gitlab-runner): allow writable rootfs on helper container

### DIFF
--- a/kubernetes/apps/gitlab-runner/runner/app/helmrelease.yaml
+++ b/kubernetes/apps/gitlab-runner/runner/app/helmrelease.yaml
@@ -131,7 +131,10 @@ spec:
                 type = "RuntimeDefault"
             [runners.kubernetes.helper_container_security_context]
               allow_privilege_escalation = false
-              read_only_root_filesystem = true
+              # The helper container runs `git` which writes ~/.gitconfig.
+              # Under PSS run_as_non_root the runtime UID has no /etc/passwd
+              # entry, so HOME resolves to "/", which fails with ROFS.
+              read_only_root_filesystem = false
               run_as_non_root = true
               [runners.kubernetes.helper_container_security_context.capabilities]
                 drop = ["ALL"]


### PR DESCRIPTION
## Problem

After PRs #936 and #937 cleared the runner manager and PSS admission issues, Test 7 advanced to the `get_sources` stage and now fails with:

```
error: could not lock config file //.gitconfig: Read-only file system
ERROR: Job failed: command terminated with exit code 1
```

## Root cause

The helper container runs `git`, which writes `~/.gitconfig` during `get_sources`. With `run_as_non_root = true` and `run_as_user = 1000` (set on the pod), the runtime UID has no matching entry in the helper image's `/etc/passwd`, so glibc resolves `HOME` to `/`. Combined with `read_only_root_filesystem = true` on the helper, git can't write `/.gitconfig` and the job aborts.

## Fix

Set `read_only_root_filesystem = false` on the helper container, mirroring what the build container already does. Capabilities remain dropped to `ALL`, privesc still disabled, runAsNonRoot still enforced — only the rootfs writability is relaxed for git's working files.

## Verification

`flux-local build hr gitlab-runner` renders the updated TOML inside the runner config secret. Once merged + reconciled, retry the Kaniko pipeline (Phase 03 UAT Test 7, attempt #4).

Stacks on top of #937 and #936.