### PR TITLE
feat(talos): add CIS Bucket A network sysctls

### DIFF
--- a/talos/patches/global/machine-sysctls.yaml
+++ b/talos/patches/global/machine-sysctls.yaml
@@ -8,3 +8,18 @@ machine:
     net.ipv4.neigh.default.gc_thresh2: "8192"  # Prevent ARP cache overflows
     net.ipv4.neigh.default.gc_thresh3: "16384" # Prevent ARP cache overflows
     user.max_user_namespaces: "11255"          # User Namespaces
+    net.ipv4.conf.all.accept_source_route: "0"     # CIS §5.2.1 — disable IP source routing
+    net.ipv4.conf.default.accept_source_route: "0" # CIS §5.2.1 — disable IP source routing
+    net.ipv6.conf.all.accept_source_route: "0"     # CIS §5.2.1 — disable IP source routing
+    net.ipv6.conf.default.accept_source_route: "0" # CIS §5.2.1 — disable IP source routing
+    net.ipv4.conf.all.accept_redirects: "0"        # CIS §5.2.2 — disable ICMP redirects accept
+    net.ipv4.conf.default.accept_redirects: "0"    # CIS §5.2.2 — disable ICMP redirects accept
+    net.ipv6.conf.all.accept_redirects: "0"        # CIS §5.2.2 — disable ICMP redirects accept
+    net.ipv6.conf.default.accept_redirects: "0"    # CIS §5.2.2 — disable ICMP redirects accept
+    net.ipv4.conf.all.secure_redirects: "0"        # CIS §5.2.3 — disable secure ICMP redirects accept
+    net.ipv4.conf.default.secure_redirects: "0"    # CIS §5.2.3 — disable secure ICMP redirects accept
+    net.ipv4.conf.all.log_martians: "1"            # CIS §5.2.4 — log martian packets
+    net.ipv4.conf.default.log_martians: "1"        # CIS §5.2.4 — log martian packets
+    net.ipv4.conf.all.send_redirects: "0"          # CIS §5.1.1 — disable IP redirects send
+    net.ipv4.conf.default.send_redirects: "0"      # CIS §5.1.1 — disable IP redirects send
+    # CIS §5.2.8 (rp_filter) — DEFERRED to Bucket C (Cilium native routing + BPF masq + DSR creates legitimate asymmetric paths). See SECURITY.md.


### PR DESCRIPTION
Phase 04 plan 04-04 — applies CIS Bucket A network hardening sysctls (§5.1.1, §5.2.1–5.2.4) to all Talos nodes.

## Sysctls added
15 keys covering source-routing rejection, ICMP redirect hardening, and martian logging across IPv4/IPv6.

`rp_filter` is intentionally **excluded** (deferred to plan 04-06 Bucket-C deviation D-15) — Cilium native routing + BPF masquerade + DSR creates legitimate asymmetric paths that strict RPF would drop.

## Rollout (already applied live, no reboot needed)
| Node | IP | Result |
|---|---|---|
| k8s-niobe | 10.60.85.10 | ✅ Applied, Ready |
| k8s-trinity | 10.60.85.11 | ✅ Applied, Ready |
| k8s-ghost | 10.60.85.12 | ✅ Applied, Ready |

## Verification (k8s-niobe)
\`\`\`
/proc/sys/net/ipv4/conf/all/send_redirects     = 0
/proc/sys/net/ipv4/conf/all/accept_redirects   = 0
/proc/sys/net/ipv4/conf/all/log_martians       = 1
/proc/sys/net/ipv6/conf/all/accept_source_route = 0
\`\`\`

All 3 nodes Ready post-apply; Cilium unaffected.