### PR TITLE
fix(plex): allocate render device with plugin

### DIFF
--- a/kubernetes/apps/default/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/default/plex/app/helmrelease.yaml
@@ -53,8 +53,10 @@ spec:
               requests:
                 cpu: 100m
                 memory: 512Mi
+                squat.ai/video: 1
               limits:
                 memory: 2Gi
+                squat.ai/video: 1
     defaultPodOptions:
       priorityClassName: app-high
       automountServiceAccountToken: false

--- a/kubernetes/apps/kube-system/generic-device-plugin/app/daemonset.yaml
+++ b/kubernetes/apps/kube-system/generic-device-plugin/app/daemonset.yaml
@@ -1,0 +1,58 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/apps/daemonset_v1.json
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: generic-device-plugin
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: generic-device-plugin
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: generic-device-plugin
+    spec:
+      priorityClassName: system-node-critical
+      tolerations:
+        - operator: Exists
+          effect: NoExecute
+        - operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: generic-device-plugin
+          image: docker.io/squat/generic-device-plugin:0.2.0@sha256:bf312a67334be792d3a3d3042c99225aec469957dc1737911970aebbf82d1545
+          args:
+            - --domain=squat.ai
+            - --device
+            - |
+              name: video
+              groups:
+                - paths:
+                    - path: /dev/dri/renderD128
+          ports:
+            - name: http
+              containerPort: 8080
+          resources:
+            requests:
+              cpu: 50m
+              memory: 10Mi
+            limits:
+              cpu: 50m
+              memory: 20Mi
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: device-plugin
+              mountPath: /var/lib/kubelet/device-plugins
+            - name: dev
+              mountPath: /dev
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+        - name: dev
+          hostPath:
+            path: /dev
+  updateStrategy:
+    type: RollingUpdate

--- a/kubernetes/apps/kube-system/generic-device-plugin/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/generic-device-plugin/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./daemonset.yaml

--- a/kubernetes/apps/kube-system/generic-device-plugin/ks.yaml
+++ b/kubernetes/apps/kube-system/generic-device-plugin/ks.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app generic-device-plugin
+  namespace: &namespace kube-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/kube-system/generic-device-plugin/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: false

--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - ./coredns/ks.yaml
   - ./csi-driver-nfs/ks.yaml
   - ./descheduler/ks.yaml
+  - ./generic-device-plugin/ks.yaml
   - ./intel-gpu-resource-driver/ks.yaml
   - ./metrics-server/ks.yaml
   - ./multus/ks.yaml


### PR DESCRIPTION
## Summary
- add generic-device-plugin to advertise `/dev/dri/renderD128` as `squat.ai/video` on kube-system nodes
- require `squat.ai/video: 1` for Plex so kubelet allocates the render device instead of only bind-mounting `/dev/dri`
- normalize the plugin image to explicit `docker.io/...` with digest pinning

## Root cause
The Plex pod could see `/dev/dri/renderD128` from the hostPath mount, but opening it failed with `Operation not permitted`. Kubernetes had not allocated the device, so the container device cgroup still denied access.

## Validation
- kustomize build kubernetes/apps/default/plex/app
- kustomize build kubernetes/apps/kube-system/generic-device-plugin/app
- kustomize build kubernetes/apps/kube-system
- flux-local test --enable-helm --all-namespaces --path kubernetes/flux/cluster -v --sources flux-system