### PR TITLE
fix(database): enforce CNPG replica spread

### DIFF
--- a/kubernetes/apps/cnpg-system/cnpg/app/storageclass.yaml
+++ b/kubernetes/apps/cnpg-system/cnpg/app/storageclass.yaml
@@ -13,3 +13,18 @@ parameters:
   dataLocality: "strict-local"
   staleReplicaTimeout: "2880"
   replicaAutoBalance: "ignored"
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.34.1/storageclass.json
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn-cnpg-strict-local-wffc
+allowVolumeExpansion: true
+provisioner: driver.longhorn.io
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  numberOfReplicas: "1"
+  dataLocality: "strict-local"
+  staleReplicaTimeout: "2880"
+  replicaAutoBalance: "ignored"

--- a/kubernetes/apps/database/postgres/app/helmrelease.yaml
+++ b/kubernetes/apps/database/postgres/app/helmrelease.yaml
@@ -52,6 +52,8 @@ spec:
     cluster:
       priorityClassName: cluster-critical
       affinity:
+        enablePodAntiAffinity: true
+        podAntiAffinityType: required
         topologyKey: kubernetes.io/hostname
       imageCatalogRef:
         kind: ClusterImageCatalog
@@ -76,7 +78,7 @@ spec:
             name: postgres-cluster-app
       storage:
         size: 16Gi
-        storageClass: longhorn-cnpg-strict-local
+        storageClass: longhorn-cnpg-strict-local-wffc
     recovery:
       method: pg_basebackup
       pgBaseBackup:


### PR DESCRIPTION
## Summary
- add a WaitForFirstConsumer strict-local Longhorn StorageClass for CNPG replacement PVCs
- require hostname anti-affinity for CNPG instances
- move future Postgres cluster PVCs to the WFFC strict-local class

## Validation
- kustomize build kubernetes/apps/cnpg-system/cnpg/app
- kubeconform -strict -ignore-missing-schemas /tmp/cnpg-system-render.yaml
- kustomize build kubernetes/apps/database/postgres/app
- kubeconform -strict -ignore-missing-schemas /tmp/postgres-app-render.yaml
- helm template postgres cluster --repo https://cloudnative-pg.github.io/charts --version 0.6.0 -n database -f /tmp/postgres-values.yaml

## Notes
- live replica rebuild was not performed by this PR
- intended to prevent future strict-local replacement PVCs from binding before scheduling