### PR TITLE
feat(kyverno): install Kyverno admission controller

### DIFF
--- a/kubernetes/apps/kyverno/kustomization.yaml
+++ b/kubernetes/apps/kyverno/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kyverno
+components:
+  - ../../components/alerts
+  - ../../components/common
+resources:
+  - ./kyverno/ks.yaml

--- a/kubernetes/apps/kyverno/kyverno/app/ciliumnetworkpolicy.yaml
+++ b/kubernetes/apps/kyverno/kyverno/app/ciliumnetworkpolicy.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/CiliumProject/cilium/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: kyverno
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/part-of: kyverno
+  ingress:
+    - fromEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "9443"
+              protocol: TCP
+  egress:
+    - toEntities:
+        - kube-apiserver
+    - toEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": kube-system
+            "k8s:k8s-app": kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: ANY
+          rules:
+            dns:
+              - matchPattern: "*"

--- a/kubernetes/apps/kyverno/kyverno/app/helmrelease.yaml
+++ b/kubernetes/apps/kyverno/kyverno/app/helmrelease.yaml
@@ -1,0 +1,76 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kyverno
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: kyverno
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: -1
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    admissionController:
+      replicas: 1
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 512Mi
+      podSecurityContext:
+        runAsNonRoot: true
+        fsGroup: 1000
+      containerSecurityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop: ["ALL"]
+    backgroundController:
+      replicas: 1
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          memory: 384Mi
+      podSecurityContext:
+        runAsNonRoot: true
+        fsGroup: 1000
+      containerSecurityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop: ["ALL"]
+    reportsController:
+      replicas: 1
+      podSecurityContext:
+        runAsNonRoot: true
+        fsGroup: 1000
+      containerSecurityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop: ["ALL"]
+    cleanupController:
+      replicas: 1
+      podSecurityContext:
+        runAsNonRoot: true
+        fsGroup: 1000
+      containerSecurityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop: ["ALL"]
+    features:
+      policyExceptions:
+        enabled: true

--- a/kubernetes/apps/kyverno/kyverno/app/helmrelease.yaml
+++ b/kubernetes/apps/kyverno/kyverno/app/helmrelease.yaml
@@ -29,7 +29,10 @@ spec:
           memory: 512Mi
       podSecurityContext:
         runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
         fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
       containerSecurityContext:
         allowPrivilegeEscalation: false
         readOnlyRootFilesystem: true
@@ -45,7 +48,10 @@ spec:
           memory: 384Mi
       podSecurityContext:
         runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
         fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
       containerSecurityContext:
         allowPrivilegeEscalation: false
         readOnlyRootFilesystem: true
@@ -55,7 +61,10 @@ spec:
       replicas: 1
       podSecurityContext:
         runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
         fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
       containerSecurityContext:
         allowPrivilegeEscalation: false
         readOnlyRootFilesystem: true
@@ -65,7 +74,10 @@ spec:
       replicas: 1
       podSecurityContext:
         runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
         fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
       containerSecurityContext:
         allowPrivilegeEscalation: false
         readOnlyRootFilesystem: true

--- a/kubernetes/apps/kyverno/kyverno/app/kustomization.yaml
+++ b/kubernetes/apps/kyverno/kyverno/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./ciliumnetworkpolicy.yaml

--- a/kubernetes/apps/kyverno/kyverno/app/ocirepository.yaml
+++ b/kubernetes/apps/kyverno/kyverno/app/ocirepository.yaml
@@ -11,5 +11,5 @@ spec:
     operation: copy
   ref:
     # renovate: datasource=docker depName=ghcr.io/kyverno/charts/kyverno
-    tag: kyverno-3.7.2
+    tag: 3.7.2
   url: oci://ghcr.io/kyverno/charts/kyverno

--- a/kubernetes/apps/kyverno/kyverno/app/ocirepository.yaml
+++ b/kubernetes/apps/kyverno/kyverno/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kyverno
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    # renovate: datasource=docker depName=ghcr.io/kyverno/charts/kyverno
+    tag: kyverno-3.7.2
+  url: oci://ghcr.io/kyverno/charts/kyverno

--- a/kubernetes/apps/kyverno/kyverno/ks.yaml
+++ b/kubernetes/apps/kyverno/kyverno/ks.yaml
@@ -22,3 +22,4 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: *namespace
+  wait: false

--- a/kubernetes/apps/kyverno/kyverno/ks.yaml
+++ b/kubernetes/apps/kyverno/kyverno/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app kyverno
+  namespace: &namespace kyverno
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: *app
+      namespace: *namespace
+  interval: 1h
+  path: ./kubernetes/apps/kyverno/kyverno/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace


### PR DESCRIPTION
Installs Kyverno admission controller into a new `kyverno` namespace. No policies are registered in this PR — Kyverno makes no admission decisions yet.

## Changes

- New `kyverno` namespace + Flux Kustomization at `kubernetes/apps/kyverno/kyverno/`
- HelmRelease pinned to `oci://ghcr.io/kyverno/charts/kyverno:3.7.2`
- Sized for cluster load: admission controller 100m/256Mi req, 512Mi limit; background controller 100m/128Mi req, 384Mi limit; single replicas
- `features.policyExceptions.enabled: true`
- CiliumNetworkPolicy: egress to kube-apiserver + kube-dns only; ingress from kube-apiserver to webhook on :9443

## Risk

Low. New namespace, no ClusterPolicies, no admission webhooks active until policies land in a follow-up PR. NetworkPolicy is restrictive.

## Verification

- `kustomize build --enable-helm kubernetes/apps/kyverno/` succeeds
- flux-local CI passes
- After merge: `flux get hr kyverno -n kyverno` Ready=True; `kubectl -n kyverno get pods` Running