### PR TITLE
fix(multus): preserve service account token on v5 chart

### DIFF
--- a/kubernetes/apps/kube-system/multus/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/multus/app/helmrelease.yaml
@@ -10,6 +10,8 @@ spec:
     name: multus
   interval: 1h
   values:
+    defaultPodOptions:
+      automountServiceAccountToken: true
     cni:
       binPath: /opt/cni/bin
       netPath: /etc/cni/net.d


### PR DESCRIPTION
## Summary
- restore `automountServiceAccountToken: true` for Multus after the bjw-s common v5 default changed to false
- keeps the chart at 1.3.0 while preserving the service-account token Multus uses to write its host kubeconfig

## Validation
- `kustomize build kubernetes/apps/kube-system/multus/app`
- `helm template multus oci://ghcr.io/bjw-s-labs/helm/multus --version 1.3.0 ...` renders `.spec.template.spec.automountServiceAccountToken: true`
- `flux-local test --enable-helm --all-namespaces --path kubernetes/flux/cluster -v --sources flux-system`