### PR TITLE
feat: expand Multus VLAN plumbing to all nodes

### DIFF
--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -35,6 +35,11 @@ nodes:
           - network: "0.0.0.0/0"
             gateway: "10.60.0.1"
         mtu: 1500
+        vlans:
+          - vlanId: 30
+            mtu: 1500
+          - vlanId: 25
+            mtu: 1500
         vip:
           ip: "10.60.8.10"
     schematic:
@@ -64,6 +69,11 @@ nodes:
           - network: "0.0.0.0/0"
             gateway: "10.60.0.1"
         mtu: 1500
+        vlans:
+          - vlanId: 30
+            mtu: 1500
+          - vlanId: 25
+            mtu: 1500
         vip:
           ip: "10.60.8.10"
     schematic:


### PR DESCRIPTION
## Summary
- add the Phase 5 IoT/VPN VLAN children to `k8s-niobe` and `k8s-trinity`
- keep the same talhelper-rendered `ethSel0.30` / `ethSel0.25` master names on every node
- remove the Home Assistant rescheduling hazard without pinning it to one node

## Validation
- `task talos:generate-config`
- rendered all three node configs with `ethSel0.30` / `ethSel0.25`
- applied Talos config to all three nodes without reboot
- verified live VLAN links on `10.60.85.10`, `10.60.85.11`, and `10.60.85.12`
- temporary `iot` and `vpn` Multus canaries passed on `k8s-niobe`, `k8s-trinity`, and `k8s-ghost`

## Notes
This follow-up addresses the post-UAT finding that Home Assistant is not node-pinned. With VLAN plumbing on all nodes, the shared NAD masters exist wherever the workload schedules.
