### PR TITLE
fix(grafana): import dashboards into general folder

### DIFF
--- a/kubernetes/apps/cert-manager/cert-manager/app/grafanadashboard.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/grafanadashboard.yaml
@@ -6,6 +6,7 @@ metadata:
   name: cert-manager
 spec:
   allowCrossNamespaceImport: true
+  folder: General
   instanceSelector:
     matchLabels:
       dashboards: grafana

--- a/kubernetes/apps/cnpg-system/cnpg/app/grafanadashboard.yaml
+++ b/kubernetes/apps/cnpg-system/cnpg/app/grafanadashboard.yaml
@@ -6,6 +6,7 @@ metadata:
   name: cloudnative-pg
 spec:
   allowCrossNamespaceImport: true
+  folder: General
   instanceSelector:
     matchLabels:
       dashboards: grafana

--- a/kubernetes/apps/external-secrets/external-secrets/app/grafanadashboard.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/app/grafanadashboard.yaml
@@ -6,6 +6,7 @@ metadata:
   name: external-secrets
 spec:
   allowCrossNamespaceImport: true
+  folder: General
   instanceSelector:
     matchLabels:
       dashboards: grafana

--- a/kubernetes/apps/flux-system/flux-instance/app/grafanadashboard.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/grafanadashboard.yaml
@@ -6,6 +6,7 @@ metadata:
   name: flux-k8s-api-performance
 spec:
   allowCrossNamespaceImport: true
+  folder: General
   instanceSelector:
     matchLabels:
       dashboards: grafana
@@ -21,6 +22,7 @@ metadata:
   name: flux-performance
 spec:
   allowCrossNamespaceImport: true
+  folder: General
   instanceSelector:
     matchLabels:
       dashboards: grafana
@@ -36,6 +38,7 @@ metadata:
   name: flux-cluster
 spec:
   allowCrossNamespaceImport: true
+  folder: General
   instanceSelector:
     matchLabels:
       dashboards: grafana
@@ -51,6 +54,7 @@ metadata:
   name: flux-control-plane
 spec:
   allowCrossNamespaceImport: true
+  folder: General
   instanceSelector:
     matchLabels:
       dashboards: grafana

--- a/kubernetes/apps/kube-system/cilium/dashboards/grafanadashboard.yaml
+++ b/kubernetes/apps/kube-system/cilium/dashboards/grafanadashboard.yaml
@@ -6,6 +6,7 @@ metadata:
   name: cilium
 spec:
   allowCrossNamespaceImport: true
+  folder: General
   instanceSelector:
     matchLabels:
       dashboards: grafana
@@ -23,6 +24,7 @@ metadata:
   name: cilium-operator
 spec:
   allowCrossNamespaceImport: true
+  folder: General
   instanceSelector:
     matchLabels:
       dashboards: grafana

--- a/kubernetes/apps/longhorn-system/longhorn/app/grafanadashboard.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/grafanadashboard.yaml
@@ -6,6 +6,7 @@ metadata:
   name: longhorn
 spec:
   allowCrossNamespaceImport: true
+  folder: General
   instanceSelector:
     matchLabels:
       dashboards: grafana

--- a/kubernetes/apps/monitoring/fluent-bit/app/grafanadashboard.yaml
+++ b/kubernetes/apps/monitoring/fluent-bit/app/grafanadashboard.yaml
@@ -6,6 +6,7 @@ metadata:
   name: fluent-bit
 spec:
   allowCrossNamespaceImport: true
+  folder: General
   instanceSelector:
     matchLabels:
       dashboards: grafana

--- a/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/external-dns.yaml
+++ b/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/external-dns.yaml
@@ -6,6 +6,7 @@ metadata:
   name: external-dns
 spec:
   allowCrossNamespaceImport: true
+  folder: General
   instanceSelector:
     matchLabels:
       dashboards: grafana

--- a/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/kubernetes-api-server.yaml
+++ b/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/kubernetes-api-server.yaml
@@ -6,6 +6,7 @@ metadata:
   name: kubernetes-api-server
 spec:
   allowCrossNamespaceImport: true
+  folder: General
   instanceSelector:
     matchLabels:
       dashboards: grafana

--- a/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/kubernetes-coredns.yaml
+++ b/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/kubernetes-coredns.yaml
@@ -6,6 +6,7 @@ metadata:
   name: kubernetes-coredns
 spec:
   allowCrossNamespaceImport: true
+  folder: General
   instanceSelector:
     matchLabels:
       dashboards: grafana

--- a/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/kubernetes-global.yaml
+++ b/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/kubernetes-global.yaml
@@ -6,6 +6,7 @@ metadata:
   name: kubernetes-global
 spec:
   allowCrossNamespaceImport: true
+  folder: General
   instanceSelector:
     matchLabels:
       dashboards: grafana

--- a/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/kubernetes-namespaces.yaml
+++ b/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/kubernetes-namespaces.yaml
@@ -6,6 +6,7 @@ metadata:
   name: kubernetes-namespaces
 spec:
   allowCrossNamespaceImport: true
+  folder: General
   instanceSelector:
     matchLabels:
       dashboards: grafana

--- a/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/kubernetes-nodes.yaml
+++ b/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/kubernetes-nodes.yaml
@@ -6,6 +6,7 @@ metadata:
   name: kubernetes-nodes
 spec:
   allowCrossNamespaceImport: true
+  folder: General
   instanceSelector:
     matchLabels:
       dashboards: grafana

--- a/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/kubernetes-pods.yaml
+++ b/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/kubernetes-pods.yaml
@@ -6,6 +6,7 @@ metadata:
   name: kubernetes-pods
 spec:
   allowCrossNamespaceImport: true
+  folder: General
   instanceSelector:
     matchLabels:
       dashboards: grafana

--- a/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/kubernetes-volumes.yaml
+++ b/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/kubernetes-volumes.yaml
@@ -6,6 +6,7 @@ metadata:
   name: kubernetes-volumes
 spec:
   allowCrossNamespaceImport: true
+  folder: General
   instanceSelector:
     matchLabels:
       dashboards: grafana

--- a/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/node-exporter-full.yaml
+++ b/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/node-exporter-full.yaml
@@ -6,6 +6,7 @@ metadata:
   name: node-exporter-full
 spec:
   allowCrossNamespaceImport: true
+  folder: General
   instanceSelector:
     matchLabels:
       dashboards: grafana

--- a/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/vm-stack.yaml
+++ b/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/vm-stack.yaml
@@ -6,6 +6,7 @@ metadata:
   name: vm-stack
 spec:
   allowCrossNamespaceImport: true
+  folder: General
   instanceSelector:
     matchLabels:
       dashboards: grafana

--- a/kubernetes/apps/monitoring/smartctl-exporter/app/grafanadashboard.yaml
+++ b/kubernetes/apps/monitoring/smartctl-exporter/app/grafanadashboard.yaml
@@ -6,6 +6,7 @@ metadata:
   name: smartctl-exporter
 spec:
   allowCrossNamespaceImport: true
+  folder: General
   instanceSelector:
     matchLabels:
       dashboards: grafana

--- a/kubernetes/apps/monitoring/unpoller/app/grafanadashboard-insights.yaml
+++ b/kubernetes/apps/monitoring/unpoller/app/grafanadashboard-insights.yaml
@@ -6,6 +6,7 @@ metadata:
   name: unifi-insights
 spec:
   allowCrossNamespaceImport: true
+  folder: General
   instanceSelector:
     matchLabels:
       dashboards: grafana

--- a/kubernetes/apps/monitoring/unpoller/app/grafanadashboard-pdu.yaml
+++ b/kubernetes/apps/monitoring/unpoller/app/grafanadashboard-pdu.yaml
@@ -6,6 +6,7 @@ metadata:
   name: unifi-pdu
 spec:
   allowCrossNamespaceImport: true
+  folder: General
   instanceSelector:
     matchLabels:
       dashboards: grafana

--- a/kubernetes/apps/monitoring/unpoller/app/grafanadashboard-sites.yaml
+++ b/kubernetes/apps/monitoring/unpoller/app/grafanadashboard-sites.yaml
@@ -6,6 +6,7 @@ metadata:
   name: unifi-network-sites
 spec:
   allowCrossNamespaceImport: true
+  folder: General
   instanceSelector:
     matchLabels:
       dashboards: grafana

--- a/kubernetes/apps/monitoring/unpoller/app/grafanadashboard-uap.yaml
+++ b/kubernetes/apps/monitoring/unpoller/app/grafanadashboard-uap.yaml
@@ -6,6 +6,7 @@ metadata:
   name: unifi-uap
 spec:
   allowCrossNamespaceImport: true
+  folder: General
   instanceSelector:
     matchLabels:
       dashboards: grafana

--- a/kubernetes/apps/monitoring/unpoller/app/grafanadashboard-usw.yaml
+++ b/kubernetes/apps/monitoring/unpoller/app/grafanadashboard-usw.yaml
@@ -6,6 +6,7 @@ metadata:
   name: unifi-usw
 spec:
   allowCrossNamespaceImport: true
+  folder: General
   instanceSelector:
     matchLabels:
       dashboards: grafana

--- a/kubernetes/apps/monitoring/victoria-logs/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/victoria-logs/app/helmrelease.yaml
@@ -50,3 +50,4 @@ spec:
             matchLabels:
               dashboards: grafana
           allowCrossNamespaceImport: true
+          folder: General

--- a/kubernetes/apps/monitoring/victoria-metrics-k8s-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics-k8s-stack/app/helmrelease.yaml
@@ -43,6 +43,7 @@ spec:
             matchLabels:
               dashboards: grafana
           allowCrossNamespaceImport: true
+          folder: General
 
     defaultDatasources:
       grafanaOperator:

--- a/kubernetes/apps/network/cloudflare-tunnel/app/grafanadashboard.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/grafanadashboard.yaml
@@ -6,6 +6,7 @@ metadata:
   name: cloudflare-tunnels
 spec:
   allowCrossNamespaceImport: true
+  folder: General
   instanceSelector:
     matchLabels:
       dashboards: grafana

--- a/kubernetes/apps/network/envoy-gateway/app/grafanadashboard.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/grafanadashboard.yaml
@@ -6,6 +6,7 @@ metadata:
   name: envoy-overview
 spec:
   allowCrossNamespaceImport: true
+  folder: General
   instanceSelector:
     matchLabels:
       dashboards: grafana
@@ -21,6 +22,7 @@ metadata:
   name: envoy-upstream
 spec:
   allowCrossNamespaceImport: true
+  folder: General
   instanceSelector:
     matchLabels:
       dashboards: grafana
@@ -36,6 +38,7 @@ metadata:
   name: envoy-downstream
 spec:
   allowCrossNamespaceImport: true
+  folder: General
   instanceSelector:
     matchLabels:
       dashboards: grafana


### PR DESCRIPTION
## Summary
- set repo-managed GrafanaDashboard resources to import into Grafana's General folder
- pass the same folder setting through VictoriaMetrics and VictoriaLogs Helm dashboard specs

## Validation
- kustomize build for affected dashboard app paths
- server dry-run for rendered GrafanaDashboard CRs
- server dry-run for VictoriaMetrics/VictoriaLogs HelmReleases
- flux-local test --path ./kubernetes --skip-invalid-kustomization-paths