### PR TITLE
fix(authentik): raise worker memory limit after OOMs

### DIFF
--- a/kubernetes/apps/default/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/default/authentik/app/helmrelease.yaml
@@ -108,7 +108,7 @@ spec:
           cpu: 100m
           memory: 512Mi
         limits:
-          memory: 768Mi
+          memory: 1Gi
       envFrom:
         - secretRef:
             name: authentik-secret


### PR DESCRIPTION
## Summary
- raise only Authentik worker memory limit from 768Mi to 1Gi
- keep CPU and memory requests unchanged so scheduling footprint does not increase
- addresses repeated memcg OOMs from old `authentik-worker-77956777df-kcw49` at the prior 512Mi cap

## Evidence
- Talos kernel logs mapped pod UID `dfdb2d74-7472-4d23-b522-8faecb605298` to `default/authentik-worker-77956777df-kcw49`
- repeated `Memory cgroup out of memory` kills for worker `python` processes on k8s-trinity between 2026-05-01 and 2026-05-03
- PR #992 already moved worker request to 512Mi and limit to 768Mi; this follow-up adds cap headroom only
- Home Assistant OOMs were from the old 512Mi cap and are already covered by PR #992's 768Mi limit

## Validation
- `git diff --check -- kubernetes/apps/default/authentik/app/helmrelease.yaml`
- `kustomize build kubernetes/apps/default/authentik/app`
- `flux-local build helmrelease authentik --path kubernetes/apps/default/authentik --namespace default --skip-crds --skip-secrets`
