### PR TITLE
feat: add curated Multus VLAN networking

### DIFF
--- a/kubernetes/apps/default/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/default/home-assistant/app/helmrelease.yaml
@@ -62,8 +62,14 @@ spec:
     defaultPodOptions:
       priorityClassName: app-high
       automountServiceAccountToken: false
-      dnsPolicy: ClusterFirstWithHostNet
-      hostNetwork: true
+      annotations:
+        k8s.v1.cni.cncf.io/networks: |-
+          [{
+            "name": "iot",
+            "namespace": "kube-system",
+            "ips": ["10.30.0.20/24"],
+            "mac": "02:30:00:00:00:20"
+          }]
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/kubernetes/apps/default/home-assistant/ks.yaml
+++ b/kubernetes/apps/default/home-assistant/ks.yaml
@@ -12,6 +12,8 @@ spec:
   components:
     - ../../../../components/volsync
   dependsOn:
+    - name: multus-networks
+      namespace: kube-system
     - name: longhorn
       namespace: longhorn-system
     - name: volsync

--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ./descheduler/ks.yaml
   - ./intel-gpu-resource-driver/ks.yaml
   - ./metrics-server/ks.yaml
+  - ./multus/ks.yaml
   - ./reloader/ks.yaml
   - ./snapshot-controller/ks.yaml
   - ./spegel/ks.yaml

--- a/kubernetes/apps/kube-system/multus/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/multus/app/helmrelease.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: multus
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: multus
+  interval: 1h
+  values:
+    cni:
+      binPath: /opt/cni/bin
+      netPath: /etc/cni/net.d
+    multus:
+      resources:
+        requests:
+          cpu: 10m
+        limits:
+          memory: 512Mi

--- a/kubernetes/apps/kube-system/multus/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/multus/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/kube-system/multus/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/multus/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: multus
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.2.1
+  url: oci://ghcr.io/bjw-s-labs/helm/multus

--- a/kubernetes/apps/kube-system/multus/ks.yaml
+++ b/kubernetes/apps/kube-system/multus/ks.yaml
@@ -1,0 +1,50 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app multus
+  namespace: &namespace kube-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: multus
+      namespace: *namespace
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: network-attachment-definitions.k8s.cni.cncf.io
+  interval: 1h
+  path: ./kubernetes/apps/kube-system/multus/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: false
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: multus-networks
+  namespace: &namespace kube-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: multus-networks
+  dependsOn:
+    - name: multus
+  interval: 1h
+  path: ./kubernetes/apps/kube-system/multus/networks
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: true

--- a/kubernetes/apps/kube-system/multus/networks/iot.yaml
+++ b/kubernetes/apps/kube-system/multus/networks/iot.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/k8s.cni.cncf.io/networkattachmentdefinition_v1.json
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: iot
+  namespace: kube-system
+spec:
+  config: |-
+    {
+      "cniVersion": "0.3.1",
+      "name": "iot",
+      "plugins": [
+        {
+          "type": "macvlan",
+          "master": "ethSel0.30",
+          "mode": "bridge",
+          "ipam": {
+            "type": "static",
+            "routes": [
+              {"dst": "0.0.0.0/0", "gw": "10.30.0.1"}
+            ]
+          }
+        },
+        {
+          "type": "sbr"
+        }
+      ]
+    }

--- a/kubernetes/apps/kube-system/multus/networks/kustomization.yaml
+++ b/kubernetes/apps/kube-system/multus/networks/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./iot.yaml
+  - ./vpn.yaml

--- a/kubernetes/apps/kube-system/multus/networks/vpn.yaml
+++ b/kubernetes/apps/kube-system/multus/networks/vpn.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/k8s.cni.cncf.io/networkattachmentdefinition_v1.json
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: vpn
+  namespace: kube-system
+spec:
+  config: |-
+    {
+      "cniVersion": "0.3.1",
+      "name": "vpn",
+      "plugins": [
+        {
+          "type": "macvlan",
+          "master": "ethSel0.25",
+          "mode": "bridge",
+          "ipam": {
+            "type": "static",
+            "routes": [
+              {"dst": "0.0.0.0/0", "gw": "10.25.0.1"}
+            ]
+          }
+        },
+        {
+          "type": "sbr"
+        }
+      ]
+    }

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -92,6 +92,11 @@ nodes:
           - network: "0.0.0.0/0"
             gateway: "10.60.0.1"
         mtu: 1500
+        vlans:
+          - vlanId: 30
+            mtu: 1500
+          - vlanId: 25
+            mtu: 1500
         vip:
           ip: "10.60.8.10"
     schematic:


### PR DESCRIPTION
## Summary
- add Talos VLAN subinterfaces for `k8s-ghost` IoT/VPN networks
- install Multus and shared `kube-system` `iot`/`vpn` NetworkAttachmentDefinitions
- attach Home Assistant to the IoT Multus network with static IP/MAC after dropping host networking

## Validation
- `flux-local test --enable-helm --all-namespaces --path kubernetes/flux/cluster -v --sources flux-system` — 139 passed
- Talos live links verified on `k8s-ghost`: `ethSel0.30` and `ethSel0.25` up
- Multus canaries previously validated `iot` and `vpn` gateway reachability

## Notes
- Clean PR branch contains no `.planning/` files.
- Live Home Assistant UAT was stopped because Flux currently reconciles `main`; after merge, normal GitOps reconciliation should apply this branch's Home Assistant manifest changes.
