### PR TITLE
fix(unpoller): revert to v2.39.0 — v3.0.0 panics on Prometheus descriptor conflict

### DIFF
--- a/kubernetes/apps/monitoring/unpoller/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/unpoller/app/helmrelease.yaml
@@ -16,7 +16,7 @@ spec:
           app:
             image:
               repository: ghcr.io/unpoller/unpoller
-              tag: v3.0.0@sha256:1c9caf56720b59343113fe148fb2f4c84e5a74e4dad10cc504b2fff82f5ef794
+              tag: v2.39.0@sha256:1cf63ad43121acc6995da1bd636063de9023b4bfc16599a4297951a6fb6b7fd2
             env:
               TZ: America/Chicago
               UP_UNIFI_DEFAULT_ROLE: home-ops


### PR DESCRIPTION
Renovate auto-merged unpoller v3.0.0 (PR #1018), but v3.0.0 has an upstream Prometheus collector bug: `panic: descriptors reported by collector have inconsistent label names or help strings for the same fully-qualified name, offender is Desc{fqName: "unpoller_device_uptime_seconds"}`. Pod is in CrashLoopBackOff. This reverts to v2.39.0 which was stable.