### PR TITLE
fix(gitlab-runner): use ubuntu helper image flavor for valid uid 1000

### DIFF
--- a/kubernetes/apps/gitlab-runner/runner/app/helmrelease.yaml
+++ b/kubernetes/apps/gitlab-runner/runner/app/helmrelease.yaml
@@ -111,6 +111,15 @@ spec:
             namespace = "gitlab-runner"
             image = "alpine:3.20"
             helper_image = ""
+            # The default (alpine) helper image has no /etc/passwd entry for
+            # uid 1000, so glibc's getpwuid(1000) returns NULL and git's
+            # global-config lookup falls back to HOME='/'. Git then tries to
+            # lock '//.gitconfig', which fails with EACCES (or EROFS, depending
+            # on whether helper rootfs is read-only). The ubuntu-flavored
+            # helper image ships an `ubuntu:x:1000:1000:Ubuntu:/home/ubuntu`
+            # entry with /home/ubuntu pre-created (mode 0750, owner 1000:1000),
+            # giving uid 1000 a real, writable HOME.
+            helper_image_flavor = "ubuntu"
             privileged = false
             poll_timeout = 600
             service_account = "gitlab-runner"


### PR DESCRIPTION
## Root Cause

The default (alpine) `gitlab-runner-helper` image has no `/etc/passwd` entry for uid 1000. Under PSS `restricted` we run helper as uid 1000, so `getpwuid(1000)` returns NULL and git's global-config lookup falls back to `HOME='/'`. Git then tries to lock `//.gitconfig` and fails:

- with **EROFS** when helper rootfs was read-only (pre-PR #938),
- with **EACCES** after PR #938 made it writable (`/` is still root-owned 0755).

Both errors are the same bug — missing user entry, not missing write permission.

## Evidence

Inspected both helper image variants for v18.11.1:

- `gitlab-runner-helper:x86_64-v18.11.1` (alpine, default): `/etc/passwd` contains root, nobody, guest — **no uid 1000**.
- `gitlab-runner-helper:ubuntu-x86_64-v18.11.1`: `/etc/passwd` contains `ubuntu:x:1000:1000:Ubuntu:/home/ubuntu:/bin/bash` AND `/home/ubuntu/` exists with mode `0750` owned by `1000:1000`.

Also verified `executors/kubernetes/kubernetes.go` (`buildContainer` at line 1474) leaves `Env=nil` for the helper container, so no amount of `runners.environment` can inject `HOME` — env must come from the image's `/etc/passwd` (or pod_spec patching, which requires a beta feature flag).

## Fix

Set `helper_image_flavor = "ubuntu"`. uid 1000 now resolves to a real user with a writable HOME. No PSS relaxation, no pod_spec beta feature, no env injection plumbing.

## Verification

```
flux-local build hr gitlab-runner --skip-secrets --path kubernetes/apps/gitlab-runner -A
```

renders the new `helper_image_flavor = "ubuntu"` field into the generated runner `config.toml`. End-to-end CI verification (Phase 03 UAT Test 7 Kaniko pipeline) requires deployment.

## Cascade context

Fourth fix in the runner-system cascade for Test 7:
- #936 — mount `/tmp` emptyDir on runner manager pod (job trace buffering).
- #937 — drop ALL caps on auto-injected `init-permissions` container.
- #938 — set `read_only_root_filesystem = false` on helper container (treated symptom — changed errno from EROFS to EACCES on the same path).
- **this PR** — addresses the actual root cause of the `//.gitconfig` failure.