### PR TITLE
fix(scheduling): priority class names

### DIFF
--- a/kubernetes/apps/default/harbor/app/helmrelease.yaml
+++ b/kubernetes/apps/default/harbor/app/helmrelease.yaml
@@ -25,7 +25,6 @@ spec:
     remediation:
       retries: -1
   values:
-    priorityClassName: app-high
     updateStrategy:
       type: Recreate
     expose:
@@ -69,6 +68,7 @@ spec:
         coreDatabase: harbor
         existingSecret: postgres-cluster-app
     core:
+      priorityClassName: app-high
       image:
         repository: docker.io/goharbor/harbor-core
       resources:
@@ -84,19 +84,27 @@ spec:
               name: harbor-oidc-config
               key: CONFIG_OVERWRITE_JSON
     registry:
+      priorityClassName: app-high
       registry:
         image:
           repository: docker.io/goharbor/registry-photon
+        resources:
+          requests:
+            cpu: 50m
+            memory: 256Mi
+          limits:
+            memory: 512Mi
       controller:
         image:
           repository: docker.io/goharbor/harbor-registryctl
-      resources:
-        requests:
-          cpu: 50m
-          memory: 256Mi
-        limits:
-          memory: 512Mi
+        resources:
+          requests:
+            cpu: 50m
+            memory: 256Mi
+          limits:
+            memory: 512Mi
     jobservice:
+      priorityClassName: app-high
       image:
         repository: docker.io/goharbor/harbor-jobservice
       resources:
@@ -106,6 +114,7 @@ spec:
         limits:
           memory: 256Mi
     trivy:
+      priorityClassName: app-high
       image:
         repository: docker.io/goharbor/trivy-adapter-photon
       resources:
@@ -113,8 +122,10 @@ spec:
           cpu: 50m
           memory: 256Mi
         limits:
+          cpu: null
           memory: 512Mi
     portal:
+      priorityClassName: app-high
       image:
         repository: docker.io/goharbor/harbor-portal
       resources:
@@ -124,5 +135,12 @@ spec:
         limits:
           memory: 128Mi
     exporter:
+      priorityClassName: app-high
       image:
         repository: docker.io/goharbor/harbor-exporter
+      resources:
+        requests:
+          cpu: 10m
+          memory: 64Mi
+        limits:
+          memory: 128Mi

--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -29,6 +29,17 @@ spec:
         - "10.43.0.10"
         - "fd00:43::a"
     replicaCount: 2
+    podDisruptionBudget:
+      minAvailable: 1
+    topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: coredns
+            app.kubernetes.io/name: coredns
+            k8s-app: kube-dns
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
     servers:
       - zones:
           - zone: ts.net.


### PR DESCRIPTION
## Summary

Ships the safe Phase 2 scheduling gap fixes from the milestone audit without changing global live-VM-derived resource sizing yet.

This PR intentionally keeps the deferred VictoriaMetrics right-sizing pass out of scope. Live P95/P99 evidence showed broader request changes are needed, but that will be handled in a separate PR.

## Changes

- Moves Harbor priority from the ignored top-level `values.priorityClassName` to chart-supported per-component `priorityClassName` keys.
- Adds explicit resources for Harbor exporter and both registry containers (`registry` and `registryctl`).
- Removes Harbor Trivy's chart default CPU limit via `cpu: null` so it follows the repo's no-CPU-limits sizing pattern.
- Adds a CoreDNS `PodDisruptionBudget` and hostname `topologySpreadConstraints` for the replicated CoreDNS workload.

## Verification

- `kustomize build kubernetes/apps/default/harbor/app`
- `kustomize build kubernetes/apps/kube-system/coredns/app`
- Rendered Harbor chart and confirmed all Harbor workloads render `priorityClassName: app-high`, exporter/resources are present, registry subcontainers have resources, and Trivy renders without a CPU limit.
- Rendered CoreDNS chart and confirmed `PodDisruptionBudget/coredns` plus deployment `topologySpreadConstraints` render.
- `flux-local test --enable-helm --all-namespaces --path kubernetes/flux/cluster -v --sources flux-system` — 140 passed.

## Follow-up

A separate PR should apply or explicitly accept the live VictoriaMetrics right-sizing findings for SCHED-04/SCHED-01.
