### PR TITLE
fix(monitoring): pin images and prune VM cardinality

### DIFF
--- a/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
@@ -19,6 +19,8 @@ spec:
   values:
     dashboard:
       enabled: true
+    image:
+      tag: v5.22.2@sha256:d45fc24e8f43d83286d81625ee8d919d0fc88255a6500b63f68d7966a4f9e9af
     serviceMonitor:
       enabled: true
     resources:

--- a/kubernetes/apps/monitoring/grafana/instance/grafana.yaml
+++ b/kubernetes/apps/monitoring/grafana/instance/grafana.yaml
@@ -49,6 +49,7 @@ spec:
         spec:
           containers:
             - name: grafana
+              image: docker.io/grafana/grafana:12.4.1@sha256:e932bd6ed0e026595b08483cd0141e5103e1ab7ff8604839ff899b8dc54cabcb
               env:
                 - name: GF_AUTH_GENERIC_OAUTH_CLIENT_ID
                   valueFrom:

--- a/kubernetes/apps/monitoring/silence-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/silence-operator/app/helmrelease.yaml
@@ -18,5 +18,7 @@ spec:
       retries: 3
   values:
     alertmanagerAddress: http://vmalertmanager-vm-kube-stack.monitoring.svc.cluster.local:9093
+    image:
+      tag: 0.20.1@sha256:99f087838f39830f587ab7897708ad9155ccd71a5d71e76e81b9217e6eaa386f
     networkPolicy:
       enabled: false

--- a/kubernetes/apps/monitoring/victoria-metrics-k8s-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics-k8s-stack/app/helmrelease.yaml
@@ -234,9 +234,6 @@ spec:
                 - action: drop
                   regex: workqueue_work_duration_seconds_bucket
                   sourceLabels: [__name__]
-                - action: drop
-                  regex: scheduler_plugin_execution_duration_seconds_bucket
-                  sourceLabels: [__name__]
           jobLabel: component
           namespaceSelector:
             matchNames:
@@ -265,27 +262,6 @@ spec:
                   sourceLabels:
                     - __name__
                     - le
-                - action: drop
-                  regex: apiserver_request_body_size_bytes_bucket
-                  sourceLabels: [__name__]
-                - action: drop
-                  regex: apiserver_watch_list_duration_seconds_bucket
-                  sourceLabels: [__name__]
-                - action: drop
-                  regex: apiserver_watch_cache_read_wait_seconds_bucket
-                  sourceLabels: [__name__]
-                - action: drop
-                  regex: apiserver_response_sizes_bucket
-                  sourceLabels: [__name__]
-                - action: drop
-                  regex: apiserver_watch_events_sizes_bucket
-                  sourceLabels: [__name__]
-                - action: drop
-                  regex: workqueue_work_duration_seconds_bucket
-                  sourceLabels: [__name__]
-                - action: drop
-                  regex: scheduler_plugin_execution_duration_seconds_bucket
-                  sourceLabels: [__name__]
 
     kubeScheduler:
       vmScrape:
@@ -299,6 +275,13 @@ spec:
               tlsConfig:
                 caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
                 insecureSkipVerify: true
+              metricRelabelConfigs:
+                - action: drop
+                  regex: workqueue_work_duration_seconds_bucket
+                  sourceLabels: [__name__]
+                - action: drop
+                  regex: scheduler_plugin_execution_duration_seconds_bucket
+                  sourceLabels: [__name__]
 
     kubeControllerManager:
       vmScrape:
@@ -312,6 +295,10 @@ spec:
               tlsConfig:
                 caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
                 insecureSkipVerify: true
+              metricRelabelConfigs:
+                - action: drop
+                  regex: workqueue_work_duration_seconds_bucket
+                  sourceLabels: [__name__]
 
     prometheus-node-exporter:
       fullnameOverride: node-exporter

--- a/kubernetes/apps/monitoring/victoria-metrics-k8s-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics-k8s-stack/app/helmrelease.yaml
@@ -216,6 +216,27 @@ spec:
                   sourceLabels:
                     - __name__
                     - le
+                - action: drop
+                  regex: apiserver_request_body_size_bytes_bucket
+                  sourceLabels: [__name__]
+                - action: drop
+                  regex: apiserver_watch_list_duration_seconds_bucket
+                  sourceLabels: [__name__]
+                - action: drop
+                  regex: apiserver_watch_cache_read_wait_seconds_bucket
+                  sourceLabels: [__name__]
+                - action: drop
+                  regex: apiserver_response_sizes_bucket
+                  sourceLabels: [__name__]
+                - action: drop
+                  regex: apiserver_watch_events_sizes_bucket
+                  sourceLabels: [__name__]
+                - action: drop
+                  regex: workqueue_work_duration_seconds_bucket
+                  sourceLabels: [__name__]
+                - action: drop
+                  regex: scheduler_plugin_execution_duration_seconds_bucket
+                  sourceLabels: [__name__]
           jobLabel: component
           namespaceSelector:
             matchNames:
@@ -244,6 +265,27 @@ spec:
                   sourceLabels:
                     - __name__
                     - le
+                - action: drop
+                  regex: apiserver_request_body_size_bytes_bucket
+                  sourceLabels: [__name__]
+                - action: drop
+                  regex: apiserver_watch_list_duration_seconds_bucket
+                  sourceLabels: [__name__]
+                - action: drop
+                  regex: apiserver_watch_cache_read_wait_seconds_bucket
+                  sourceLabels: [__name__]
+                - action: drop
+                  regex: apiserver_response_sizes_bucket
+                  sourceLabels: [__name__]
+                - action: drop
+                  regex: apiserver_watch_events_sizes_bucket
+                  sourceLabels: [__name__]
+                - action: drop
+                  regex: workqueue_work_duration_seconds_bucket
+                  sourceLabels: [__name__]
+                - action: drop
+                  regex: scheduler_plugin_execution_duration_seconds_bucket
+                  sourceLabels: [__name__]
 
     kubeScheduler:
       vmScrape:


### PR DESCRIPTION
## Summary

Follow-up to the Grafana Operator migration. This pins the new Grafana-related workloads by image digest and applies conservative VictoriaMetrics scrape-time cardinality pruning.

## Changes

- Pin Grafana Operator, Grafana, and silence-operator images with `tag@sha256` references so Kyverno digest-pin policy passes for the new Phase 8 workloads.
- Add targeted `metricRelabelConfigs` for high-cardinality metrics on the scrape jobs that actually emit them:
  - kube-api-server: selected apiserver bucket metrics and `workqueue_work_duration_seconds_bucket`
  - kube-scheduler: `workqueue_work_duration_seconds_bucket` and `scheduler_plugin_execution_duration_seconds_bucket`
  - kube-controller-manager: `workqueue_work_duration_seconds_bucket`
- Keep protected dashboard/rule metrics collected: `apiserver_request_total`, `container_network_*`, `apiserver_request_duration_seconds_bucket`, `apiserver_request_sli_duration_seconds_bucket`, and `workqueue_queue_duration_seconds_bucket`.

## Dashboard and rule safety

- Fetched and searched 26 external GrafanaDashboard JSON files; none referenced the dropped metrics.
- Rendered Cilium chart dashboards; no dropped metric references.
- Rendered vm-k8s-stack chart and confirmed dropped metric hits are only the new relabel regexes.
- Confirmed protected metrics are still not dropped because they are used by dashboards or bundled rules.

## Verification

- [x] `flux-local test --path ./kubernetes --skip-invalid-kustomization-paths`
- [x] Rendered vm-k8s-stack chart and checked VMServiceScrape relabel placement
- [x] Rendered Grafana Operator and silence-operator charts to confirm digest-pinned image refs
- [x] GPT-5.5 code review: no findings after relabel placement fix
- [x] GPT-5.5 dashboard-focused review: no significant issues
