### PR TITLE
feat(kyverno): add 8-policy catalog and CI gate

### DIFF
--- a/.github/workflows/kyverno.yaml
+++ b/.github/workflows/kyverno.yaml
@@ -82,11 +82,18 @@ jobs:
         run: |
           set +e
           kyverno apply kubernetes/apps/kyverno/policies/app/ \
-            --resource rendered.yaml \
+            --resource "${GITHUB_WORKSPACE}/rendered.yaml" \
             --table 2>&1 | tee apply-output.txt
-          echo "rc=${PIPESTATUS[0]}" >> "${GITHUB_OUTPUT}"
+          rc=${PIPESTATUS[0]}
+          echo "rc=${rc}" >> "${GITHUB_OUTPUT}"
           {
             echo "### Kyverno Apply"
+            echo ''
+            echo "kyverno apply exited with rc=${rc} (informational; non-blocking per CONTEXT D-11)."
+            if [ "${rc}" -ne 0 ]; then
+              echo ''
+              echo "> :warning: non-zero exit — investigate before relying on the table below."
+            fi
             echo ''
             echo '```'
             cat apply-output.txt

--- a/.github/workflows/kyverno.yaml
+++ b/.github/workflows/kyverno.yaml
@@ -75,7 +75,7 @@ jobs:
             --enable-helm
             --skip-invalid-kustomization-paths
             --output-file /github/workspace/rendered.yaml
-            --path /github/workspace/kubernetes/flux/cluster
+            /github/workspace/kubernetes/flux/cluster
 
       - name: Run kyverno apply (informational)
         id: apply
@@ -146,7 +146,7 @@ jobs:
             --enable-helm
             --skip-invalid-kustomization-paths
             --output-file /github/workspace/rendered-pr.yaml
-            --path /github/workspace/pr/kubernetes/flux/cluster
+            /github/workspace/pr/kubernetes/flux/cluster
 
       - name: Render main with flux-local
         uses: docker://ghcr.io/allenporter/flux-local:v8.2.0
@@ -156,7 +156,7 @@ jobs:
             --enable-helm
             --skip-invalid-kustomization-paths
             --output-file /github/workspace/rendered-main.yaml
-            --path /github/workspace/main/kubernetes/flux/cluster
+            /github/workspace/main/kubernetes/flux/cluster
 
       - name: Compute diff-only failure set
         id: diff

--- a/.github/workflows/kyverno.yaml
+++ b/.github/workflows/kyverno.yaml
@@ -143,15 +143,29 @@ jobs:
       - name: Compute diff-only failure set
         id: diff
         run: |
-          set -uo pipefail
+          set -euo pipefail
 
           extract_failures() {
             local manifest="$1"
-            kyverno apply pr/kubernetes/apps/kyverno/policies/app/ \
-              --resource "${manifest}" \
-              --policy-report --output-format json 2>/dev/null \
-              | jq -r '.. | objects | select(has("results")) | .results[]? | select(.result=="fail") | "\(.policy)::\(.resources[0].kind)/\(.resources[0].namespace)/\(.resources[0].name)"' \
-              | sort -u
+            if [[ ! -s "${manifest}" ]]; then
+              echo "ERROR: ${manifest} missing or empty (flux-local render failed?)" >&2
+              exit 1
+            fi
+
+            local out
+            if ! out=$(kyverno apply pr/kubernetes/apps/kyverno/policies/app/ \
+                  --resource "${GITHUB_WORKSPACE}/${manifest}" \
+                  --policy-report --output-format json); then
+              echo "ERROR: kyverno apply failed for ${manifest}" >&2
+              echo "${out}" >&2
+              exit 1
+            fi
+
+            jq -r 'if type == "array" then .[] else . end
+                   | .results[]?
+                   | select(.result=="fail")
+                   | "\(.policy)::\(.resources[0].kind)/\(.resources[0].namespace)/\(.resources[0].name)"' \
+              <<<"${out}" | sort -u
           }
 
           extract_failures rendered-pr.yaml   > fails-pr.txt

--- a/.github/workflows/kyverno.yaml
+++ b/.github/workflows/kyverno.yaml
@@ -1,0 +1,265 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: "Kyverno"
+
+on:
+  pull_request:
+    branches: ["main"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pre-job:
+    name: Kyverno Pre-Job
+    runs-on: ubuntu-latest
+    outputs:
+      any_changed: ${{ steps.changed-files.outputs.any_changed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Get Changed Files
+        id: changed-files
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+        with:
+          files: |
+            kubernetes/**
+            .github/workflows/kyverno.yaml
+
+  # Layer A — kyverno test against per-policy fixtures (BLOCKING).
+  # Fast unit test of policy authoring; catches policy bugs before render.
+  test:
+    name: Kyverno Test (Layer A)
+    needs: pre-job
+    runs-on: ubuntu-latest
+    if: ${{ needs.pre-job.outputs.any_changed == 'true' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Kyverno CLI
+        uses: kyverno/action-install-cli@fcee92fca5c883169ef9927acf543e0b5fc58289 # v0.2.0
+        with:
+          release: v1.17.2
+
+      - name: Run kyverno test
+        run: kyverno test kubernetes/apps/kyverno/policies/tests/
+
+  # Layer B — kyverno apply on rendered manifests (INFORMATIONAL).
+  # Full violation table for the PR's manifests; does NOT block merge per CONTEXT D-11
+  # (would block any PR touching a namespace with pre-existing violations).
+  apply:
+    name: Kyverno Apply (Layer B)
+    needs: pre-job
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    if: ${{ needs.pre-job.outputs.any_changed == 'true' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Kyverno CLI
+        uses: kyverno/action-install-cli@fcee92fca5c883169ef9927acf543e0b5fc58289 # v0.2.0
+        with:
+          release: v1.17.2
+
+      - name: Render manifests with flux-local
+        uses: docker://ghcr.io/allenporter/flux-local:v8.2.0
+        with:
+          args: >-
+            build all
+            --enable-helm
+            --skip-invalid-kustomization-paths
+            --output-file /github/workspace/rendered.yaml
+            --path /github/workspace/kubernetes/flux/cluster
+
+      - name: Run kyverno apply (informational)
+        id: apply
+        continue-on-error: true
+        run: |
+          set +e
+          kyverno apply kubernetes/apps/kyverno/policies/app/ \
+            --resource rendered.yaml \
+            --table 2>&1 | tee apply-output.txt
+          echo "rc=${PIPESTATUS[0]}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "### Kyverno Apply (Layer B — informational)"
+            echo ''
+            echo '```'
+            cat apply-output.txt
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Comment PR with apply results
+        if: ${{ always() }}
+        continue-on-error: true
+        uses: mshick/add-pr-comment@8e4927817251f1ff60c001f04568532b38e0b4a0 # v3.11
+        with:
+          message-id: "${{ github.event.pull_request.number }}/kyverno/apply"
+          message-failure: "Kyverno apply step did not run successfully (informational only)."
+          message: |
+            ### Kyverno Apply (Layer B — informational)
+
+            ```
+            (see workflow Job Summary for full output)
+            ```
+
+            This is informational only. The blocking gate is the **Diff-Only** job.
+
+  # Layer C — diff-only against main (BLOCKING gate per CONTEXT D-11/D-12).
+  # Fail only on NEW violations introduced by this PR. Logic ported inline from
+  # .planning/spikes/004-kyverno-ci-feedback/scripts/ci-diff-only.sh.
+  diff-only:
+    name: Kyverno Diff-Only (Layer C)
+    needs: pre-job
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    if: ${{ needs.pre-job.outputs.any_changed == 'true' }}
+    steps:
+      - name: Checkout PR HEAD
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: pr
+
+      - name: Checkout main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: "${{ github.event.repository.default_branch }}"
+          path: main
+
+      - name: Install Kyverno CLI
+        uses: kyverno/action-install-cli@fcee92fca5c883169ef9927acf543e0b5fc58289 # v0.2.0
+        with:
+          release: v1.17.2
+
+      - name: Render PR HEAD with flux-local
+        uses: docker://ghcr.io/allenporter/flux-local:v8.2.0
+        with:
+          args: >-
+            build all
+            --enable-helm
+            --skip-invalid-kustomization-paths
+            --output-file /github/workspace/rendered-pr.yaml
+            --path /github/workspace/pr/kubernetes/flux/cluster
+
+      - name: Render main with flux-local
+        uses: docker://ghcr.io/allenporter/flux-local:v8.2.0
+        with:
+          args: >-
+            build all
+            --enable-helm
+            --skip-invalid-kustomization-paths
+            --output-file /github/workspace/rendered-main.yaml
+            --path /github/workspace/main/kubernetes/flux/cluster
+
+      - name: Compute diff-only failure set
+        id: diff
+        run: |
+          set -uo pipefail
+
+          extract_failures() {
+            local manifest="$1"
+            kyverno apply pr/kubernetes/apps/kyverno/policies/app/ \
+              --resource "${manifest}" \
+              --policy-report --output-format json 2>/dev/null \
+              | jq -r '.[] | .results[]? | select(.result=="fail") | "\(.policy)::\(.resources[0].kind)/\(.resources[0].namespace)/\(.resources[0].name)"' \
+              | sort -u
+          }
+
+          extract_failures rendered-pr.yaml   > fails-pr.txt
+          extract_failures rendered-main.yaml > fails-main.txt
+
+          comm -23 fails-pr.txt fails-main.txt > new-fails.txt
+          comm -13 fails-pr.txt fails-main.txt > fixed-fails.txt
+
+          PRE_EXISTING=$(wc -l < fails-main.txt)
+          PR_TOTAL=$(wc -l < fails-pr.txt)
+          NEW_COUNT=$(wc -l < new-fails.txt)
+          FIXED_COUNT=$(wc -l < fixed-fails.txt)
+
+          {
+            echo "### Kyverno Diff-Only (Layer C — BLOCKING)"
+            echo ''
+            echo "- Pre-existing violations on main: ${PRE_EXISTING}"
+            echo "- Total violations on PR:          ${PR_TOTAL}"
+            echo "- Fixed by this PR:                ${FIXED_COUNT}"
+            echo "- NEW violations introduced:       ${NEW_COUNT}"
+            echo ''
+            if [ "${NEW_COUNT}" -gt 0 ]; then
+              echo '#### NEW violations'
+              echo '```'
+              cat new-fails.txt
+              echo '```'
+            fi
+            if [ "${FIXED_COUNT}" -gt 0 ]; then
+              echo '#### Fixed by this PR'
+              echo '```'
+              head -20 fixed-fails.txt
+              echo '```'
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          echo "new_count=${NEW_COUNT}" >> "${GITHUB_OUTPUT}"
+          {
+            echo 'new_fails<<EOF'
+            cat new-fails.txt
+            echo EOF
+          } >> "${GITHUB_OUTPUT}"
+          {
+            echo 'fixed_fails<<EOF'
+            head -20 fixed-fails.txt
+            echo EOF
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Comment PR (success — no new violations)
+        if: ${{ steps.diff.outputs.new_count == '0' }}
+        continue-on-error: true
+        uses: mshick/add-pr-comment@8e4927817251f1ff60c001f04568532b38e0b4a0 # v3.11
+        with:
+          message-id: "${{ github.event.pull_request.number }}/kyverno/diff-only"
+          message: |
+            ✅ No new Kyverno violations introduced by this PR.
+
+            (Pre-existing violations on `main` are not gated; see the Job Summary for diff-only details.)
+
+      - name: Comment PR (failure — new violations)
+        if: ${{ steps.diff.outputs.new_count != '0' }}
+        continue-on-error: true
+        uses: mshick/add-pr-comment@8e4927817251f1ff60c001f04568532b38e0b4a0 # v3.11
+        with:
+          message-id: "${{ github.event.pull_request.number }}/kyverno/diff-only"
+          message: |
+            ❌ This PR introduces **${{ steps.diff.outputs.new_count }}** new Kyverno violation(s):
+
+            ```
+            ${{ steps.diff.outputs.new_fails }}
+            ```
+
+            Either fix the offending resources or, if the violation is intentional and accepted,
+            add a Kyverno PolicyException CR (see `kubernetes/apps/kyverno/policies/`).
+
+      - name: Fail on new violations
+        if: ${{ steps.diff.outputs.new_count != '0' }}
+        run: |
+          echo "Diff-only gate FAILED: ${{ steps.diff.outputs.new_count }} new violation(s)."
+          exit 1
+
+  kyverno-status:
+    name: Kyverno Success
+    needs: ["test", "apply", "diff-only"]
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    steps:
+      - name: Any jobs failed?
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1
+
+      - name: All jobs passed or skipped?
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: echo "All jobs passed or skipped" && echo "${{ toJSON(needs.*.result) }}"

--- a/.github/workflows/kyverno.yaml
+++ b/.github/workflows/kyverno.yaml
@@ -15,32 +15,28 @@ jobs:
     name: Kyverno Pre-Job
     runs-on: ubuntu-latest
     outputs:
-      any_changed: ${{ steps.changed-files.outputs.any_changed }}
+      any_changed: ${{ steps.changed.outputs.any_changed }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
-      # WR-01: Replaced tj-actions/changed-files (CVE-2025-30066 retroactive tag
-      # rewrite history) with native git diff. Dependency-free and the diff scope
-      # is identical to the previous `files:` glob.
       - name: Get Changed Files
-        id: changed-files
+        id: changed
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           set -euo pipefail
-          git fetch --no-tags --depth=1 origin "${BASE_REF}"
-          if git diff --name-only "origin/${BASE_REF}...HEAD" -- \
-                'kubernetes/**' '.github/workflows/kyverno.yaml' \
+          git fetch --no-tags origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          if git diff --name-only "origin/${BASE_REF}..HEAD" -- \
+                'kubernetes/apps/kyverno/**' '.github/workflows/kyverno.yaml' \
                 | grep -q .; then
             echo "any_changed=true" >> "${GITHUB_OUTPUT}"
           else
             echo "any_changed=false" >> "${GITHUB_OUTPUT}"
           fi
 
-  # Unit test policies against per-policy fixtures (BLOCKING).
   test:
     name: Kyverno Test
     needs: pre-job
@@ -58,16 +54,10 @@ jobs:
       - name: Run kyverno test
         run: kyverno test kubernetes/apps/kyverno/policies/tests/
 
-  # Apply policies to rendered manifests (INFORMATIONAL — full violation table for the PR).
-  # Does NOT block merge per CONTEXT D-11 (would block any PR touching a namespace with
-  # pre-existing violations). The diff job is the blocking gate.
-  apply:
-    name: Kyverno Apply
+  validate:
+    name: Kyverno Validate
     needs: pre-job
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
     if: ${{ needs.pre-job.outputs.any_changed == 'true' }}
     steps:
       - name: Checkout
@@ -88,198 +78,31 @@ jobs:
             --output-file /github/workspace/rendered.yaml
             /github/workspace/kubernetes/flux/cluster
 
-      - name: Run kyverno apply (informational)
-        id: apply
-        continue-on-error: true
+      # --audit-warn downgrades audit-policy fails to warnings; --warn-exit-code 0
+      # makes warnings rc=0. So rc=1 only on real engine errors or enforce-mode
+      # failures (we have none today). Audit findings appear in the table for
+      # visibility without gating — see kubernetes/apps/kyverno/policies/.
+      - name: Run kyverno apply
         run: |
-          set +e
+          set -o pipefail
+          {
+            echo '### Kyverno Validate'
+            echo ''
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
           kyverno apply kubernetes/apps/kyverno/policies/app/ \
             --resource "${GITHUB_WORKSPACE}/rendered.yaml" \
-            --table 2>&1 | tee apply-output.txt
-          rc=${PIPESTATUS[0]}
-          echo "rc=${rc}" >> "${GITHUB_OUTPUT}"
-          {
-            echo "### Kyverno Apply"
-            echo ''
-            echo "kyverno apply exited with rc=${rc} (informational; non-blocking per CONTEXT D-11)."
-            if [ "${rc}" -ne 0 ]; then
-              echo ''
-              echo "> :warning: non-zero exit — investigate before relying on the table below."
-            fi
-            echo ''
-            echo '```'
-            cat apply-output.txt
-            echo '```'
-          } >> "${GITHUB_STEP_SUMMARY}"
-
-  # Diff against main — fail only on NEW violations introduced by this PR (BLOCKING).
-  # Per CONTEXT D-11/D-12. Logic ported from .planning/spikes/004-kyverno-ci-feedback/scripts/ci-diff-only.sh.
-  diff-only:
-    name: Kyverno Diff (vs main)
-    needs: pre-job
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    if: ${{ needs.pre-job.outputs.any_changed == 'true' }}
-    steps:
-      - name: Checkout PR HEAD
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          path: pr
-
-      - name: Checkout main
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: "${{ github.event.repository.default_branch }}"
-          path: main
-
-      - name: Install Kyverno CLI
-        uses: kyverno/action-install-cli@fcee92fca5c883169ef9927acf543e0b5fc58289 # v0.2.0
-        with:
-          release: v1.17.2
-
-      - name: Render PR HEAD with flux-local
-        uses: docker://ghcr.io/allenporter/flux-local:v8.2.0
-        with:
-          args: >-
-            build all
-            --enable-helm
-            --skip-invalid-kustomization-paths
-            --output-file /github/workspace/rendered-pr.yaml
-            /github/workspace/pr/kubernetes/flux/cluster
-
-      - name: Render main with flux-local
-        uses: docker://ghcr.io/allenporter/flux-local:v8.2.0
-        with:
-          args: >-
-            build all
-            --enable-helm
-            --skip-invalid-kustomization-paths
-            --output-file /github/workspace/rendered-main.yaml
-            /github/workspace/main/kubernetes/flux/cluster
-
-      - name: Compute diff-only failure set
-        id: diff
-        run: |
-          set -euo pipefail
-
-          extract_failures() {
-            local manifest="$1"
-            if [[ ! -s "${manifest}" ]]; then
-              echo "ERROR: ${manifest} missing or empty (flux-local render failed?)" >&2
-              exit 1
-            fi
-
-            local out err rc
-            err=$(mktemp)
-            rc=0
-            out=$(kyverno apply pr/kubernetes/apps/kyverno/policies/app/ \
-                  --resource "${GITHUB_WORKSPACE}/${manifest}" \
-                  --policy-report --output-format json 2>"${err}") || rc=$?
-
-            # kyverno apply exits non-zero whenever any policy result is "fail".
-            # That's expected — we want to count those failures, not abort.
-            # Only treat as a real crash if the JSON output is empty/invalid.
-            if ! jq -e . >/dev/null 2>&1 <<<"${out}"; then
-              echo "ERROR: kyverno apply produced no parseable JSON for ${manifest} (rc=${rc})" >&2
-              echo "--- kyverno stderr ---" >&2
-              cat "${err}" >&2
-              echo "--- kyverno stdout ---" >&2
-              echo "${out}" >&2
-              rm -f "${err}"
-              exit 1
-            fi
-            rm -f "${err}"
-
-            jq -r 'if type == "array" then .[] else . end
-                   | .results[]?
-                   | select(.result=="fail")
-                   | "\(.policy)::\(.resources[0].kind)/\(.resources[0].namespace)/\(.resources[0].name)"' \
-              <<<"${out}" | sort -u
-          }
-
-          extract_failures rendered-pr.yaml   > fails-pr.txt
-          extract_failures rendered-main.yaml > fails-main.txt
-
-          comm -23 fails-pr.txt fails-main.txt > new-fails.txt
-          comm -13 fails-pr.txt fails-main.txt > fixed-fails.txt
-
-          PRE_EXISTING=$(wc -l < fails-main.txt)
-          PR_TOTAL=$(wc -l < fails-pr.txt)
-          NEW_COUNT=$(wc -l < new-fails.txt)
-          FIXED_COUNT=$(wc -l < fixed-fails.txt)
-
-          {
-            echo "### Kyverno Diff (vs main)"
-            echo ''
-            echo "- Pre-existing violations on main: ${PRE_EXISTING}"
-            echo "- Total violations on PR:          ${PR_TOTAL}"
-            echo "- Fixed by this PR:                ${FIXED_COUNT}"
-            echo "- NEW violations introduced:       ${NEW_COUNT}"
-            echo ''
-            if [ "${NEW_COUNT}" -gt 0 ]; then
-              echo '#### NEW violations'
-              echo '```'
-              cat new-fails.txt
-              echo '```'
-            fi
-            if [ "${FIXED_COUNT}" -gt 0 ]; then
-              echo '#### Fixed by this PR'
-              echo '```'
-              head -20 fixed-fails.txt
-              echo '```'
-            fi
-          } >> "${GITHUB_STEP_SUMMARY}"
-
-          echo "new_count=${NEW_COUNT}" >> "${GITHUB_OUTPUT}"
-          {
-            echo 'new_fails<<EOF'
-            cat new-fails.txt
-            echo EOF
-          } >> "${GITHUB_OUTPUT}"
-          {
-            echo 'fixed_fails<<EOF'
-            head -20 fixed-fails.txt
-            echo EOF
-          } >> "${GITHUB_OUTPUT}"
-
-      - name: Comment PR (success — no new violations)
-        if: ${{ steps.diff.outputs.new_count == '0' }}
-        continue-on-error: true
-        uses: mshick/add-pr-comment@8e4927817251f1ff60c001f04568532b38e0b4a0 # v3.11
-        with:
-          message-id: "${{ github.event.pull_request.number }}/kyverno/diff-only"
-          message: |
-            ✅ No new Kyverno violations introduced by this PR.
-
-            (Pre-existing violations on `main` are not gated; see the Job Summary for diff-only details.)
-
-      - name: Comment PR (failure — new violations)
-        if: ${{ steps.diff.outputs.new_count != '0' }}
-        continue-on-error: true
-        uses: mshick/add-pr-comment@8e4927817251f1ff60c001f04568532b38e0b4a0 # v3.11
-        with:
-          message-id: "${{ github.event.pull_request.number }}/kyverno/diff-only"
-          message: |
-            ❌ This PR introduces **${{ steps.diff.outputs.new_count }}** new Kyverno violation(s):
-
-            ```
-            ${{ steps.diff.outputs.new_fails }}
-            ```
-
-            Either fix the offending resources or, if the violation is intentional and accepted,
-            add a Kyverno PolicyException CR (see `kubernetes/apps/kyverno/policies/`).
-
-      - name: Fail on new violations
-        if: ${{ steps.diff.outputs.new_count != '0' }}
-        run: |
-          echo "Diff-only gate FAILED: ${{ steps.diff.outputs.new_count }} new violation(s)."
-          exit 1
+            --audit-warn \
+            --warn-exit-code 0 \
+            --continue-on-fail \
+            --table \
+            --remove-color \
+            | tee -a "${GITHUB_STEP_SUMMARY}"
+          echo '```' >> "${GITHUB_STEP_SUMMARY}"
 
   kyverno-status:
     name: Kyverno Success
-    needs: ["test", "apply", "diff-only"]
+    needs: ["test", "validate"]
     runs-on: ubuntu-latest
     if: ${{ always() }}
     steps:
@@ -289,4 +112,4 @@ jobs:
 
       - name: All jobs passed or skipped?
         if: ${{ !(contains(needs.*.result, 'failure')) }}
-        run: echo "All jobs passed or skipped" && echo "${{ toJSON(needs.*.result) }}"
+        run: echo "${{ toJSON(needs.*.result) }}"

--- a/.github/workflows/kyverno.yaml
+++ b/.github/workflows/kyverno.yaml
@@ -19,14 +19,26 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
+      # WR-01: Replaced tj-actions/changed-files (CVE-2025-30066 retroactive tag
+      # rewrite history) with native git diff. Dependency-free and the diff scope
+      # is identical to the previous `files:` glob.
       - name: Get Changed Files
         id: changed-files
-        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
-        with:
-          files: |
-            kubernetes/**
-            .github/workflows/kyverno.yaml
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin "${BASE_REF}"
+          if git diff --name-only "origin/${BASE_REF}...HEAD" -- \
+                'kubernetes/**' '.github/workflows/kyverno.yaml' \
+                | grep -q .; then
+            echo "any_changed=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "any_changed=false" >> "${GITHUB_OUTPUT}"
+          fi
 
   # Unit test policies against per-policy fixtures (BLOCKING).
   test:

--- a/.github/workflows/kyverno.yaml
+++ b/.github/workflows/kyverno.yaml
@@ -177,8 +177,12 @@ jobs:
             out=$(kyverno apply pr/kubernetes/apps/kyverno/policies/app/ \
                   --resource "${GITHUB_WORKSPACE}/${manifest}" \
                   --policy-report --output-format json 2>"${err}") || rc=$?
-            if [ "${rc}" -ne 0 ]; then
-              echo "ERROR: kyverno apply failed for ${manifest} (rc=${rc})" >&2
+
+            # kyverno apply exits non-zero whenever any policy result is "fail".
+            # That's expected — we want to count those failures, not abort.
+            # Only treat as a real crash if the JSON output is empty/invalid.
+            if ! jq -e . >/dev/null 2>&1 <<<"${out}"; then
+              echo "ERROR: kyverno apply produced no parseable JSON for ${manifest} (rc=${rc})" >&2
               echo "--- kyverno stderr ---" >&2
               cat "${err}" >&2
               echo "--- kyverno stdout ---" >&2

--- a/.github/workflows/kyverno.yaml
+++ b/.github/workflows/kyverno.yaml
@@ -173,11 +173,11 @@ jobs:
 
             local out err rc
             err=$(mktemp)
+            rc=0
             out=$(kyverno apply pr/kubernetes/apps/kyverno/policies/app/ \
                   --resource "${GITHUB_WORKSPACE}/${manifest}" \
-                  --policy-report --output-format json 2>"${err}")
-            rc=$?
-            if [ $rc -ne 0 ]; then
+                  --policy-report --output-format json 2>"${err}") || rc=$?
+            if [ "${rc}" -ne 0 ]; then
               echo "ERROR: kyverno apply failed for ${manifest} (rc=${rc})" >&2
               echo "--- kyverno stderr ---" >&2
               cat "${err}" >&2

--- a/.github/workflows/kyverno.yaml
+++ b/.github/workflows/kyverno.yaml
@@ -171,14 +171,22 @@ jobs:
               exit 1
             fi
 
-            local out
-            if ! out=$(kyverno apply pr/kubernetes/apps/kyverno/policies/app/ \
+            local out err rc
+            err=$(mktemp)
+            out=$(kyverno apply pr/kubernetes/apps/kyverno/policies/app/ \
                   --resource "${GITHUB_WORKSPACE}/${manifest}" \
-                  --policy-report --output-format json); then
-              echo "ERROR: kyverno apply failed for ${manifest}" >&2
+                  --policy-report --output-format json 2>"${err}")
+            rc=$?
+            if [ $rc -ne 0 ]; then
+              echo "ERROR: kyverno apply failed for ${manifest} (rc=${rc})" >&2
+              echo "--- kyverno stderr ---" >&2
+              cat "${err}" >&2
+              echo "--- kyverno stdout ---" >&2
               echo "${out}" >&2
+              rm -f "${err}"
               exit 1
             fi
+            rm -f "${err}"
 
             jq -r 'if type == "array" then .[] else . end
                    | .results[]?

--- a/.github/workflows/kyverno.yaml
+++ b/.github/workflows/kyverno.yaml
@@ -28,10 +28,9 @@ jobs:
             kubernetes/**
             .github/workflows/kyverno.yaml
 
-  # Layer A — kyverno test against per-policy fixtures (BLOCKING).
-  # Fast unit test of policy authoring; catches policy bugs before render.
+  # Unit test policies against per-policy fixtures (BLOCKING).
   test:
-    name: Kyverno Test (Layer A)
+    name: Kyverno Test
     needs: pre-job
     runs-on: ubuntu-latest
     if: ${{ needs.pre-job.outputs.any_changed == 'true' }}
@@ -47,11 +46,11 @@ jobs:
       - name: Run kyverno test
         run: kyverno test kubernetes/apps/kyverno/policies/tests/
 
-  # Layer B — kyverno apply on rendered manifests (INFORMATIONAL).
-  # Full violation table for the PR's manifests; does NOT block merge per CONTEXT D-11
-  # (would block any PR touching a namespace with pre-existing violations).
+  # Apply policies to rendered manifests (INFORMATIONAL — full violation table for the PR).
+  # Does NOT block merge per CONTEXT D-11 (would block any PR touching a namespace with
+  # pre-existing violations). The diff job is the blocking gate.
   apply:
-    name: Kyverno Apply (Layer B)
+    name: Kyverno Apply
     needs: pre-job
     runs-on: ubuntu-latest
     permissions:
@@ -87,34 +86,17 @@ jobs:
             --table 2>&1 | tee apply-output.txt
           echo "rc=${PIPESTATUS[0]}" >> "${GITHUB_OUTPUT}"
           {
-            echo "### Kyverno Apply (Layer B — informational)"
+            echo "### Kyverno Apply"
             echo ''
             echo '```'
             cat apply-output.txt
             echo '```'
           } >> "${GITHUB_STEP_SUMMARY}"
 
-      - name: Comment PR with apply results
-        if: ${{ always() }}
-        continue-on-error: true
-        uses: mshick/add-pr-comment@8e4927817251f1ff60c001f04568532b38e0b4a0 # v3.11
-        with:
-          message-id: "${{ github.event.pull_request.number }}/kyverno/apply"
-          message-failure: "Kyverno apply step did not run successfully (informational only)."
-          message: |
-            ### Kyverno Apply (Layer B — informational)
-
-            ```
-            (see workflow Job Summary for full output)
-            ```
-
-            This is informational only. The blocking gate is the **Diff-Only** job.
-
-  # Layer C — diff-only against main (BLOCKING gate per CONTEXT D-11/D-12).
-  # Fail only on NEW violations introduced by this PR. Logic ported inline from
-  # .planning/spikes/004-kyverno-ci-feedback/scripts/ci-diff-only.sh.
+  # Diff against main — fail only on NEW violations introduced by this PR (BLOCKING).
+  # Per CONTEXT D-11/D-12. Logic ported from .planning/spikes/004-kyverno-ci-feedback/scripts/ci-diff-only.sh.
   diff-only:
-    name: Kyverno Diff-Only (Layer C)
+    name: Kyverno Diff (vs main)
     needs: pre-job
     runs-on: ubuntu-latest
     permissions:
@@ -168,7 +150,7 @@ jobs:
             kyverno apply pr/kubernetes/apps/kyverno/policies/app/ \
               --resource "${manifest}" \
               --policy-report --output-format json 2>/dev/null \
-              | jq -r '.[] | .results[]? | select(.result=="fail") | "\(.policy)::\(.resources[0].kind)/\(.resources[0].namespace)/\(.resources[0].name)"' \
+              | jq -r '.. | objects | select(has("results")) | .results[]? | select(.result=="fail") | "\(.policy)::\(.resources[0].kind)/\(.resources[0].namespace)/\(.resources[0].name)"' \
               | sort -u
           }
 
@@ -184,7 +166,7 @@ jobs:
           FIXED_COUNT=$(wc -l < fixed-fails.txt)
 
           {
-            echo "### Kyverno Diff-Only (Layer C — BLOCKING)"
+            echo "### Kyverno Diff (vs main)"
             echo ''
             echo "- Pre-existing violations on main: ${PRE_EXISTING}"
             echo "- Total violations on PR:          ${PR_TOTAL}"

--- a/.github/workflows/kyverno.yaml
+++ b/.github/workflows/kyverno.yaml
@@ -102,14 +102,14 @@ jobs:
 
   kyverno-status:
     name: Kyverno Success
-    needs: ["test", "validate"]
+    needs: ["pre-job", "test", "validate"]
     runs-on: ubuntu-latest
     if: ${{ always() }}
     steps:
-      - name: Any jobs failed?
-        if: ${{ contains(needs.*.result, 'failure') }}
+      - name: Required jobs passed?
+        if: ${{ needs.pre-job.result != 'success' || (needs.pre-job.outputs.any_changed == 'true' && (needs.test.result != 'success' || needs.validate.result != 'success')) }}
         run: exit 1
 
-      - name: All jobs passed or skipped?
-        if: ${{ !(contains(needs.*.result, 'failure')) }}
+      - name: Kyverno checks complete
+        if: ${{ needs.pre-job.result == 'success' && (needs.pre-job.outputs.any_changed != 'true' || (needs.test.result == 'success' && needs.validate.result == 'success')) }}
         run: echo "${{ toJSON(needs.*.result) }}"

--- a/kubernetes/apps/kyverno/kustomization.yaml
+++ b/kubernetes/apps/kyverno/kustomization.yaml
@@ -8,3 +8,4 @@ components:
   - ../../components/common
 resources:
   - ./kyverno/ks.yaml
+  - ./policies/ks.yaml

--- a/kubernetes/apps/kyverno/policies/app/01-require-namespace-psa-labels.yaml
+++ b/kubernetes/apps/kyverno/policies/app/01-require-namespace-psa-labels.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/kyverno/main/.schemas/v1/clusterpolicy.json
+# Tier 1 — Ready for Enforce after remediation PR for 12 namespaces.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-namespace-psa-labels
+  annotations:
+    policies.kyverno.io/title: Require Namespace PSA Labels
+    policies.kyverno.io/category: Pod Security
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: >-
+      Every user namespace must declare pod-security.kubernetes.io/enforce. This is
+      defense-in-depth alongside Kyverno itself; if Kyverno is ever removed, PSA still
+      blocks the worst classes of pod misconfigurations.
+spec:
+  validationFailureAction: Audit  # Flip to Enforce after remediation PRs land
+  background: true
+  rules:
+    - name: check-psa-enforce-label
+      match:
+        any:
+          - resources:
+              kinds: [Namespace]
+              names: ["*"]
+      exclude:
+        any:
+          - resources:
+              names:
+                - kube-system
+                - kube-public
+                - kube-node-lease
+                - kyverno
+                - flux-system
+                - default
+                - cilium-secrets    # Cilium-managed, no user pods
+      validate:
+        message: "Namespace must set label pod-security.kubernetes.io/enforce (restricted | baseline | privileged)"
+        pattern:
+          metadata:
+            labels:
+              pod-security.kubernetes.io/enforce: "?*"

--- a/kubernetes/apps/kyverno/policies/app/01-require-namespace-psa-labels.yaml
+++ b/kubernetes/apps/kyverno/policies/app/01-require-namespace-psa-labels.yaml
@@ -39,4 +39,4 @@ spec:
         pattern:
           metadata:
             labels:
-              pod-security.kubernetes.io/enforce: "?*"
+              pod-security.kubernetes.io/enforce: "restricted | baseline | privileged"

--- a/kubernetes/apps/kyverno/policies/app/02-require-image-digest-pin.yaml
+++ b/kubernetes/apps/kyverno/policies/app/02-require-image-digest-pin.yaml
@@ -1,0 +1,47 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/kyverno/main/.schemas/v1/clusterpolicy.json
+# Tier 2 — Stays in Audit indefinitely. Renovate enforces drift; this surfaces gaps.
+# Why not Enforce: 325 existing violations across upstream charts that don't pin digests.
+# Flipping to Enforce would block every Helm chart upgrade.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-image-digest-pin
+  annotations:
+    policies.kyverno.io/title: Require Image Digest Pin
+    policies.kyverno.io/category: Supply Chain
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/description: >-
+      Container images must be pinned by SHA256 digest, not floating tags.
+      Surfaces tag-rewrite supply-chain risk via PolicyReports; remediation is
+      Renovate's `pinDigests: true` feature.
+spec:
+  validationFailureAction: Audit  # Stays in Audit; this is a metrics-only policy
+  background: true
+  rules:
+    - name: check-image-digest
+      match:
+        any:
+          - resources:
+              kinds: [Pod]
+      exclude:
+        any:
+          - resources:
+              namespaces: [kube-system, kube-public, kube-node-lease, kyverno, flux-system]
+      validate:
+        message: "Container image must be pinned by digest (image@sha256:...)"
+        foreach:
+          - list: "request.object.spec.containers"
+            deny:
+              conditions:
+                any:
+                  - key: "{{ element.image | contains(@, '@sha256:') }}"
+                    operator: NotEquals
+                    value: true
+          - list: "request.object.spec.initContainers || `[]`"
+            deny:
+              conditions:
+                any:
+                  - key: "{{ element.image | contains(@, '@sha256:') }}"
+                    operator: NotEquals
+                    value: true

--- a/kubernetes/apps/kyverno/policies/app/02-require-image-digest-pin.yaml
+++ b/kubernetes/apps/kyverno/policies/app/02-require-image-digest-pin.yaml
@@ -45,3 +45,10 @@ spec:
                   - key: "{{ element.image | contains(@, '@sha256:') }}"
                     operator: NotEquals
                     value: true
+          - list: "request.object.spec.ephemeralContainers || `[]`"
+            deny:
+              conditions:
+                any:
+                  - key: "{{ element.image | contains(@, '@sha256:') }}"
+                    operator: NotEquals
+                    value: true

--- a/kubernetes/apps/kyverno/policies/app/03-require-non-root-and-readonly-fs.yaml
+++ b/kubernetes/apps/kyverno/policies/app/03-require-non-root-and-readonly-fs.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/kyverno/main/.schemas/v1/clusterpolicy.json
+# Tier 2 — Stays in Audit. 326 existing violations; per-namespace exclusion likely needed.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-non-root-and-readonly-fs
+  annotations:
+    policies.kyverno.io/title: Require Non-Root + Read-Only Root FS
+    policies.kyverno.io/category: Pod Security
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: >-
+      Containers must run non-root with a read-only root filesystem. Audit-only:
+      surfaces apps that need a writable tmp emptyDir or non-root user.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: check-non-root
+      match:
+        any:
+          - resources:
+              kinds: [Pod]
+      exclude:
+        any:
+          - resources:
+              namespaces: [kube-system, kube-public, kube-node-lease, kyverno, flux-system, longhorn-system]
+      validate:
+        message: "Container must set securityContext.runAsNonRoot=true and readOnlyRootFilesystem=true"
+        foreach:
+          - list: "request.object.spec.containers"
+            deny:
+              conditions:
+                any:
+                  - key: "{{ element.securityContext.runAsNonRoot || `false` }}"
+                    operator: NotEquals
+                    value: true
+                  - key: "{{ element.securityContext.readOnlyRootFilesystem || `false` }}"
+                    operator: NotEquals
+                    value: true

--- a/kubernetes/apps/kyverno/policies/app/03-require-non-root-and-readonly-fs.yaml
+++ b/kubernetes/apps/kyverno/policies/app/03-require-non-root-and-readonly-fs.yaml
@@ -38,3 +38,23 @@ spec:
                   - key: "{{ element.securityContext.readOnlyRootFilesystem || `false` }}"
                     operator: NotEquals
                     value: true
+          - list: "request.object.spec.initContainers || `[]`"
+            deny:
+              conditions:
+                any:
+                  - key: "{{ element.securityContext.runAsNonRoot || request.object.spec.securityContext.runAsNonRoot || `false` }}"
+                    operator: NotEquals
+                    value: true
+                  - key: "{{ element.securityContext.readOnlyRootFilesystem || `false` }}"
+                    operator: NotEquals
+                    value: true
+          - list: "request.object.spec.ephemeralContainers || `[]`"
+            deny:
+              conditions:
+                any:
+                  - key: "{{ element.securityContext.runAsNonRoot || request.object.spec.securityContext.runAsNonRoot || `false` }}"
+                    operator: NotEquals
+                    value: true
+                  - key: "{{ element.securityContext.readOnlyRootFilesystem || `false` }}"
+                    operator: NotEquals
+                    value: true

--- a/kubernetes/apps/kyverno/policies/app/03-require-non-root-and-readonly-fs.yaml
+++ b/kubernetes/apps/kyverno/policies/app/03-require-non-root-and-readonly-fs.yaml
@@ -31,27 +31,27 @@ spec:
           - resources:
               namespaces: [kube-system, kube-public, kube-node-lease, kyverno, flux-system, longhorn-system]
       validate:
-        message: "Container must set securityContext.runAsNonRoot=true (or runAsUser != 0)"
+        message: "Container must set securityContext.runAsNonRoot=true"
         foreach:
           - list: "request.object.spec.containers"
             deny:
               conditions:
                 any:
-                  - key: "{{ element.securityContext.runAsNonRoot || request.object.spec.securityContext.runAsNonRoot || `false` }}"
+                  - key: "{{ not_null(element.securityContext.runAsNonRoot, request.object.spec.securityContext.runAsNonRoot, `false`) }}"
                     operator: NotEquals
                     value: true
           - list: "request.object.spec.initContainers || `[]`"
             deny:
               conditions:
                 any:
-                  - key: "{{ element.securityContext.runAsNonRoot || request.object.spec.securityContext.runAsNonRoot || `false` }}"
+                  - key: "{{ not_null(element.securityContext.runAsNonRoot, request.object.spec.securityContext.runAsNonRoot, `false`) }}"
                     operator: NotEquals
                     value: true
           - list: "request.object.spec.ephemeralContainers || `[]`"
             deny:
               conditions:
                 any:
-                  - key: "{{ element.securityContext.runAsNonRoot || request.object.spec.securityContext.runAsNonRoot || `false` }}"
+                  - key: "{{ not_null(element.securityContext.runAsNonRoot, request.object.spec.securityContext.runAsNonRoot, `false`) }}"
                     operator: NotEquals
                     value: true
     - name: check-readOnlyRootFilesystem

--- a/kubernetes/apps/kyverno/policies/app/03-require-non-root-and-readonly-fs.yaml
+++ b/kubernetes/apps/kyverno/policies/app/03-require-non-root-and-readonly-fs.yaml
@@ -32,7 +32,7 @@ spec:
             deny:
               conditions:
                 any:
-                  - key: "{{ element.securityContext.runAsNonRoot || `false` }}"
+                  - key: "{{ element.securityContext.runAsNonRoot || request.object.spec.securityContext.runAsNonRoot || `false` }}"
                     operator: NotEquals
                     value: true
                   - key: "{{ element.securityContext.readOnlyRootFilesystem || `false` }}"

--- a/kubernetes/apps/kyverno/policies/app/03-require-non-root-and-readonly-fs.yaml
+++ b/kubernetes/apps/kyverno/policies/app/03-require-non-root-and-readonly-fs.yaml
@@ -1,6 +1,11 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/kyverno/main/.schemas/v1/clusterpolicy.json
 # Tier 2 — Stays in Audit. 326 existing violations; per-namespace exclusion likely needed.
+#
+# Split into two named rules (check-runAsNonRoot, check-readOnlyRootFilesystem) so
+# PolicyReport entries pinpoint which control was violated. With one combined rule
+# and `any: [cond1, cond2]`, the report only surfaces a generic message without
+# saying which condition fired — making 326 audit entries hard to triage.
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -16,7 +21,7 @@ spec:
   validationFailureAction: Audit
   background: true
   rules:
-    - name: check-non-root
+    - name: check-runAsNonRoot
       match:
         any:
           - resources:
@@ -26,16 +31,13 @@ spec:
           - resources:
               namespaces: [kube-system, kube-public, kube-node-lease, kyverno, flux-system, longhorn-system]
       validate:
-        message: "Container must set securityContext.runAsNonRoot=true and readOnlyRootFilesystem=true"
+        message: "Container must set securityContext.runAsNonRoot=true (or runAsUser != 0)"
         foreach:
           - list: "request.object.spec.containers"
             deny:
               conditions:
                 any:
                   - key: "{{ element.securityContext.runAsNonRoot || request.object.spec.securityContext.runAsNonRoot || `false` }}"
-                    operator: NotEquals
-                    value: true
-                  - key: "{{ element.securityContext.readOnlyRootFilesystem || `false` }}"
                     operator: NotEquals
                     value: true
           - list: "request.object.spec.initContainers || `[]`"
@@ -45,9 +47,6 @@ spec:
                   - key: "{{ element.securityContext.runAsNonRoot || request.object.spec.securityContext.runAsNonRoot || `false` }}"
                     operator: NotEquals
                     value: true
-                  - key: "{{ element.securityContext.readOnlyRootFilesystem || `false` }}"
-                    operator: NotEquals
-                    value: true
           - list: "request.object.spec.ephemeralContainers || `[]`"
             deny:
               conditions:
@@ -55,6 +54,36 @@ spec:
                   - key: "{{ element.securityContext.runAsNonRoot || request.object.spec.securityContext.runAsNonRoot || `false` }}"
                     operator: NotEquals
                     value: true
+    - name: check-readOnlyRootFilesystem
+      match:
+        any:
+          - resources:
+              kinds: [Pod]
+      exclude:
+        any:
+          - resources:
+              namespaces: [kube-system, kube-public, kube-node-lease, kyverno, flux-system, longhorn-system]
+      validate:
+        message: "Container must set securityContext.readOnlyRootFilesystem=true"
+        foreach:
+          - list: "request.object.spec.containers"
+            deny:
+              conditions:
+                any:
+                  - key: "{{ element.securityContext.readOnlyRootFilesystem || `false` }}"
+                    operator: NotEquals
+                    value: true
+          - list: "request.object.spec.initContainers || `[]`"
+            deny:
+              conditions:
+                any:
+                  - key: "{{ element.securityContext.readOnlyRootFilesystem || `false` }}"
+                    operator: NotEquals
+                    value: true
+          - list: "request.object.spec.ephemeralContainers || `[]`"
+            deny:
+              conditions:
+                any:
                   - key: "{{ element.securityContext.readOnlyRootFilesystem || `false` }}"
                     operator: NotEquals
                     value: true

--- a/kubernetes/apps/kyverno/policies/app/04-require-network-policy-per-namespace.yaml
+++ b/kubernetes/apps/kyverno/policies/app/04-require-network-policy-per-namespace.yaml
@@ -1,7 +1,19 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/kyverno/main/.schemas/v1/clusterpolicy.json
-# Tier 3 — New policy. Ship as Audit, observe ~7 days, then Enforce.
-# Forces explicit east-west traffic decisions per namespace.
+# Tier 3 — BACKGROUND-SCAN ONLY. See WARNING below.
+#
+# WARNING (CR-02): This policy CANNOT be flipped to validationFailureAction: Enforce.
+# At admission time, a Namespace is admitted as a single object before any
+# NetworkPolicy can possibly exist inside it (NetworkPolicies require an existing
+# namespace as their parent). The apiCall to list NetworkPolicies in
+# request.object.metadata.name will always return zero on CREATE admission, so an
+# Enforce flip would permanently block all namespace creation in the cluster.
+#
+# To prevent false-positive PolicyReports on every new namespace admission, the
+# rule is gated by a precondition that skips admission events; useful signal
+# comes solely from background scans of namespaces that already exist.
+# Reference: https://kyverno.io/docs/writing-policies/preconditions/ and
+#            https://kyverno.io/docs/writing-policies/background/
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -13,6 +25,7 @@ metadata:
     policies.kyverno.io/description: >-
       Every user namespace must have at least one NetworkPolicy (or CiliumNetworkPolicy).
       Default-deny is preferred but not enforced here; this is the floor.
+      BACKGROUND-SCAN ONLY — see WARNING in file header; cannot be Enforced.
 spec:
   validationFailureAction: Audit
   background: true
@@ -33,6 +46,15 @@ spec:
                 - flux-system
                 - default
                 - cilium-secrets
+      preconditions:
+        all:
+          # Skip admission events (CREATE/UPDATE/DELETE/CONNECT). Background scans
+          # do not set request.operation, so the `|| 'BACKGROUND'` default keeps
+          # them in scope. Without this gate, every Namespace CREATE would emit a
+          # false-positive PolicyReport since no NetworkPolicy can exist yet.
+          - key: "{{ request.operation || 'BACKGROUND' }}"
+            operator: Equals
+            value: BACKGROUND
       context:
         - name: netpols
           apiCall:

--- a/kubernetes/apps/kyverno/policies/app/04-require-network-policy-per-namespace.yaml
+++ b/kubernetes/apps/kyverno/policies/app/04-require-network-policy-per-namespace.yaml
@@ -1,0 +1,55 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/kyverno/main/.schemas/v1/clusterpolicy.json
+# Tier 3 — New policy. Ship as Audit, observe ~7 days, then Enforce.
+# Forces explicit east-west traffic decisions per namespace.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-network-policy-per-namespace
+  annotations:
+    policies.kyverno.io/title: Require NetworkPolicy per Namespace
+    policies.kyverno.io/category: Network
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: >-
+      Every user namespace must have at least one NetworkPolicy (or CiliumNetworkPolicy).
+      Default-deny is preferred but not enforced here; this is the floor.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: check-namespace-has-netpol
+      match:
+        any:
+          - resources:
+              kinds: [Namespace]
+      exclude:
+        any:
+          - resources:
+              names:
+                - kube-system
+                - kube-public
+                - kube-node-lease
+                - kyverno
+                - flux-system
+                - default
+                - cilium-secrets
+      context:
+        - name: netpols
+          apiCall:
+            urlPath: "/apis/networking.k8s.io/v1/namespaces/{{request.object.metadata.name}}/networkpolicies"
+            jmesPath: "items | length(@)"
+        - name: cilium_netpols
+          apiCall:
+            urlPath: "/apis/cilium.io/v2/namespaces/{{request.object.metadata.name}}/ciliumnetworkpolicies"
+            jmesPath: "items | length(@)"
+      validate:
+        message: "Namespace must have at least one NetworkPolicy or CiliumNetworkPolicy"
+        deny:
+          conditions:
+            all:
+              - key: "{{ netpols }}"
+                operator: Equals
+                value: 0
+              - key: "{{ cilium_netpols }}"
+                operator: Equals
+                value: 0

--- a/kubernetes/apps/kyverno/policies/app/05-disallow-host-namespaces.yaml
+++ b/kubernetes/apps/kyverno/policies/app/05-disallow-host-namespaces.yaml
@@ -29,6 +29,6 @@ spec:
         message: "Pod must not set spec.hostNetwork, spec.hostPID, or spec.hostIPC"
         pattern:
           spec:
-            =(hostNetwork): "false"
-            =(hostPID): "false"
-            =(hostIPC): "false"
+            =(hostNetwork): false
+            =(hostPID): false
+            =(hostIPC): false

--- a/kubernetes/apps/kyverno/policies/app/05-disallow-host-namespaces.yaml
+++ b/kubernetes/apps/kyverno/policies/app/05-disallow-host-namespaces.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/kyverno/main/.schemas/v1/clusterpolicy.json
+# Tier 3 — Defense-in-depth. Block hostNetwork/hostPID/hostIPC pods.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-host-namespaces
+  annotations:
+    policies.kyverno.io/title: Disallow Host Namespaces
+    policies.kyverno.io/category: Pod Security
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/description: >-
+      Pods must not use hostNetwork, hostPID, or hostIPC. Equivalent to PSS Baseline.
+      Excludes system addons (Cilium, kubelet pods, etc.) that legitimately need it.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: check-no-host-namespaces
+      match:
+        any:
+          - resources:
+              kinds: [Pod]
+      exclude:
+        any:
+          - resources:
+              namespaces: [kube-system, kube-public, kube-node-lease, kyverno, flux-system]
+      validate:
+        message: "Pod must not set spec.hostNetwork, spec.hostPID, or spec.hostIPC"
+        pattern:
+          spec:
+            =(hostNetwork): "false"
+            =(hostPID): "false"
+            =(hostIPC): "false"

--- a/kubernetes/apps/kyverno/policies/app/06-verify-image-signature-cosign.yaml
+++ b/kubernetes/apps/kyverno/policies/app/06-verify-image-signature-cosign.yaml
@@ -45,6 +45,14 @@ spec:
           required: false       # Audit-only mode; flip to true to Enforce
           attestors:
             - entries:
+                # WARNING (WR-06): the wildcards below accept signatures from ANY
+                # GitHub repo via the public Sigstore Fulcio CA + Rekor — including
+                # attacker-owned forks that successfully run a signing workflow.
+                # DO NOT flip `required: true` or `validationFailureAction: Enforce`
+                # until `subject:` is narrowed to specific orgs/repos
+                # (e.g. https://github.com/melotic/* and https://github.com/kyverno/*).
+                # See https://kyverno.io/policies/?policytypes=Verify%2520images for
+                # canonical scoped examples.
                 - keyless:
                     subject: "https://github.com/*"
                     issuer: "https://token.actions.githubusercontent.com"

--- a/kubernetes/apps/kyverno/policies/app/06-verify-image-signature-cosign.yaml
+++ b/kubernetes/apps/kyverno/policies/app/06-verify-image-signature-cosign.yaml
@@ -1,0 +1,52 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/kyverno/main/.schemas/v1/clusterpolicy.json
+# Tier 3 — Cosign signature verification. Audit indefinitely; require explicit
+# allow-list for unsigned images (e.g., prompp until Spike 002 gating conditions met).
+#
+# Note: requires Kyverno's verifyImages rule which talks to a key/keyless verifier.
+# This is a SKELETON — production version needs a real key (cosign.pub from the
+# vendors we trust) and a tested verifier endpoint. Ship as Audit only until the
+# trust roots are nailed down.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: verify-image-signature-cosign
+  annotations:
+    policies.kyverno.io/title: Verify Image Signatures (cosign)
+    policies.kyverno.io/category: Supply Chain
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/description: >-
+      Container images from approved registries must carry a valid cosign signature.
+      Hard exclusion for prompp images until Spike 002's signature/SBOM gating
+      conditions are met.
+spec:
+  validationFailureAction: Audit
+  webhookConfiguration:
+    failurePolicy: Ignore   # Don't block when verifier endpoint is down
+  rules:
+    - name: verify-trusted-registries
+      match:
+        any:
+          - resources:
+              kinds: [Pod]
+      exclude:
+        any:
+          - resources:
+              namespaces: [kube-system, kube-public, kube-node-lease, kyverno, flux-system]
+          # prompp explicitly excluded — see Spike 002 (image-provenance) gating conditions
+          - resources:
+              namespaces: [spike-prompp]
+      verifyImages:
+        - imageReferences:
+            - "ghcr.io/*"
+            - "registry.k8s.io/*"
+          mutateDigest: false   # Don't auto-mutate; that's Renovate's job
+          verifyDigest: false
+          required: false       # Audit-only mode; flip to true to Enforce
+          attestors:
+            - entries:
+                - keyless:
+                    subject: "https://github.com/*"
+                    issuer: "https://token.actions.githubusercontent.com"
+                    rekor:
+                      url: "https://rekor.sigstore.dev"

--- a/kubernetes/apps/kyverno/policies/app/07-disallow-untrusted-images.yaml
+++ b/kubernetes/apps/kyverno/policies/app/07-disallow-untrusted-images.yaml
@@ -1,0 +1,49 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/kyverno/main/.schemas/v1/clusterpolicy.json
+# Tier 1 — SEC-04 image denylist. Ships Audit per D-07/D-10; Enforce flip in plan 04-06.
+# Spike 002 REJECT of prompp is final (CONTEXT D-02). Adding to or removing from the
+# denylist requires a tracked PR — process IS the gate per D-09.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-untrusted-images
+  annotations:
+    policies.kyverno.io/title: Disallow Untrusted Images
+    policies.kyverno.io/category: Supply Chain
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/description: >-
+      Container images whose name matches the denylist are blocked from running.
+      Initial denylist entries (prompp, vmstorage-prompp) reflect Spike 002's REJECT
+      decision on observability-prompp. Adding to the denylist requires a PR.
+spec:
+  validationFailureAction: Audit  # Tier 1 — Enforce flip in plan 04-06
+  background: true
+  rules:
+    - name: check-image-denylist
+      match:
+        any:
+          - resources:
+              kinds: [Pod]
+      exclude:
+        any:
+          - resources:
+              namespaces: [kube-system, kube-public, kube-node-lease, kyverno, flux-system]
+      validate:
+        message: >-
+          Image name matches denylist (currently: prompp, vmstorage-prompp).
+          Adding to the allow-exception requires a PR.
+        foreach:
+          - list: "request.object.spec.containers"
+            deny:
+              conditions:
+                any:
+                  - key: "{{ element.image | regex_match('(prompp|vmstorage-prompp)', @) }}"
+                    operator: Equals
+                    value: true
+          - list: "request.object.spec.initContainers || `[]`"
+            deny:
+              conditions:
+                any:
+                  - key: "{{ element.image | regex_match('(prompp|vmstorage-prompp)', @) }}"
+                    operator: Equals
+                    value: true

--- a/kubernetes/apps/kyverno/policies/app/07-disallow-untrusted-images.yaml
+++ b/kubernetes/apps/kyverno/policies/app/07-disallow-untrusted-images.yaml
@@ -47,3 +47,10 @@ spec:
                   - key: "{{ element.image | regex_match('(^|/)(prompp|vmstorage-prompp)(:|@|$)', @) }}"
                     operator: Equals
                     value: true
+          - list: "request.object.spec.ephemeralContainers || `[]`"
+            deny:
+              conditions:
+                any:
+                  - key: "{{ element.image | regex_match('(^|/)(prompp|vmstorage-prompp)(:|@|$)', @) }}"
+                    operator: Equals
+                    value: true

--- a/kubernetes/apps/kyverno/policies/app/07-disallow-untrusted-images.yaml
+++ b/kubernetes/apps/kyverno/policies/app/07-disallow-untrusted-images.yaml
@@ -31,7 +31,7 @@ spec:
       validate:
         message: >-
           Image name matches denylist (currently: prompp, vmstorage-prompp).
-          Adding to the allow-exception requires a PR.
+          Changes to the denylist require a PR.
         foreach:
           - list: "request.object.spec.containers"
             deny:

--- a/kubernetes/apps/kyverno/policies/app/07-disallow-untrusted-images.yaml
+++ b/kubernetes/apps/kyverno/policies/app/07-disallow-untrusted-images.yaml
@@ -37,13 +37,13 @@ spec:
             deny:
               conditions:
                 any:
-                  - key: "{{ element.image | regex_match('(prompp|vmstorage-prompp)', @) }}"
+                  - key: "{{ element.image | regex_match('(^|/)(prompp|vmstorage-prompp)(:|@|$)', @) }}"
                     operator: Equals
                     value: true
           - list: "request.object.spec.initContainers || `[]`"
             deny:
               conditions:
                 any:
-                  - key: "{{ element.image | regex_match('(prompp|vmstorage-prompp)', @) }}"
+                  - key: "{{ element.image | regex_match('(^|/)(prompp|vmstorage-prompp)(:|@|$)', @) }}"
                     operator: Equals
                     value: true

--- a/kubernetes/apps/kyverno/policies/app/08-require-image-registry-allowlist.yaml
+++ b/kubernetes/apps/kyverno/policies/app/08-require-image-registry-allowlist.yaml
@@ -35,18 +35,11 @@ spec:
           Container image must come from an allowlisted registry
           (ghcr.io, docker.io, index.docker.io, quay.io, registry.k8s.io,
           mirror.gcr.io, lscr.io, docker.dragonflydb.io, harbor.melotic.dev).
-        foreach:
-          - list: "request.object.spec.containers"
-            deny:
-              conditions:
-                all:
-                  - key: "{{ element.image | regex_match('^(ghcr.io|quay.io|mirror.gcr.io|docker.io|index.docker.io|lscr.io|docker.dragonflydb.io|harbor.melotic.dev|registry.k8s.io)/', @) }}"
-                    operator: Equals
-                    value: false
-          - list: "request.object.spec.initContainers || `[]`"
-            deny:
-              conditions:
-                all:
-                  - key: "{{ element.image | regex_match('^(ghcr.io|quay.io|mirror.gcr.io|docker.io|index.docker.io|lscr.io|docker.dragonflydb.io|harbor.melotic.dev|registry.k8s.io)/', @) }}"
-                    operator: Equals
-                    value: false
+        pattern:
+          spec:
+            =(ephemeralContainers):
+              - image: "ghcr.io/* | quay.io/* | mirror.gcr.io/* | docker.io/* | index.docker.io/* | lscr.io/* | docker.dragonflydb.io/* | harbor.melotic.dev/* | registry.k8s.io/*"
+            =(initContainers):
+              - image: "ghcr.io/* | quay.io/* | mirror.gcr.io/* | docker.io/* | index.docker.io/* | lscr.io/* | docker.dragonflydb.io/* | harbor.melotic.dev/* | registry.k8s.io/*"
+            containers:
+              - image: "ghcr.io/* | quay.io/* | mirror.gcr.io/* | docker.io/* | index.docker.io/* | lscr.io/* | docker.dragonflydb.io/* | harbor.melotic.dev/* | registry.k8s.io/*"

--- a/kubernetes/apps/kyverno/policies/app/08-require-image-registry-allowlist.yaml
+++ b/kubernetes/apps/kyverno/policies/app/08-require-image-registry-allowlist.yaml
@@ -1,0 +1,52 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/kyverno/main/.schemas/v1/clusterpolicy.json
+# Tier 1 — SEC-04 registry allowlist. Ships Audit per D-07/D-10; Enforce flip in plan 04-06.
+# 9-registry list per CONTEXT D-17 / RESEARCH.md §324-356 — matches every registry
+# currently in use across kubernetes/apps/. Adding a registry requires a tracked PR
+# (process IS the gate per D-09).
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-image-registry-allowlist
+  annotations:
+    policies.kyverno.io/title: Require Image Registry Allowlist
+    policies.kyverno.io/category: Supply Chain
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/description: >-
+      Container images must come from an allowlisted registry. Adding a new registry
+      to the allowlist requires a PR. Bare-name DockerHub images (no registry prefix)
+      are implicitly denied — Renovate normalizes to docker.io/... so no real workload
+      regression is expected.
+spec:
+  validationFailureAction: Audit  # Tier 1 — Enforce flip in plan 04-06
+  background: true
+  rules:
+    - name: check-registry-allowlist
+      match:
+        any:
+          - resources:
+              kinds: [Pod]
+      exclude:
+        any:
+          - resources:
+              namespaces: [kube-system, kube-public, kube-node-lease, kyverno, flux-system]
+      validate:
+        message: >-
+          Container image must come from an allowlisted registry
+          (ghcr.io, docker.io, index.docker.io, quay.io, registry.k8s.io,
+          mirror.gcr.io, lscr.io, docker.dragonflydb.io, harbor.melotic.dev).
+        foreach:
+          - list: "request.object.spec.containers"
+            deny:
+              conditions:
+                all:
+                  - key: "{{ element.image | regex_match('^(ghcr.io|quay.io|mirror.gcr.io|docker.io|index.docker.io|lscr.io|docker.dragonflydb.io|harbor.melotic.dev|registry.k8s.io)/', @) }}"
+                    operator: Equals
+                    value: false
+          - list: "request.object.spec.initContainers || `[]`"
+            deny:
+              conditions:
+                all:
+                  - key: "{{ element.image | regex_match('^(ghcr.io|quay.io|mirror.gcr.io|docker.io|index.docker.io|lscr.io|docker.dragonflydb.io|harbor.melotic.dev|registry.k8s.io)/', @) }}"
+                    operator: Equals
+                    value: false

--- a/kubernetes/apps/kyverno/policies/app/kustomization.yaml
+++ b/kubernetes/apps/kyverno/policies/app/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./01-require-namespace-psa-labels.yaml
+  - ./02-require-image-digest-pin.yaml
+  - ./03-require-non-root-and-readonly-fs.yaml
+  - ./04-require-network-policy-per-namespace.yaml
+  - ./05-disallow-host-namespaces.yaml
+  - ./06-verify-image-signature-cosign.yaml
+  - ./07-disallow-untrusted-images.yaml
+  - ./08-require-image-registry-allowlist.yaml

--- a/kubernetes/apps/kyverno/policies/ks.yaml
+++ b/kubernetes/apps/kyverno/policies/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app kyverno-policies
+  namespace: &namespace kyverno
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: kyverno
+      namespace: kyverno
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: kyverno
+      namespace: kyverno
+  interval: 1h
+  path: ./kubernetes/apps/kyverno/policies/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: true

--- a/kubernetes/apps/kyverno/policies/tests/01-require-namespace-psa-labels/fixtures/bad-namespace.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/01-require-namespace-psa-labels/fixtures/bad-namespace.yaml
@@ -1,0 +1,8 @@
+---
+# Bad fixture — fails require-namespace-psa-labels (no PSA enforce label)
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: example-bad
+  labels:
+    app.kubernetes.io/name: example

--- a/kubernetes/apps/kyverno/policies/tests/01-require-namespace-psa-labels/fixtures/good-namespace.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/01-require-namespace-psa-labels/fixtures/good-namespace.yaml
@@ -1,0 +1,10 @@
+---
+# Good fixture — passes require-namespace-psa-labels
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: example-good
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/kubernetes/apps/kyverno/policies/tests/01-require-namespace-psa-labels/fixtures/invalid-namespace.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/01-require-namespace-psa-labels/fixtures/invalid-namespace.yaml
@@ -1,0 +1,8 @@
+---
+# Bad fixture — non-empty but invalid PSA enforce level
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: example-invalid
+  labels:
+    pod-security.kubernetes.io/enforce: permissive

--- a/kubernetes/apps/kyverno/policies/tests/01-require-namespace-psa-labels/kyverno-test.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/01-require-namespace-psa-labels/kyverno-test.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: require-namespace-psa-labels-test
+policies:
+  - ../../app/01-require-namespace-psa-labels.yaml
+resources:
+  - fixtures/good-namespace.yaml
+  - fixtures/bad-namespace.yaml
+results:
+  - policy: require-namespace-psa-labels
+    rule: check-psa-enforce-label
+    resources: [example-good]
+    kind: Namespace
+    result: pass
+  - policy: require-namespace-psa-labels
+    rule: check-psa-enforce-label
+    resources: [example-bad]
+    kind: Namespace
+    result: fail

--- a/kubernetes/apps/kyverno/policies/tests/01-require-namespace-psa-labels/kyverno-test.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/01-require-namespace-psa-labels/kyverno-test.yaml
@@ -8,6 +8,7 @@ policies:
 resources:
   - fixtures/good-namespace.yaml
   - fixtures/bad-namespace.yaml
+  - fixtures/invalid-namespace.yaml
 results:
   - policy: require-namespace-psa-labels
     rule: check-psa-enforce-label
@@ -17,5 +18,10 @@ results:
   - policy: require-namespace-psa-labels
     rule: check-psa-enforce-label
     resources: [example-bad]
+    kind: Namespace
+    result: fail
+  - policy: require-namespace-psa-labels
+    rule: check-psa-enforce-label
+    resources: [example-invalid]
     kind: Namespace
     result: fail

--- a/kubernetes/apps/kyverno/policies/tests/02-require-image-digest-pin/fixtures/bad-pod.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/02-require-image-digest-pin/fixtures/bad-pod.yaml
@@ -1,0 +1,11 @@
+---
+# Bad fixture — image uses a floating tag
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-pod
+  namespace: default
+spec:
+  containers:
+    - name: app
+      image: ghcr.io/kyverno/kyverno:v1.17.2

--- a/kubernetes/apps/kyverno/policies/tests/02-require-image-digest-pin/fixtures/good-pod.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/02-require-image-digest-pin/fixtures/good-pod.yaml
@@ -1,0 +1,11 @@
+---
+# Good fixture — image pinned by SHA256 digest
+apiVersion: v1
+kind: Pod
+metadata:
+  name: good-pod
+  namespace: default
+spec:
+  containers:
+    - name: app
+      image: ghcr.io/kyverno/kyverno@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

--- a/kubernetes/apps/kyverno/policies/tests/02-require-image-digest-pin/kyverno-test.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/02-require-image-digest-pin/kyverno-test.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: require-image-digest-pin-test
+policies:
+  - ../../app/02-require-image-digest-pin.yaml
+resources:
+  - fixtures/good-pod.yaml
+  - fixtures/bad-pod.yaml
+results:
+  - policy: require-image-digest-pin
+    rule: check-image-digest
+    resources: [good-pod]
+    kind: Pod
+    result: pass
+  - policy: require-image-digest-pin
+    rule: check-image-digest
+    resources: [bad-pod]
+    kind: Pod
+    result: fail

--- a/kubernetes/apps/kyverno/policies/tests/03-require-non-root-and-readonly-fs/fixtures/bad-container-nonroot-false.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/03-require-non-root-and-readonly-fs/fixtures/bad-container-nonroot-false.yaml
@@ -1,0 +1,16 @@
+---
+# Bad fixture — explicit container runAsNonRoot=false overrides pod-level true
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-container-nonroot-false
+  namespace: default
+spec:
+  securityContext:
+    runAsNonRoot: true
+  containers:
+    - name: app
+      image: ghcr.io/kyverno/kyverno:v1.17.2
+      securityContext:
+        runAsNonRoot: false
+        readOnlyRootFilesystem: true

--- a/kubernetes/apps/kyverno/policies/tests/03-require-non-root-and-readonly-fs/fixtures/bad-readonly-false.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/03-require-non-root-and-readonly-fs/fixtures/bad-readonly-false.yaml
@@ -1,0 +1,15 @@
+---
+# Bad fixture — readOnlyRootFilesystem is explicitly false
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-readonly-false
+  namespace: default
+spec:
+  securityContext:
+    runAsNonRoot: true
+  containers:
+    - name: app
+      image: ghcr.io/kyverno/kyverno:v1.17.2
+      securityContext:
+        readOnlyRootFilesystem: false

--- a/kubernetes/apps/kyverno/policies/tests/03-require-non-root-and-readonly-fs/fixtures/bad-readonly-missing.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/03-require-non-root-and-readonly-fs/fixtures/bad-readonly-missing.yaml
@@ -1,0 +1,13 @@
+---
+# Bad fixture — readOnlyRootFilesystem is missing
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-readonly-missing
+  namespace: default
+spec:
+  securityContext:
+    runAsNonRoot: true
+  containers:
+    - name: app
+      image: ghcr.io/kyverno/kyverno:v1.17.2

--- a/kubernetes/apps/kyverno/policies/tests/03-require-non-root-and-readonly-fs/fixtures/good-pod-level-nonroot.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/03-require-non-root-and-readonly-fs/fixtures/good-pod-level-nonroot.yaml
@@ -1,0 +1,15 @@
+---
+# Good fixture — pod-level runAsNonRoot with container read-only root filesystem
+apiVersion: v1
+kind: Pod
+metadata:
+  name: good-pod-level-nonroot
+  namespace: default
+spec:
+  securityContext:
+    runAsNonRoot: true
+  containers:
+    - name: app
+      image: ghcr.io/kyverno/kyverno:v1.17.2
+      securityContext:
+        readOnlyRootFilesystem: true

--- a/kubernetes/apps/kyverno/policies/tests/03-require-non-root-and-readonly-fs/kyverno-test.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/03-require-non-root-and-readonly-fs/kyverno-test.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: require-non-root-and-readonly-fs-test
+policies:
+  - ../../app/03-require-non-root-and-readonly-fs.yaml
+resources:
+  - fixtures/good-pod-level-nonroot.yaml
+  - fixtures/bad-container-nonroot-false.yaml
+  - fixtures/bad-readonly-false.yaml
+  - fixtures/bad-readonly-missing.yaml
+results:
+  - policy: require-non-root-and-readonly-fs
+    rule: check-runAsNonRoot
+    resources: [good-pod-level-nonroot]
+    kind: Pod
+    result: pass
+  - policy: require-non-root-and-readonly-fs
+    rule: check-readOnlyRootFilesystem
+    resources: [good-pod-level-nonroot]
+    kind: Pod
+    result: pass
+  - policy: require-non-root-and-readonly-fs
+    rule: check-runAsNonRoot
+    resources: [bad-container-nonroot-false]
+    kind: Pod
+    result: fail
+  - policy: require-non-root-and-readonly-fs
+    rule: check-readOnlyRootFilesystem
+    resources: [bad-container-nonroot-false]
+    kind: Pod
+    result: pass
+  - policy: require-non-root-and-readonly-fs
+    rule: check-runAsNonRoot
+    resources: [bad-readonly-false]
+    kind: Pod
+    result: pass
+  - policy: require-non-root-and-readonly-fs
+    rule: check-readOnlyRootFilesystem
+    resources: [bad-readonly-false]
+    kind: Pod
+    result: fail
+  - policy: require-non-root-and-readonly-fs
+    rule: check-runAsNonRoot
+    resources: [bad-readonly-missing]
+    kind: Pod
+    result: pass
+  - policy: require-non-root-and-readonly-fs
+    rule: check-readOnlyRootFilesystem
+    resources: [bad-readonly-missing]
+    kind: Pod
+    result: fail

--- a/kubernetes/apps/kyverno/policies/tests/04-require-network-policy-per-namespace/fixtures/namespace-cilium-netpol.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/04-require-network-policy-per-namespace/fixtures/namespace-cilium-netpol.yaml
@@ -1,0 +1,8 @@
+---
+# Good fixture — mocked CiliumNetworkPolicy count is non-zero
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: namespace-cilium-netpol
+  labels:
+    pod-security.kubernetes.io/enforce: restricted

--- a/kubernetes/apps/kyverno/policies/tests/04-require-network-policy-per-namespace/fixtures/namespace-create.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/04-require-network-policy-per-namespace/fixtures/namespace-create.yaml
@@ -1,0 +1,8 @@
+---
+# Skipped fixture — admission CREATE is outside this background-scan-only policy
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: namespace-create
+  labels:
+    pod-security.kubernetes.io/enforce: restricted

--- a/kubernetes/apps/kyverno/policies/tests/04-require-network-policy-per-namespace/fixtures/namespace-netpol.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/04-require-network-policy-per-namespace/fixtures/namespace-netpol.yaml
@@ -1,0 +1,8 @@
+---
+# Good fixture — mocked NetworkPolicy count is non-zero
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: namespace-netpol
+  labels:
+    pod-security.kubernetes.io/enforce: restricted

--- a/kubernetes/apps/kyverno/policies/tests/04-require-network-policy-per-namespace/fixtures/namespace-no-netpol.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/04-require-network-policy-per-namespace/fixtures/namespace-no-netpol.yaml
@@ -1,0 +1,8 @@
+---
+# Bad fixture — mocked NetworkPolicy and CiliumNetworkPolicy counts are zero
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: namespace-no-netpol
+  labels:
+    pod-security.kubernetes.io/enforce: restricted

--- a/kubernetes/apps/kyverno/policies/tests/04-require-network-policy-per-namespace/kyverno-test.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/04-require-network-policy-per-namespace/kyverno-test.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: require-network-policy-per-namespace-test
+policies:
+  - ../../app/04-require-network-policy-per-namespace.yaml
+resources:
+  - fixtures/namespace-netpol.yaml
+  - fixtures/namespace-cilium-netpol.yaml
+  - fixtures/namespace-no-netpol.yaml
+  - fixtures/namespace-create.yaml
+variables: values.yaml
+results:
+  - policy: require-network-policy-per-namespace
+    rule: check-namespace-has-netpol
+    resources: [namespace-netpol]
+    kind: Namespace
+    result: pass
+  - policy: require-network-policy-per-namespace
+    rule: check-namespace-has-netpol
+    resources: [namespace-cilium-netpol]
+    kind: Namespace
+    result: pass
+  - policy: require-network-policy-per-namespace
+    rule: check-namespace-has-netpol
+    resources: [namespace-no-netpol]
+    kind: Namespace
+    result: fail
+  - policy: require-network-policy-per-namespace
+    rule: check-namespace-has-netpol
+    resources: [namespace-create]
+    kind: Namespace
+    result: skip

--- a/kubernetes/apps/kyverno/policies/tests/04-require-network-policy-per-namespace/values.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/04-require-network-policy-per-namespace/values.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Values
+policies:
+  - name: require-network-policy-per-namespace
+    resources:
+      - name: namespace-netpol
+        values:
+          request.operation: BACKGROUND
+          netpols: 1
+          cilium_netpols: 0
+      - name: namespace-cilium-netpol
+        values:
+          request.operation: BACKGROUND
+          netpols: 0
+          cilium_netpols: 1
+      - name: namespace-no-netpol
+        values:
+          request.operation: BACKGROUND
+          netpols: 0
+          cilium_netpols: 0
+      - name: namespace-create
+        values:
+          request.operation: CREATE
+          netpols: 0
+          cilium_netpols: 0

--- a/kubernetes/apps/kyverno/policies/tests/05-disallow-host-namespaces/fixtures/bad-pod.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/05-disallow-host-namespaces/fixtures/bad-pod.yaml
@@ -1,0 +1,12 @@
+---
+# Bad fixture — hostNetwork is true
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-pod
+  namespace: default
+spec:
+  hostNetwork: true
+  containers:
+    - name: app
+      image: ghcr.io/kyverno/kyverno:v1.17.2

--- a/kubernetes/apps/kyverno/policies/tests/05-disallow-host-namespaces/fixtures/good-pod.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/05-disallow-host-namespaces/fixtures/good-pod.yaml
@@ -1,0 +1,14 @@
+---
+# Good fixture — host namespace fields are false
+apiVersion: v1
+kind: Pod
+metadata:
+  name: good-pod
+  namespace: default
+spec:
+  hostNetwork: false
+  hostPID: false
+  hostIPC: false
+  containers:
+    - name: app
+      image: ghcr.io/kyverno/kyverno:v1.17.2

--- a/kubernetes/apps/kyverno/policies/tests/05-disallow-host-namespaces/kyverno-test.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/05-disallow-host-namespaces/kyverno-test.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: disallow-host-namespaces-test
+policies:
+  - ../../app/05-disallow-host-namespaces.yaml
+resources:
+  - fixtures/good-pod.yaml
+  - fixtures/bad-pod.yaml
+results:
+  - policy: disallow-host-namespaces
+    rule: check-no-host-namespaces
+    resources: [good-pod]
+    kind: Pod
+    result: pass
+  - policy: disallow-host-namespaces
+    rule: check-no-host-namespaces
+    resources: [bad-pod]
+    kind: Pod
+    result: fail

--- a/kubernetes/apps/kyverno/policies/tests/07-disallow-untrusted-images/fixtures/bad-pod.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/07-disallow-untrusted-images/fixtures/bad-pod.yaml
@@ -1,0 +1,11 @@
+---
+# Bad fixture — image name matches denylist (prompp)
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-pod
+  namespace: default
+spec:
+  containers:
+    - name: app
+      image: prompp:latest

--- a/kubernetes/apps/kyverno/policies/tests/07-disallow-untrusted-images/fixtures/good-pod.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/07-disallow-untrusted-images/fixtures/good-pod.yaml
@@ -1,0 +1,11 @@
+---
+# Good fixture — image not on denylist
+apiVersion: v1
+kind: Pod
+metadata:
+  name: good-pod
+  namespace: default
+spec:
+  containers:
+    - name: app
+      image: ghcr.io/kyverno/kyverno:v1.17.2

--- a/kubernetes/apps/kyverno/policies/tests/07-disallow-untrusted-images/fixtures/helper-pod.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/07-disallow-untrusted-images/fixtures/helper-pod.yaml
@@ -1,0 +1,11 @@
+---
+# Good fixture — substring match is not enough to hit the segment-bounded denylist
+apiVersion: v1
+kind: Pod
+metadata:
+  name: helper-pod
+  namespace: default
+spec:
+  containers:
+    - name: app
+      image: ghcr.io/example/my-prompp-helper:latest

--- a/kubernetes/apps/kyverno/policies/tests/07-disallow-untrusted-images/kyverno-test.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/07-disallow-untrusted-images/kyverno-test.yaml
@@ -8,6 +8,7 @@ policies:
 resources:
   - fixtures/good-pod.yaml
   - fixtures/bad-pod.yaml
+  - fixtures/helper-pod.yaml
 results:
   - policy: disallow-untrusted-images
     rule: check-image-denylist
@@ -19,3 +20,8 @@ results:
     resources: [bad-pod]
     kind: Pod
     result: fail
+  - policy: disallow-untrusted-images
+    rule: check-image-denylist
+    resources: [helper-pod]
+    kind: Pod
+    result: pass

--- a/kubernetes/apps/kyverno/policies/tests/07-disallow-untrusted-images/kyverno-test.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/07-disallow-untrusted-images/kyverno-test.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: disallow-untrusted-images-test
+policies:
+  - ../../app/07-disallow-untrusted-images.yaml
+resources:
+  - fixtures/good-pod.yaml
+  - fixtures/bad-pod.yaml
+results:
+  - policy: disallow-untrusted-images
+    rule: check-image-denylist
+    resources: [good-pod]
+    kind: Pod
+    result: pass
+  - policy: disallow-untrusted-images
+    rule: check-image-denylist
+    resources: [bad-pod]
+    kind: Pod
+    result: fail

--- a/kubernetes/apps/kyverno/policies/tests/08-require-image-registry-allowlist/fixtures/bad-pod.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/08-require-image-registry-allowlist/fixtures/bad-pod.yaml
@@ -1,0 +1,11 @@
+---
+# Bad fixture — image from non-allowlisted registry
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-pod
+  namespace: default
+spec:
+  containers:
+    - name: app
+      image: evil.example.com/foo:latest

--- a/kubernetes/apps/kyverno/policies/tests/08-require-image-registry-allowlist/fixtures/good-pod.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/08-require-image-registry-allowlist/fixtures/good-pod.yaml
@@ -1,0 +1,11 @@
+---
+# Good fixture — image from allowlisted registry (ghcr.io)
+apiVersion: v1
+kind: Pod
+metadata:
+  name: good-pod
+  namespace: default
+spec:
+  containers:
+    - name: app
+      image: ghcr.io/kyverno/kyverno:v1.17.2

--- a/kubernetes/apps/kyverno/policies/tests/08-require-image-registry-allowlist/kyverno-test.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/08-require-image-registry-allowlist/kyverno-test.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: require-image-registry-allowlist-test
+policies:
+  - ../../app/08-require-image-registry-allowlist.yaml
+resources:
+  - fixtures/good-pod.yaml
+  - fixtures/bad-pod.yaml
+results:
+  - policy: require-image-registry-allowlist
+    rule: check-registry-allowlist
+    resources: [good-pod]
+    kind: Pod
+    result: pass
+  - policy: require-image-registry-allowlist
+    rule: check-registry-allowlist
+    resources: [bad-pod]
+    kind: Pod
+    result: fail


### PR DESCRIPTION
Adds Kyverno ClusterPolicies and a GitHub Actions workflow to validate policy changes. **All policies ship in Audit mode** — they log violations but do not block admission. A follow-up PR will flip Tier-1 policies to Enforce after a real-world audit window.

Stacked on #953 (Kyverno install). Merge that first.

## Policies (all Audit)

**Tier 1 — security-critical**
- `require-namespace-psa-labels` — Pod Security Admission `enforce` labels on namespaces
- `disallow-untrusted-images` — denylist (`prompp`, `vmstorage-prompp`)
- `require-image-registry-allowlist` — only ghcr.io, docker.io, index.docker.io, quay.io, registry.k8s.io, mirror.gcr.io, lscr.io, docker.dragonflydb.io, harbor.melotic.dev

**Tier 2 — pod hardening**
- `require-image-digest-pin` — image refs must include `@sha256:`
- `require-non-root-and-readonly-fs` — non-root containers with read-only root filesystems
- `disallow-host-namespaces` — no hostNetwork/hostPID/hostIPC

**Tier 3 — broader audit signals**
- `require-network-policy-per-namespace` — background-scan check for at least one NetworkPolicy/CiliumNetworkPolicy per user namespace
- `verify-image-signature-cosign` — Audit-only cosign verification skeleton pending trust-root decisions

## CI workflow (`.github/workflows/kyverno.yaml`)

- `kyverno test` blocks merge on policy-authoring regressions using fixtures in `kubernetes/apps/kyverno/policies/tests/`.
- `kyverno apply` renders the cluster with flux-local and posts an informational PolicyReport table to the workflow summary.
- A final status job normalizes skipped/no-op runs and fails if any required Kyverno job fails or is cancelled.

## Why Audit-only

A first-pass Enforce on a live cluster will block legitimate workloads. Audit mode produces PolicyReports we can review before any policy gets teeth.

## Verification

- `kustomize build kubernetes/apps/kyverno/policies/app` succeeds
- `kyverno test kubernetes/apps/kyverno/policies/tests/` passes
- flux-local CI passes
- After merge: `kubectl get cpol` shows all 8; `kubectl get policyreport -A` populates as workloads reconcile

## Follow-ups

- Tier-1 Audit→Enforce flip (separate PR after audit window)
- CIS Talos sysctls hardening (separate PR)
