### PR TITLE
fix(kyverno): remediate registry allowlist live image sources

### DIFF
--- a/.github/workflows/kyverno.yaml
+++ b/.github/workflows/kyverno.yaml
@@ -30,7 +30,12 @@ jobs:
           set -euo pipefail
           git fetch --no-tags origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}"
           if git diff --name-only "origin/${BASE_REF}..HEAD" -- \
-                'kubernetes/apps/kyverno/**' '.github/workflows/kyverno.yaml' \
+                'kubernetes/**' \
+                'talos/**' \
+                'bootstrap/**' \
+                'cluster*.yaml' \
+                'nodes*.yaml' \
+                '.github/workflows/kyverno.yaml' \
                 | grep -q .; then
             echo "any_changed=true" >> "${GITHUB_OUTPUT}"
           else
@@ -78,13 +83,9 @@ jobs:
             --output-file /github/workspace/rendered.yaml
             /github/workspace/kubernetes/flux/cluster
 
-      # --audit-warn downgrades audit-policy fails to warnings; --warn-exit-code 0
-      # makes warnings rc=0. So rc=1 only on real engine errors or enforce-mode
-      # failures (we have none today). Audit findings appear in the table for
-      # visibility without gating — see kubernetes/apps/kyverno/policies/.
       - name: Run kyverno apply
         run: |
-          set -o pipefail
+          set -euo pipefail
           {
             echo '### Kyverno Validate'
             echo ''
@@ -95,6 +96,22 @@ jobs:
             --audit-warn \
             --warn-exit-code 0 \
             --continue-on-fail \
+            --table \
+            --remove-color \
+            | tee -a "${GITHUB_STEP_SUMMARY}"
+          echo '```' >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Run registry allowlist gate
+        run: |
+          set -euo pipefail
+          {
+            echo ''
+            echo '### Registry Allowlist Gate'
+            echo ''
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
+          kyverno apply kubernetes/apps/kyverno/policies/app/08-require-image-registry-allowlist.yaml \
+            --resource "${GITHUB_WORKSPACE}/rendered.yaml" \
             --table \
             --remove-color \
             | tee -a "${GITHUB_STEP_SUMMARY}"

--- a/kubernetes/apps/default/harbor/app/helmrelease.yaml
+++ b/kubernetes/apps/default/harbor/app/helmrelease.yaml
@@ -73,6 +73,8 @@ spec:
         coreDatabase: harbor
         existingSecret: postgres-cluster-app
     core:
+      image:
+        repository: docker.io/goharbor/harbor-core
       resources:
         requests:
           cpu: 50m
@@ -86,6 +88,12 @@ spec:
               name: harbor-oidc-config
               key: CONFIG_OVERWRITE_JSON
     registry:
+      registry:
+        image:
+          repository: docker.io/goharbor/registry-photon
+      controller:
+        image:
+          repository: docker.io/goharbor/harbor-registryctl
       resources:
         requests:
           cpu: 50m
@@ -93,6 +101,8 @@ spec:
         limits:
           memory: 512Mi
     jobservice:
+      image:
+        repository: docker.io/goharbor/harbor-jobservice
       resources:
         requests:
           cpu: 30m
@@ -100,6 +110,8 @@ spec:
         limits:
           memory: 256Mi
     trivy:
+      image:
+        repository: docker.io/goharbor/trivy-adapter-photon
       resources:
         requests:
           cpu: 50m
@@ -107,9 +119,14 @@ spec:
         limits:
           memory: 512Mi
     portal:
+      image:
+        repository: docker.io/goharbor/harbor-portal
       resources:
         requests:
           cpu: 10m
           memory: 64Mi
         limits:
           memory: 128Mi
+    exporter:
+      image:
+        repository: docker.io/goharbor/harbor-exporter

--- a/kubernetes/apps/default/kopia-verify/app/cronjob.yaml
+++ b/kubernetes/apps/default/kopia-verify/app/cronjob.yaml
@@ -37,17 +37,17 @@ spec:
                 - /bin/sh
                 - -c
                 - |
+                  set -eu
+
                   echo "Connecting to kopia repository..."
                   kopia repository connect filesystem \
                     --path=/repository \
                     --password="$KOPIA_PASSWORD"
                   echo "Running snapshot verification (5% of files)..."
                   kopia snapshot verify --verify-files-percent=5 --file-parallelism=2
-                  VERIFY_EXIT=$?
                   echo "Running blob verification..."
                   kopia blob stats
-                  echo "Verification complete. Exit code: $VERIFY_EXIT"
-                  exit $VERIFY_EXIT
+                  echo "Verification complete."
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true

--- a/kubernetes/apps/default/kopia-verify/app/cronjob.yaml
+++ b/kubernetes/apps/default/kopia-verify/app/cronjob.yaml
@@ -24,7 +24,7 @@ spec:
             fsGroup: 988
           containers:
             - name: kopia
-              image: kopia/kopia:0.22.3
+              image: docker.io/kopia/kopia:0.22.3
               env:
                 - name: USER
                   value: kopia

--- a/kubernetes/apps/default/nas-backup/app/cronjob.yaml
+++ b/kubernetes/apps/default/nas-backup/app/cronjob.yaml
@@ -24,7 +24,7 @@ spec:
             fsGroup: 65534
           containers:
             - name: rclone
-              image: rclone/rclone:1.73.5
+              image: docker.io/rclone/rclone:1.73.5
               args:
                 - copy
                 - /source

--- a/kubernetes/apps/default/paperless-ngx/app/helmrelease.yaml
+++ b/kubernetes/apps/default/paperless-ngx/app/helmrelease.yaml
@@ -17,7 +17,7 @@ spec:
         initContainers:
           fix-run:
             image:
-              repository: docker.io/busybox
+              repository: docker.io/library/busybox
               tag: latest
             command: ["sh", "-c", "chown 1000:1000 /run"]
             securityContext:

--- a/kubernetes/apps/default/paperless-ngx/app/helmrelease.yaml
+++ b/kubernetes/apps/default/paperless-ngx/app/helmrelease.yaml
@@ -17,7 +17,7 @@ spec:
         initContainers:
           fix-run:
             image:
-              repository: busybox
+              repository: docker.io/busybox
               tag: latest
             command: ["sh", "-c", "chown 1000:1000 /run"]
             securityContext:
@@ -102,7 +102,7 @@ spec:
                 memory: 2Gi
           tika:
             image:
-              repository: apache/tika
+              repository: docker.io/apache/tika
               tag: 3.3.0.0
             securityContext:
               allowPrivilegeEscalation: false
@@ -112,7 +112,7 @@ spec:
                 memory: 512Mi
           gotenberg:
             image:
-              repository: gotenberg/gotenberg
+              repository: docker.io/gotenberg/gotenberg
               tag: "8.31.0"
             securityContext:
               allowPrivilegeEscalation: false

--- a/kubernetes/apps/default/slskd/app/helmrelease.yaml
+++ b/kubernetes/apps/default/slskd/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
         containers:
           app:
             image:
-              repository: slskd/slskd
+              repository: docker.io/slskd/slskd
               tag: 0.25.1
             env:
               DOTNET_BUNDLE_EXTRACT_BASE_DIR: /tmp/.net

--- a/kubernetes/apps/default/soularr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/soularr/app/helmrelease.yaml
@@ -24,7 +24,7 @@ spec:
         initContainers:
           wait-for-slskd:
             image:
-              repository: docker.io/busybox
+              repository: docker.io/library/busybox
               tag: 1.37.0
             command:
               - sh

--- a/kubernetes/apps/default/soularr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/soularr/app/helmrelease.yaml
@@ -24,7 +24,7 @@ spec:
         initContainers:
           wait-for-slskd:
             image:
-              repository: busybox
+              repository: docker.io/busybox
               tag: 1.37.0
             command:
               - sh

--- a/kubernetes/apps/gitlab-runner/runner/app/helmrelease.yaml
+++ b/kubernetes/apps/gitlab-runner/runner/app/helmrelease.yaml
@@ -120,7 +120,7 @@ spec:
           environment = ["FF_USE_FASTZIP=true", "DOCKER_CONFIG=/tmp/.docker"]
           [runners.kubernetes]
             namespace = "gitlab-runner"
-            image = "alpine:3.20"
+            image = "docker.io/library/alpine:3.20"
             helper_image = ""
             # The default (alpine) helper image has no /etc/passwd entry for
             # uid 1000, so glibc's getpwuid(1000) returns NULL and git's

--- a/kubernetes/apps/kyverno/policies/app/08-require-image-registry-allowlist.yaml
+++ b/kubernetes/apps/kyverno/policies/app/08-require-image-registry-allowlist.yaml
@@ -1,7 +1,7 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/kyverno/main/.schemas/v1/clusterpolicy.json
 # Tier 1 — SEC-04 registry allowlist. Ships Audit per D-07/D-10; Enforce flip in plan 04-06.
-# 9-registry list per CONTEXT D-17 / RESEARCH.md §324-356 — matches every registry
+# 12-registry list per CONTEXT D-17 / RESEARCH.md §324-356 — matches every registry
 # currently in use across kubernetes/apps/. Adding a registry requires a tracked PR
 # (process IS the gate per D-09).
 apiVersion: kyverno.io/v1
@@ -33,13 +33,14 @@ spec:
       validate:
         message: >-
           Container image must come from an allowlisted registry
-          (ghcr.io, docker.io, index.docker.io, quay.io, registry.k8s.io,
-          mirror.gcr.io, lscr.io, docker.dragonflydb.io, harbor.melotic.dev).
+          (ghcr.io, quay.io, mirror.gcr.io, docker.io, index.docker.io,
+          lscr.io, docker.dragonflydb.io, harbor.melotic.dev, registry.k8s.io,
+          registry.gitlab.com, code.forgejo.org, cr.fluentbit.io).
         pattern:
           spec:
             =(ephemeralContainers):
-              - image: "ghcr.io/* | quay.io/* | mirror.gcr.io/* | docker.io/* | index.docker.io/* | lscr.io/* | docker.dragonflydb.io/* | harbor.melotic.dev/* | registry.k8s.io/*"
+              - image: "ghcr.io/* | quay.io/* | mirror.gcr.io/* | docker.io/* | index.docker.io/* | lscr.io/* | docker.dragonflydb.io/* | harbor.melotic.dev/* | registry.k8s.io/* | registry.gitlab.com/* | code.forgejo.org/* | cr.fluentbit.io/*"
             =(initContainers):
-              - image: "ghcr.io/* | quay.io/* | mirror.gcr.io/* | docker.io/* | index.docker.io/* | lscr.io/* | docker.dragonflydb.io/* | harbor.melotic.dev/* | registry.k8s.io/*"
+              - image: "ghcr.io/* | quay.io/* | mirror.gcr.io/* | docker.io/* | index.docker.io/* | lscr.io/* | docker.dragonflydb.io/* | harbor.melotic.dev/* | registry.k8s.io/* | registry.gitlab.com/* | code.forgejo.org/* | cr.fluentbit.io/*"
             containers:
-              - image: "ghcr.io/* | quay.io/* | mirror.gcr.io/* | docker.io/* | index.docker.io/* | lscr.io/* | docker.dragonflydb.io/* | harbor.melotic.dev/* | registry.k8s.io/*"
+              - image: "ghcr.io/* | quay.io/* | mirror.gcr.io/* | docker.io/* | index.docker.io/* | lscr.io/* | docker.dragonflydb.io/* | harbor.melotic.dev/* | registry.k8s.io/* | registry.gitlab.com/* | code.forgejo.org/* | cr.fluentbit.io/*"

--- a/kubernetes/apps/kyverno/policies/tests/08-require-image-registry-allowlist/fixtures/bad-bare-pod.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/08-require-image-registry-allowlist/fixtures/bad-bare-pod.yaml
@@ -1,0 +1,11 @@
+---
+# Bad fixture — bare Docker Hub image remains denied.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-bare-pod
+  namespace: default
+spec:
+  containers:
+    - name: app
+      image: busybox:latest

--- a/kubernetes/apps/kyverno/policies/tests/08-require-image-registry-allowlist/fixtures/bad-registry-pod.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/08-require-image-registry-allowlist/fixtures/bad-registry-pod.yaml
@@ -1,0 +1,11 @@
+---
+# Bad fixture — image from non-allowlisted registry.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-registry-pod
+  namespace: default
+spec:
+  containers:
+    - name: app
+      image: evil.example.com/foo:latest

--- a/kubernetes/apps/kyverno/policies/tests/08-require-image-registry-allowlist/fixtures/good-pod.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/08-require-image-registry-allowlist/fixtures/good-pod.yaml
@@ -1,5 +1,5 @@
 ---
-# Good fixture — image from allowlisted registry (ghcr.io)
+# Good fixture — images from allowlisted registries.
 apiVersion: v1
 kind: Pod
 metadata:
@@ -7,5 +7,14 @@ metadata:
   namespace: default
 spec:
   containers:
-    - name: app
-      image: ghcr.io/kyverno/kyverno:v1.18.0
+    - name: busybox
+      image: docker.io/library/busybox:1.37.0
+      command: ["sh", "-c", "sleep 3600"]
+    - name: gitlab-runner
+      image: registry.gitlab.com/gitlab-org/gitlab-runner:alpine-v18.11.1
+      command: ["sh", "-c", "sleep 3600"]
+    - name: forgejo
+      image: code.forgejo.org/forgejo/forgejo:15.0.1-rootless
+      command: ["sh", "-c", "sleep 3600"]
+    - name: fluent-bit
+      image: cr.fluentbit.io/fluent/fluent-bit:5.0.3

--- a/kubernetes/apps/kyverno/policies/tests/08-require-image-registry-allowlist/kyverno-test.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/08-require-image-registry-allowlist/kyverno-test.yaml
@@ -7,7 +7,8 @@ policies:
   - ../../app/08-require-image-registry-allowlist.yaml
 resources:
   - fixtures/good-pod.yaml
-  - fixtures/bad-pod.yaml
+  - fixtures/bad-bare-pod.yaml
+  - fixtures/bad-registry-pod.yaml
 results:
   - policy: require-image-registry-allowlist
     rule: check-registry-allowlist
@@ -16,6 +17,11 @@ results:
     result: pass
   - policy: require-image-registry-allowlist
     rule: check-registry-allowlist
-    resources: [bad-pod]
+    resources: [bad-bare-pod]
+    kind: Pod
+    result: fail
+  - policy: require-image-registry-allowlist
+    rule: check-registry-allowlist
+    resources: [bad-registry-pod]
     kind: Pod
     result: fail

--- a/kubernetes/apps/monitoring/victoria-logs/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/victoria-logs/app/helmrelease.yaml
@@ -12,6 +12,8 @@ spec:
   values:
     fullnameOverride: victoria-logs
     server:
+      image:
+        registry: docker.io
       persistentVolume:
         enabled: true
         storageClassName: longhorn

--- a/kubernetes/apps/monitoring/victoria-metrics-k8s-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics-k8s-stack/app/helmrelease.yaml
@@ -25,8 +25,7 @@ spec:
       crds:
         cleanup:
           image:
-            registry: registry.k8s.io
-            repository: kubectl
+            repository: registry.k8s.io/kubectl
       operator:
         disable_prometheus_converter: false
         enable_converter_ownership: true

--- a/kubernetes/apps/monitoring/victoria-metrics-k8s-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics-k8s-stack/app/helmrelease.yaml
@@ -12,6 +12,21 @@ spec:
   values:
     fullnameOverride: vm-kube-stack
     victoria-metrics-operator:
+      global:
+        image:
+          registry: docker.io
+      image:
+        registry: docker.io
+      configReloader:
+        image:
+          registry: docker.io
+          repository: victoriametrics/operator
+          tag: config-reloader-v0.69.0
+      crds:
+        cleanup:
+          image:
+            registry: registry.k8s.io
+            repository: kubectl
       operator:
         disable_prometheus_converter: false
         enable_converter_ownership: true

--- a/kubernetes/apps/network/tailscale/app/helmrelease.yaml
+++ b/kubernetes/apps/network/tailscale/app/helmrelease.yaml
@@ -25,7 +25,12 @@ spec:
   values:
     operatorConfig:
       hostname: homelab-operator
+      image:
+        repository: ghcr.io/tailscale/k8s-operator
       defaultTags:
         - tag:k8s-operator
+    proxyConfig:
+      image:
+        repository: ghcr.io/tailscale/tailscale
     podAnnotations:
       secret.reloader.stakater.com/reload: operator-oauth

--- a/kubernetes/apps/network/tailscale/config/dnsconfig.yaml
+++ b/kubernetes/apps/network/tailscale/config/dnsconfig.yaml
@@ -6,5 +6,5 @@ metadata:
 spec:
   nameserver:
     image:
-      repo: tailscale/k8s-nameserver
+      repo: ghcr.io/tailscale/k8s-nameserver
       tag: unstable


### PR DESCRIPTION
Remediates Phase 04 policy 08 live image failures from chart-owned images. Includes 04-08 repo-owned image normalization and policy fixture updates plus 04-09 chart-supported image registry/repository values for Harbor, Victoria Logs, VictoriaMetrics, and Tailscale. Local Kyverno tests, policy kustomize build, diff check, and affected chart render allowlist checks pass. Live PolicyReport verification remains gated until this PR is merged and reconciled.