### PR TITLE
fix(flux): deduplicate centralized lifecycle defaults

### DIFF
--- a/kubernetes/apps/cert-manager/cert-manager/app/helmrelease.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/helmrelease.yaml
@@ -12,10 +12,6 @@ spec:
   install:
     remediation:
       retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   values:
     crds:
       enabled: true

--- a/kubernetes/apps/cert-manager/cert-manager/ks.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/ks.yaml
@@ -22,9 +22,7 @@ spec:
       kind: ClusterIssuer
       failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
       current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
-  interval: 1h
   path: ./kubernetes/apps/cert-manager/cert-manager/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/cnpg-system/barman-cloud-plugin/app/helmrelease.yaml
+++ b/kubernetes/apps/cnpg-system/barman-cloud-plugin/app/helmrelease.yaml
@@ -16,7 +16,3 @@ spec:
   install:
     remediation:
       retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3

--- a/kubernetes/apps/cnpg-system/barman-cloud-plugin/ks.yaml
+++ b/kubernetes/apps/cnpg-system/barman-cloud-plugin/ks.yaml
@@ -17,9 +17,7 @@ spec:
       kind: HelmRelease
       name: barman-cloud-plugin
       namespace: cnpg-system
-  interval: 1h
   path: ./kubernetes/apps/cnpg-system/barman-cloud-plugin/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/cnpg-system/cnpg/app/helmrelease.yaml
+++ b/kubernetes/apps/cnpg-system/cnpg/app/helmrelease.yaml
@@ -12,8 +12,6 @@ spec:
         name: cloudnative-pg
         kind: HelmRepository
       version: 0.28.0
-  install:
-    crds: CreateReplace
   interval: 1h
   values:
     monitoring:

--- a/kubernetes/apps/cnpg-system/cnpg/ks.yaml
+++ b/kubernetes/apps/cnpg-system/cnpg/ks.yaml
@@ -14,9 +14,7 @@ spec:
       kind: HelmRelease
       name: cloudnative-pg
       namespace: cnpg-system
-  interval: 1h
   path: ./kubernetes/apps/cnpg-system/cnpg/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/database/dragonfly/ks.yaml
+++ b/kubernetes/apps/database/dragonfly/ks.yaml
@@ -12,9 +12,7 @@ spec:
   dependsOn:
     - name: longhorn
       namespace: longhorn-system
-  interval: 1h
   path: ./kubernetes/apps/database/dragonfly/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/database/postgres/app/helmrelease.yaml
+++ b/kubernetes/apps/database/postgres/app/helmrelease.yaml
@@ -25,10 +25,6 @@ spec:
   install:
     remediation:
       retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   postRenderers:
     - kustomize:
         patches:

--- a/kubernetes/apps/database/postgres/ks.yaml
+++ b/kubernetes/apps/database/postgres/ks.yaml
@@ -20,9 +20,7 @@ spec:
       kind: Cluster
       failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
       current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
-  interval: 1h
   path: ./kubernetes/apps/database/postgres/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
@@ -55,9 +53,7 @@ spec:
   dependsOn:
     - name: cnpg
       namespace: cnpg-system
-  interval: 1h
   path: ./image-catalogs
-  prune: true
   sourceRef:
     kind: GitRepository
     name: cnpg-artifacts

--- a/kubernetes/apps/default/atuin/ks.yaml
+++ b/kubernetes/apps/default/atuin/ks.yaml
@@ -16,9 +16,7 @@ spec:
       namespace: longhorn-system
     - name: volsync
       namespace: volsync-system
-  interval: 1h
   path: ./kubernetes/apps/default/atuin/app
-  prune: true
   postBuild:
     substitute:
       APP: atuin

--- a/kubernetes/apps/default/aurral/ks.yaml
+++ b/kubernetes/apps/default/aurral/ks.yaml
@@ -20,9 +20,7 @@ spec:
       namespace: external-secrets
     - name: lidarr
       namespace: default
-  interval: 1h
   path: ./kubernetes/apps/default/aurral/app
-  prune: true
   postBuild:
     substitute:
       APP: aurral

--- a/kubernetes/apps/default/authentik/ks.yaml
+++ b/kubernetes/apps/default/authentik/ks.yaml
@@ -12,9 +12,7 @@ spec:
   dependsOn:
     - name: longhorn
       namespace: longhorn-system
-  interval: 1h
   path: ./kubernetes/apps/default/authentik/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/default/beets/ks.yaml
+++ b/kubernetes/apps/default/beets/ks.yaml
@@ -18,9 +18,7 @@ spec:
       namespace: volsync-system
     - name: onepassword
       namespace: external-secrets
-  interval: 1h
   path: ./kubernetes/apps/default/beets/app
-  prune: true
   postBuild:
     substitute:
       APP: beets

--- a/kubernetes/apps/default/echo/app/helmrelease.yaml
+++ b/kubernetes/apps/default/echo/app/helmrelease.yaml
@@ -12,10 +12,6 @@ spec:
   install:
     remediation:
       retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   dependsOn:
     - name: cloudflare-tunnel
       namespace: network

--- a/kubernetes/apps/default/echo/ks.yaml
+++ b/kubernetes/apps/default/echo/ks.yaml
@@ -9,9 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  interval: 1h
   path: ./kubernetes/apps/default/echo/app
-  prune: true
   postBuild:
     substitute:
       AUTH_POLICY_NAME: echo-auth

--- a/kubernetes/apps/default/forejo-runner/ks.yaml
+++ b/kubernetes/apps/default/forejo-runner/ks.yaml
@@ -11,9 +11,7 @@ spec:
       app.kubernetes.io/name: *app
   dependsOn:
     - name: forejo
-  interval: 1h
   path: ./kubernetes/apps/default/forejo-runner/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/default/forejo/ks.yaml
+++ b/kubernetes/apps/default/forejo/ks.yaml
@@ -18,9 +18,7 @@ spec:
       namespace: volsync-system
     - name: postgres
       namespace: database
-  interval: 1h
   path: ./kubernetes/apps/default/forejo/app
-  prune: true
   postBuild:
     substitute:
       APP: forejo

--- a/kubernetes/apps/default/ghidra-server/app/helmrelease.yaml
+++ b/kubernetes/apps/default/ghidra-server/app/helmrelease.yaml
@@ -12,10 +12,6 @@ spec:
   install:
     remediation:
       retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   dependsOn:
     - name: authentik
       namespace: default

--- a/kubernetes/apps/default/ghidra-server/ks.yaml
+++ b/kubernetes/apps/default/ghidra-server/ks.yaml
@@ -18,9 +18,7 @@ spec:
       namespace: volsync-system
     - name: authentik
       namespace: default
-  interval: 1h
   path: ./kubernetes/apps/default/ghidra-server/app
-  prune: true
   postBuild:
     substitute:
       APP: ghidra-server

--- a/kubernetes/apps/default/harbor/app/helmrelease.yaml
+++ b/kubernetes/apps/default/harbor/app/helmrelease.yaml
@@ -24,10 +24,6 @@ spec:
   install:
     remediation:
       retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   values:
     priorityClassName: app-high
     updateStrategy:

--- a/kubernetes/apps/default/harbor/ks.yaml
+++ b/kubernetes/apps/default/harbor/ks.yaml
@@ -9,9 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  interval: 1h
   path: ./kubernetes/apps/default/harbor/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/default/home-assistant/ks.yaml
+++ b/kubernetes/apps/default/home-assistant/ks.yaml
@@ -18,9 +18,7 @@ spec:
       namespace: longhorn-system
     - name: volsync
       namespace: volsync-system
-  interval: 1h
   path: ./kubernetes/apps/default/home-assistant/app
-  prune: true
   postBuild:
     substitute:
       APP: home-assistant

--- a/kubernetes/apps/default/kopia-verify/ks.yaml
+++ b/kubernetes/apps/default/kopia-verify/ks.yaml
@@ -13,9 +13,7 @@ spec:
       namespace: external-secrets
     - name: volsync
       namespace: volsync-system
-  interval: 1h
   path: ./kubernetes/apps/default/kopia-verify/app
-  prune: true
   postBuild:
     substitute:
       APP: kopia-verify

--- a/kubernetes/apps/default/lidarr/ks.yaml
+++ b/kubernetes/apps/default/lidarr/ks.yaml
@@ -16,9 +16,7 @@ spec:
       namespace: longhorn-system
     - name: volsync
       namespace: volsync-system
-  interval: 1h
   path: ./kubernetes/apps/default/lidarr/app
-  prune: true
   postBuild:
     substitute:
       APP: lidarr

--- a/kubernetes/apps/default/multi-scrobbler/ks.yaml
+++ b/kubernetes/apps/default/multi-scrobbler/ks.yaml
@@ -18,9 +18,7 @@ spec:
       namespace: volsync-system
     - name: onepassword
       namespace: external-secrets
-  interval: 1h
   path: ./kubernetes/apps/default/multi-scrobbler/app
-  prune: true
   postBuild:
     substitute:
       APP: multi-scrobbler

--- a/kubernetes/apps/default/nas-backup/ks.yaml
+++ b/kubernetes/apps/default/nas-backup/ks.yaml
@@ -12,9 +12,7 @@ spec:
   dependsOn:
     - name: onepassword
       namespace: external-secrets
-  interval: 1h
   path: ./kubernetes/apps/default/nas-backup/app
-  prune: true
   postBuild:
     substitute:
       APP: nas-backup

--- a/kubernetes/apps/default/paperless-ngx/ks.yaml
+++ b/kubernetes/apps/default/paperless-ngx/ks.yaml
@@ -18,9 +18,7 @@ spec:
       namespace: longhorn-system
     - name: volsync
       namespace: volsync-system
-  interval: 1h
   path: ./kubernetes/apps/default/paperless-ngx/app
-  prune: true
   postBuild:
     substitute:
       APP: paperless-ngx

--- a/kubernetes/apps/default/plex/ks.yaml
+++ b/kubernetes/apps/default/plex/ks.yaml
@@ -16,9 +16,7 @@ spec:
       namespace: longhorn-system
     - name: volsync
       namespace: volsync-system
-  interval: 1h
   path: ./kubernetes/apps/default/plex/app
-  prune: true
   postBuild:
     substitute:
       APP: plex

--- a/kubernetes/apps/default/prowlarr/ks.yaml
+++ b/kubernetes/apps/default/prowlarr/ks.yaml
@@ -16,9 +16,7 @@ spec:
       namespace: longhorn-system
     - name: volsync
       namespace: volsync-system
-  interval: 1h
   path: ./kubernetes/apps/default/prowlarr/app
-  prune: true
   postBuild:
     substitute:
       APP: prowlarr

--- a/kubernetes/apps/default/radarr/ks.yaml
+++ b/kubernetes/apps/default/radarr/ks.yaml
@@ -16,9 +16,7 @@ spec:
       namespace: longhorn-system
     - name: volsync
       namespace: volsync-system
-  interval: 1h
   path: ./kubernetes/apps/default/radarr/app
-  prune: true
   postBuild:
     substitute:
       APP: radarr

--- a/kubernetes/apps/default/recyclarr/ks.yaml
+++ b/kubernetes/apps/default/recyclarr/ks.yaml
@@ -16,9 +16,7 @@ spec:
       namespace: longhorn-system
     - name: volsync
       namespace: volsync-system
-  interval: 1h
   path: ./kubernetes/apps/default/recyclarr/app
-  prune: true
   postBuild:
     substitute:
       APP: recyclarr

--- a/kubernetes/apps/default/sabnzbd/ks.yaml
+++ b/kubernetes/apps/default/sabnzbd/ks.yaml
@@ -16,9 +16,7 @@ spec:
       namespace: longhorn-system
     - name: volsync
       namespace: volsync-system
-  interval: 1h
   path: ./kubernetes/apps/default/sabnzbd/app
-  prune: true
   postBuild:
     substitute:
       APP: sabnzbd

--- a/kubernetes/apps/default/searxng/app/helmrelease.yaml
+++ b/kubernetes/apps/default/searxng/app/helmrelease.yaml
@@ -12,10 +12,6 @@ spec:
   install:
     remediation:
       retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   values:
     controllers:
       searxng:

--- a/kubernetes/apps/default/searxng/ks.yaml
+++ b/kubernetes/apps/default/searxng/ks.yaml
@@ -9,9 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  interval: 1h
   path: ./kubernetes/apps/default/searxng/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/default/seerr/ks.yaml
+++ b/kubernetes/apps/default/seerr/ks.yaml
@@ -16,9 +16,7 @@ spec:
       namespace: longhorn-system
     - name: volsync
       namespace: volsync-system
-  interval: 1h
   path: ./kubernetes/apps/default/seerr/app
-  prune: true
   postBuild:
     substitute:
       APP: seerr

--- a/kubernetes/apps/default/slskd/app/helmrelease.yaml
+++ b/kubernetes/apps/default/slskd/app/helmrelease.yaml
@@ -13,10 +13,6 @@ spec:
   install:
     remediation:
       retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   values:
     controllers:
       slskd:

--- a/kubernetes/apps/default/slskd/ks.yaml
+++ b/kubernetes/apps/default/slskd/ks.yaml
@@ -16,9 +16,7 @@ spec:
       namespace: longhorn-system
     - name: volsync
       namespace: volsync-system
-  interval: 1h
   path: ./kubernetes/apps/default/slskd/app
-  prune: true
   postBuild:
     substitute:
       APP: slskd

--- a/kubernetes/apps/default/smtp-relay/app/helmrelease.yaml
+++ b/kubernetes/apps/default/smtp-relay/app/helmrelease.yaml
@@ -12,10 +12,6 @@ spec:
   install:
     remediation:
       retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   values:
     controllers:
       smtp-relay:

--- a/kubernetes/apps/default/smtp-relay/ks.yaml
+++ b/kubernetes/apps/default/smtp-relay/ks.yaml
@@ -9,9 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  interval: 1h
   path: ./kubernetes/apps/default/smtp-relay/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/default/sonarr/ks.yaml
+++ b/kubernetes/apps/default/sonarr/ks.yaml
@@ -16,9 +16,7 @@ spec:
       namespace: longhorn-system
     - name: volsync
       namespace: volsync-system
-  interval: 1h
   path: ./kubernetes/apps/default/sonarr/app
-  prune: true
   postBuild:
     substitute:
       APP: sonarr

--- a/kubernetes/apps/default/soularr/ks.yaml
+++ b/kubernetes/apps/default/soularr/ks.yaml
@@ -16,9 +16,7 @@ spec:
       namespace: default
     - name: slskd
       namespace: default
-  interval: 1h
   path: ./kubernetes/apps/default/soularr/app
-  prune: true
   postBuild:
     substitute:
       APP: soularr

--- a/kubernetes/apps/default/tautulli/ks.yaml
+++ b/kubernetes/apps/default/tautulli/ks.yaml
@@ -16,9 +16,7 @@ spec:
       namespace: longhorn-system
     - name: volsync
       namespace: volsync-system
-  interval: 1h
   path: ./kubernetes/apps/default/tautulli/app
-  prune: true
   postBuild:
     substitute:
       APP: tautulli

--- a/kubernetes/apps/external-secrets/external-secrets/ks.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/ks.yaml
@@ -14,9 +14,7 @@ spec:
       kind: HelmRelease
       name: *app
       namespace: *namespace
-  interval: 1h
   path: ./kubernetes/apps/external-secrets/external-secrets/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/external-secrets/onepassword/app/helmrelease.yaml
+++ b/kubernetes/apps/external-secrets/onepassword/app/helmrelease.yaml
@@ -12,10 +12,6 @@ spec:
   install:
     remediation:
       retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   values:
     controllers:
       onepassword:

--- a/kubernetes/apps/external-secrets/onepassword/ks.yaml
+++ b/kubernetes/apps/external-secrets/onepassword/ks.yaml
@@ -16,9 +16,7 @@ spec:
       kind: ClusterSecretStore
       failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
       current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
-  interval: 1h
   path: ./kubernetes/apps/external-secrets/onepassword/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
@@ -13,10 +13,8 @@ spec:
     remediation:
       retries: -1
   upgrade:
-    cleanupOnFail: true
     remediation:
       strategy: rollback
-      retries: 3
   dependsOn:
     - name: flux-operator
       namespace: flux-system

--- a/kubernetes/apps/flux-system/flux-instance/ks.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/ks.yaml
@@ -12,9 +12,7 @@ spec:
   dependsOn:
     - name: flux-operator
       namespace: *namespace
-  interval: 1h
   path: ./kubernetes/apps/flux-system/flux-instance/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/flux-system/flux-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/app/helmrelease.yaml
@@ -13,10 +13,8 @@ spec:
     remediation:
       retries: -1
   upgrade:
-    cleanupOnFail: true
     remediation:
       strategy: rollback
-      retries: 3
   values:
     serviceMonitor:
       create: true

--- a/kubernetes/apps/flux-system/flux-operator/ks.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/ks.yaml
@@ -14,9 +14,7 @@ spec:
       kind: HelmRelease
       name: *app
       namespace: *namespace
-  interval: 1h
   path: ./kubernetes/apps/flux-system/flux-operator/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/gitlab-runner/runner/app/helmrelease.yaml
+++ b/kubernetes/apps/gitlab-runner/runner/app/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
   install:
     remediation:
       retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   values:
     gitlabUrl: https://gitlab.melotic.dev/
     # The chart's singular `secret:` value does NOT mount the named Secret

--- a/kubernetes/apps/gitlab-runner/runner/ks.yaml
+++ b/kubernetes/apps/gitlab-runner/runner/ks.yaml
@@ -14,9 +14,7 @@ spec:
       namespace: gitlab
     - name: harbor
       namespace: default
-  interval: 1h
   path: ./kubernetes/apps/gitlab-runner/runner/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/gitlab/gitlab/app/helmrelease.yaml
+++ b/kubernetes/apps/gitlab/gitlab/app/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
   install:
     remediation:
       retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   postRenderers:
     - kustomize:
         patches:

--- a/kubernetes/apps/gitlab/gitlab/ks.yaml
+++ b/kubernetes/apps/gitlab/gitlab/ks.yaml
@@ -18,9 +18,7 @@ spec:
       namespace: database
     - name: authentik
       namespace: default
-  interval: 1h
   path: ./kubernetes/apps/gitlab/gitlab/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -10,14 +10,8 @@ spec:
     kind: OCIRepository
     name: cilium
   install:
-    crds: CreateReplace
     remediation:
       retries: -1
-  upgrade:
-    crds: CreateReplace
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   values:
     autoDirectNodeRoutes: true
     bandwidthManager:

--- a/kubernetes/apps/kube-system/cilium/ks.yaml
+++ b/kubernetes/apps/kube-system/cilium/ks.yaml
@@ -9,9 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  interval: 1h
   path: ./kubernetes/apps/kube-system/cilium/app
-  prune: true
   postBuild:
     substituteFrom:
       - name: cluster-secrets

--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -13,10 +13,8 @@ spec:
     remediation:
       retries: -1
   upgrade:
-    cleanupOnFail: true
     remediation:
       strategy: rollback
-      retries: 3
   values:
     fullnameOverride: coredns
     image:

--- a/kubernetes/apps/kube-system/coredns/ks.yaml
+++ b/kubernetes/apps/kube-system/coredns/ks.yaml
@@ -9,9 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  interval: 1h
   path: ./kubernetes/apps/kube-system/coredns/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/kube-system/csi-driver-nfs/ks.yaml
+++ b/kubernetes/apps/kube-system/csi-driver-nfs/ks.yaml
@@ -9,9 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  interval: 1h
   path: ./kubernetes/apps/kube-system/csi-driver-nfs/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/kube-system/descheduler/ks.yaml
+++ b/kubernetes/apps/kube-system/descheduler/ks.yaml
@@ -9,9 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  interval: 1h
   path: ./kubernetes/apps/kube-system/descheduler/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/kube-system/generic-device-plugin/ks.yaml
+++ b/kubernetes/apps/kube-system/generic-device-plugin/ks.yaml
@@ -9,9 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  interval: 1h
   path: ./kubernetes/apps/kube-system/generic-device-plugin/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/kube-system/intel-gpu-resource-driver/ks.yaml
+++ b/kubernetes/apps/kube-system/intel-gpu-resource-driver/ks.yaml
@@ -9,9 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  interval: 1h
   path: ./kubernetes/apps/kube-system/intel-gpu-resource-driver/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/kube-system/metrics-server/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/metrics-server/app/helmrelease.yaml
@@ -12,10 +12,6 @@ spec:
   install:
     remediation:
       retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   values:
     args:
       - --kubelet-insecure-tls

--- a/kubernetes/apps/kube-system/metrics-server/ks.yaml
+++ b/kubernetes/apps/kube-system/metrics-server/ks.yaml
@@ -9,9 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  interval: 1h
   path: ./kubernetes/apps/kube-system/metrics-server/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/kube-system/multus/ks.yaml
+++ b/kubernetes/apps/kube-system/multus/ks.yaml
@@ -17,9 +17,7 @@ spec:
     - apiVersion: apiextensions.k8s.io/v1
       kind: CustomResourceDefinition
       name: network-attachment-definitions.k8s.cni.cncf.io
-  interval: 1h
   path: ./kubernetes/apps/kube-system/multus/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
@@ -39,9 +37,7 @@ spec:
       app.kubernetes.io/name: multus-networks
   dependsOn:
     - name: multus
-  interval: 1h
   path: ./kubernetes/apps/kube-system/multus/networks
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/kube-system/reloader/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/reloader/app/helmrelease.yaml
@@ -12,10 +12,6 @@ spec:
   install:
     remediation:
       retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   values:
     fullnameOverride: reloader
     reloader:

--- a/kubernetes/apps/kube-system/reloader/ks.yaml
+++ b/kubernetes/apps/kube-system/reloader/ks.yaml
@@ -9,9 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  interval: 1h
   path: ./kubernetes/apps/kube-system/reloader/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/kube-system/snapshot-controller/ks.yaml
+++ b/kubernetes/apps/kube-system/snapshot-controller/ks.yaml
@@ -9,9 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  interval: 1h
   path: ./kubernetes/apps/kube-system/snapshot-controller/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/kube-system/spegel/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/spegel/app/helmrelease.yaml
@@ -12,10 +12,6 @@ spec:
   install:
     remediation:
       retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   values:
     spegel:
       containerdSock: /run/containerd/containerd.sock

--- a/kubernetes/apps/kube-system/spegel/ks.yaml
+++ b/kubernetes/apps/kube-system/spegel/ks.yaml
@@ -9,9 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  interval: 1h
   path: ./kubernetes/apps/kube-system/spegel/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/kyverno/kyverno/app/helmrelease.yaml
+++ b/kubernetes/apps/kyverno/kyverno/app/helmrelease.yaml
@@ -10,14 +10,8 @@ spec:
     kind: OCIRepository
     name: kyverno
   install:
-    crds: CreateReplace
     remediation:
       retries: -1
-  upgrade:
-    crds: CreateReplace
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   values:
     admissionController:
       replicas: 1

--- a/kubernetes/apps/kyverno/kyverno/ks.yaml
+++ b/kubernetes/apps/kyverno/kyverno/ks.yaml
@@ -14,9 +14,7 @@ spec:
       kind: HelmRelease
       name: *app
       namespace: *namespace
-  interval: 1h
   path: ./kubernetes/apps/kyverno/kyverno/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/kyverno/policies/ks.yaml
+++ b/kubernetes/apps/kyverno/policies/ks.yaml
@@ -17,9 +17,7 @@ spec:
       kind: HelmRelease
       name: kyverno
       namespace: kyverno
-  interval: 1h
   path: ./kubernetes/apps/kyverno/policies/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/longhorn-system/longhorn/ks.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/ks.yaml
@@ -19,9 +19,7 @@ spec:
       kind: InstanceManager
       current: status.currentState == 'running'
       failed: status.currentState == 'error'
-  interval: 1h
   path: ./kubernetes/apps/longhorn-system/longhorn/app
-  prune: true
   postBuild:
     substitute:
       AUTH_POLICY_NAME: longhorn-auth
@@ -45,9 +43,7 @@ spec:
       app.kubernetes.io/name: *app
   dependsOn:
     - name: longhorn
-  interval: 1h
   path: ./kubernetes/apps/longhorn-system/longhorn/jobs
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/monitoring/fluent-bit/ks.yaml
+++ b/kubernetes/apps/monitoring/fluent-bit/ks.yaml
@@ -9,9 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  interval: 1h
   path: ./kubernetes/apps/monitoring/fluent-bit/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/monitoring/gatus/ks.yaml
+++ b/kubernetes/apps/monitoring/gatus/ks.yaml
@@ -9,9 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  interval: 1h
   path: ./kubernetes/apps/monitoring/gatus/app
-  prune: true
   postBuild:
     substitute:
       AUTH_POLICY_NAME: gatus-auth

--- a/kubernetes/apps/monitoring/grafana/ks.yaml
+++ b/kubernetes/apps/monitoring/grafana/ks.yaml
@@ -9,9 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  interval: 1h
   path: ./kubernetes/apps/monitoring/grafana/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/monitoring/kromgo/ks.yaml
+++ b/kubernetes/apps/monitoring/kromgo/ks.yaml
@@ -9,9 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  interval: 1h
   path: ./kubernetes/apps/monitoring/kromgo/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/monitoring/smartctl-exporter/ks.yaml
+++ b/kubernetes/apps/monitoring/smartctl-exporter/ks.yaml
@@ -9,9 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  interval: 1h
   path: ./kubernetes/apps/monitoring/smartctl-exporter/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/monitoring/unpoller/ks.yaml
+++ b/kubernetes/apps/monitoring/unpoller/ks.yaml
@@ -9,9 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  interval: 1h
   path: ./kubernetes/apps/monitoring/unpoller/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/monitoring/victoria-logs/ks.yaml
+++ b/kubernetes/apps/monitoring/victoria-logs/ks.yaml
@@ -9,9 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  interval: 1h
   path: ./kubernetes/apps/monitoring/victoria-logs/app
-  prune: true
   postBuild:
     substitute:
       AUTH_POLICY_NAME: victoria-logs-auth

--- a/kubernetes/apps/monitoring/victoria-metrics-k8s-stack/ks.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics-k8s-stack/ks.yaml
@@ -9,9 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  interval: 1h
   path: ./kubernetes/apps/monitoring/victoria-metrics-k8s-stack/app
-  prune: true
   postBuild:
     substitute:
       AUTH_POLICY_NAME: victoria-metrics-auth
@@ -35,9 +33,7 @@ spec:
       app.kubernetes.io/name: victoria-metrics-k8s-stack
   dependsOn:
     - name: victoria-metrics-k8s-stack
-  interval: 1h
   path: ./kubernetes/apps/monitoring/victoria-metrics-k8s-stack/alertmanager-auth
-  prune: true
   postBuild:
     substitute:
       AUTH_POLICY_NAME: alertmanager-auth

--- a/kubernetes/apps/network/certificates/ks.yaml
+++ b/kubernetes/apps/network/certificates/ks.yaml
@@ -9,9 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  interval: 1h
   path: ./kubernetes/apps/network/certificates/export
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
@@ -29,9 +27,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  interval: 1h
   path: ./kubernetes/apps/network/certificates/import
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/network/cloudflare-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/app/helmrelease.yaml
@@ -13,10 +13,8 @@ spec:
     remediation:
       retries: -1
   upgrade:
-    cleanupOnFail: true
     remediation:
       strategy: rollback
-      retries: 3
   values:
     fullnameOverride: cloudflare-external-dns
     provider: cloudflare

--- a/kubernetes/apps/network/cloudflare-dns/ks.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/ks.yaml
@@ -9,9 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  interval: 1h
   path: ./kubernetes/apps/network/cloudflare-dns/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
@@ -12,10 +12,6 @@ spec:
   install:
     remediation:
       retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   values:
     controllers:
       cloudflare-tunnel:

--- a/kubernetes/apps/network/cloudflare-tunnel/ks.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/ks.yaml
@@ -9,9 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  interval: 1h
   path: ./kubernetes/apps/network/cloudflare-tunnel/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/network/envoy-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/helmrelease.yaml
@@ -10,14 +10,8 @@ spec:
     kind: OCIRepository
     name: envoy-gateway
   install:
-    crds: CreateReplace
     remediation:
       retries: -1
-  upgrade:
-    crds: CreateReplace
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   values:
     global:
       imageRegistry: mirror.gcr.io

--- a/kubernetes/apps/network/envoy-gateway/ks.yaml
+++ b/kubernetes/apps/network/envoy-gateway/ks.yaml
@@ -11,9 +11,7 @@ spec:
       app.kubernetes.io/name: *app
   dependsOn:
     - name: certificates-import
-  interval: 1h
   path: ./kubernetes/apps/network/envoy-gateway/app
-  prune: true
   postBuild:
     substituteFrom:
       - name: cluster-secrets

--- a/kubernetes/apps/network/tailscale/app/helmrelease.yaml
+++ b/kubernetes/apps/network/tailscale/app/helmrelease.yaml
@@ -14,14 +14,8 @@ spec:
       version: 1.96.5
   interval: 1h
   install:
-    crds: CreateReplace
     remediation:
       retries: -1
-  upgrade:
-    crds: CreateReplace
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   values:
     operatorConfig:
       hostname: homelab-operator

--- a/kubernetes/apps/network/tailscale/ks.yaml
+++ b/kubernetes/apps/network/tailscale/ks.yaml
@@ -9,9 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  interval: 1h
   path: ./kubernetes/apps/network/tailscale/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
@@ -31,9 +29,7 @@ spec:
       app.kubernetes.io/name: tailscale
   dependsOn:
     - name: tailscale
-  interval: 1h
   path: ./kubernetes/apps/network/tailscale/config
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/network/unifi-dns/ks.yaml
+++ b/kubernetes/apps/network/unifi-dns/ks.yaml
@@ -9,9 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  interval: 1h
   path: ./kubernetes/apps/network/unifi-dns/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/system-upgrade/tuppr/ks.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/ks.yaml
@@ -9,9 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  interval: 1h
   path: ./kubernetes/apps/system-upgrade/tuppr/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
@@ -31,9 +29,7 @@ spec:
       app.kubernetes.io/name: *app
   dependsOn:
     - name: tuppr
-  interval: 1h
   path: ./kubernetes/apps/system-upgrade/tuppr/upgrades
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/volsync-system/volsync/ks.yaml
+++ b/kubernetes/apps/volsync-system/volsync/ks.yaml
@@ -19,9 +19,7 @@ spec:
       kind: HelmRelease
       name: *app
       namespace: *namespace
-  interval: 1h
   path: ./kubernetes/apps/volsync-system/volsync/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system


### PR DESCRIPTION
## Summary

Fixes the Phase 1 PLAT-03 audit finding by removing duplicated Flux lifecycle/default fields from app manifests. The centralized `cluster-apps` patch remains the source of truth for app `Kustomization` lifecycle defaults and HelmRelease install/upgrade defaults.

## Changes

- Removed duplicated `spec.interval` and `spec.prune` from app Flux `Kustomization` documents under `kubernetes/apps/**/ks.yaml`.
- Removed duplicated HelmRelease defaults from app `helmrelease.yaml` files, including per-app `upgrade.remediation.retries: 3` overrides so releases inherit centralized `retries: 2`.
- Preserved app-specific fields such as `dependsOn`, `sourceRef`, `targetNamespace`, `wait`, `postBuild`, health checks, custom timeouts, and `install.remediation.retries: -1`.
- Preserved the `cnpg-artifacts` `GitRepository` polling interval in `kubernetes/apps/database/postgres/ks.yaml`.

## Verification

- [x] `flux-local test --enable-helm --all-namespaces --path kubernetes/flux/cluster -v --sources flux-system` passed 140/140
- [x] Duplicate scan found 0 app Flux `Kustomization` documents with `spec.interval` or `spec.prune`
- [x] Duplicate scan found 0 app HelmReleases with per-app centralized upgrade defaults or `upgrade.remediation.retries`
- [x] Remaining `interval` in app `ks.yaml` files is only the Postgres `GitRepository` interval
