### PR TITLE
fix(storage): enable Longhorn strict topology for CNPG

### DIFF
--- a/kubernetes/apps/cnpg-system/cnpg/app/storageclass.yaml
+++ b/kubernetes/apps/cnpg-system/cnpg/app/storageclass.yaml
@@ -11,6 +11,7 @@ volumeBindingMode: Immediate
 parameters:
   numberOfReplicas: "1"
   dataLocality: "strict-local"
+  strictTopology: "true"
   staleReplicaTimeout: "2880"
   replicaAutoBalance: "ignored"
 ---

--- a/kubernetes/apps/cnpg-system/cnpg/app/storageclass.yaml
+++ b/kubernetes/apps/cnpg-system/cnpg/app/storageclass.yaml
@@ -11,7 +11,6 @@ volumeBindingMode: Immediate
 parameters:
   numberOfReplicas: "1"
   dataLocality: "strict-local"
-  strictTopology: "true"
   staleReplicaTimeout: "2880"
   replicaAutoBalance: "ignored"
 ---
@@ -27,5 +26,6 @@ volumeBindingMode: WaitForFirstConsumer
 parameters:
   numberOfReplicas: "1"
   dataLocality: "strict-local"
+  strictTopology: "true"
   staleReplicaTimeout: "2880"
   replicaAutoBalance: "ignored"

--- a/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
@@ -33,6 +33,7 @@ spec:
       autoCleanupSnapshotAfterOnDemandBackupCompleted: "true"
       autoCleanupSystemGeneratedSnapshot: "true"
       concurrentReplicaRebuildPerNodeLimit: "2"
+      csiAllowedTopologyKeys: kubernetes.io/hostname
       defaultDataEngine: v1
       defaultDataLocality: best-effort
       defaultDataPath: /var/mnt/longhorn


### PR DESCRIPTION
## Summary
- configure Longhorn CSI topology keys for hostname-aware provisioning
- add `strictTopology: "true"` to the existing `longhorn-cnpg-strict-local-wffc` StorageClass
- keep Postgres pointed at `longhorn-cnpg-strict-local-wffc`; no extra CNPG StorageClass is introduced

## Validation
- kustomize build kubernetes/apps/longhorn-system/longhorn/app
- kubeconform -strict -ignore-missing-schemas /tmp/longhorn-render.yaml
- kustomize build kubernetes/apps/cnpg-system/cnpg/app
- kubeconform -strict -ignore-missing-schemas /tmp/cnpg-render.yaml
- kustomize build kubernetes/apps/database/postgres/app
- kubeconform -strict -ignore-missing-schemas /tmp/postgres-render.yaml

## Notes
- `StorageClass.parameters` are immutable live; live recovery should delete/recreate the unused WFFC StorageClass after this merges/applies
- follow-up live recovery remains gated: suspend postgres HelmRelease, remove only the stale CNPG join Job/PVC, then resume Helm after CNPG is healthy
- does not delete or modify existing healthy Postgres PVCs/PVs