### PR TITLE
fix(gitlab-runner): redirect kaniko DOCKER_CONFIG to writable /tmp

### DIFF
--- a/kubernetes/apps/gitlab-runner/runner/app/CI-PATTERNS.md
+++ b/kubernetes/apps/gitlab-runner/runner/app/CI-PATTERNS.md
@@ -80,10 +80,20 @@ build-image:
   image:
     name: gcr.io/kaniko-project/executor:v1.23.2-debug
     entrypoint: [""]
+  variables:
+    # The kaniko image's /kaniko directory is root-owned 0755 and unwritable
+    # by the build pod's uid 1000 (enforced by namespace PSS=restricted +
+    # pod_security_context.run_as_user=1000). Redirect Docker auth to /tmp,
+    # which the runner mounts as an emptyDir writable by uid 1000.
+    # Kaniko's executor honors $DOCKER_CONFIG ahead of its /kaniko/.docker
+    # default discovery path. Note: the gitlab-runner config also exports
+    # this same DOCKER_CONFIG default at the runner level (defense in depth)
+    # so jobs that omit this `variables:` block still work.
+    DOCKER_CONFIG: "/tmp/.docker"
   script:
-    - mkdir -p /kaniko/.docker
+    - mkdir -p "$DOCKER_CONFIG"
     - |
-      cat > /kaniko/.docker/config.json <<EOF
+      cat > "$DOCKER_CONFIG/config.json" <<EOF
       { "auths": { "$HARBOR_REGISTRY": { "auth": "$(printf '%s:%s' "$HARBOR_USER" "$HARBOR_PASSWORD" | base64)" } } }
       EOF
     - /kaniko/executor
@@ -93,6 +103,15 @@ build-image:
 ```
 
 Use the `:debug` tag (has `/busybox/sh`).
+
+**Why `DOCKER_CONFIG=/tmp/.docker` and not `/kaniko/.docker`:** the runner
+namespace enforces restricted Pod Security Standard, so all build pods must
+run as non-root (`run_as_user=1000`). The kaniko image's `/kaniko` directory
+is root-owned `0755`, so writing the auth config to its default location
+fails with `Permission denied`. `/tmp` is mounted as a per-job emptyDir with
+the pod's `fs_group=1000`, giving uid 1000 write access. Kaniko's executor
+loads credentials from `$DOCKER_CONFIG` if set, then `$HOME/.docker`, then
+`/kaniko/.docker` — so the redirect is transparent to the rest of the build.
 
 ## Image build via rootless Buildah (alternative)
 

--- a/kubernetes/apps/gitlab-runner/runner/app/helmrelease.yaml
+++ b/kubernetes/apps/gitlab-runner/runner/app/helmrelease.yaml
@@ -106,7 +106,18 @@ spec:
           executor = "kubernetes"
           # Avoid long-polling request bottleneck (chart logs WARNING when =1).
           request_concurrency = 4
-          environment = ["FF_USE_FASTZIP=true"]
+          # FF_USE_FASTZIP: faster artifact upload (chart-recommended).
+          # DOCKER_CONFIG: defense-in-depth default for Kaniko/Buildah jobs.
+          # The build pod runs as uid 1000 (PSS=restricted), but the kaniko
+          # image's /kaniko directory is root-owned 0755 — so writing Docker
+          # auth to the default /kaniko/.docker/config.json fails with
+          # `Permission denied` in step_script. /tmp is mounted as a
+          # writable emptyDir on every build pod, and kaniko's executor
+          # honors $DOCKER_CONFIG ahead of its /kaniko/.docker default.
+          # Setting this at the runner level means CI snippets that copy/paste
+          # the upstream kaniko docs verbatim still work; CI-PATTERNS.md
+          # additionally sets it per-job for explicitness.
+          environment = ["FF_USE_FASTZIP=true", "DOCKER_CONFIG=/tmp/.docker"]
           [runners.kubernetes]
             namespace = "gitlab-runner"
             image = "alpine:3.20"


### PR DESCRIPTION
## Context

Phase 03 UAT Test 7 (Harbor robot-account Kaniko build → push) — fifth cascading failure. Prior four are merged:

- #936 — manager pod ROFS, mount /tmp emptyDir
- #937 — drop ALL caps on init-permissions container
- #938 — allow writable rootfs on helper container
- #939 — `helper_image_flavor = ubuntu` so uid 1000 has a real HOME

With those fixes in place, the runner-system phases (admission → init-permissions → get_sources → upload artifacts) are all green. The failure has shifted into the user's `step_script`:

```
/scripts-1-7/step_script: eval: line 187:
  can't create /kaniko/.docker/config.json: Permission denied
```

## Root cause

The kaniko image's `/kaniko` directory is root-owned `0755`. The build pod runs as **uid 1000** (namespace PSS=`restricted` + `pod_security_context.run_as_user = 1000`), so the canonical kaniko snippet from upstream docs:

```yaml
- mkdir -p /kaniko/.docker
- cat > /kaniko/.docker/config.json <<EOF ... EOF
```

…fails before `/kaniko/executor` is ever invoked. This is the well-known kaniko-on-non-root-cluster wire (kaniko upstream issues #135, #681, #1592).

## Fix — two layers

**1. `CI-PATTERNS.md` kaniko snippet** sets `DOCKER_CONFIG=/tmp/.docker` in `variables:` and writes auth there. `/tmp` is mounted as a per-job emptyDir with the pod's `fs_group=1000`, so uid 1000 has write access. Kaniko's `executor` honors `$DOCKER_CONFIG` ahead of its `/kaniko/.docker` default, so the redirect is transparent to the build.

**2. `helmrelease.yaml`** adds `DOCKER_CONFIG=/tmp/.docker` to `runners.config` `environment` (alongside the existing `FF_USE_FASTZIP=true`). This is defense-in-depth: pipelines that copy upstream kaniko docs verbatim — without the per-job `variables:` block — still work because the runner injects the env var into every build container.

## Constraints honored

- ✅ Does **not** relax PSS — namespace stays `restricted:latest`
- ✅ Does **not** change `run_as_user` or drop `run_as_non_root`
- ✅ Does **not** introduce privileged or hostPath
- ✅ Preserves D-15 / SEC-02 posture (Kaniko/Buildah only, no DinD, restricted PSS)

## Validation

- YAML parses cleanly; embedded TOML in `runners.config` parses cleanly; `DOCKER_CONFIG=/tmp/.docker` confirmed present in the rendered `environment` list.
- Logical: kaniko's executor source honors `$DOCKER_CONFIG` ahead of `/kaniko/.docker`; `/tmp` is already mounted as emptyDir on build pods (helmrelease.yaml lines 167–170, established by PR #936's pattern).

## Re-test (post-merge + reconcile)

Copy the updated kaniko snippet from `kubernetes/apps/gitlab-runner/runner/app/CI-PATTERNS.md` into the test project's `.gitlab-ci.yml`, push, observe the pipeline goes green and the image lands in Harbor.

## Debug session

`.planning/debug/resolved/kaniko-step-script-perms.md` (local-only — `.planning/` is gitignored).