### PR TITLE
fix(cnpg): use best-effort Longhorn WFFC storage

### DIFF
--- a/kubernetes/apps/cnpg-system/cnpg/app/storageclass.yaml
+++ b/kubernetes/apps/cnpg-system/cnpg/app/storageclass.yaml
@@ -29,3 +29,19 @@ parameters:
   strictTopology: "true"
   staleReplicaTimeout: "2880"
   replicaAutoBalance: "ignored"
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.34.1/storageclass.json
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn-cnpg-wffc-1replica
+allowVolumeExpansion: true
+provisioner: driver.longhorn.io
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  numberOfReplicas: "1"
+  dataLocality: "best-effort"
+  strictTopology: "true"
+  staleReplicaTimeout: "2880"
+  replicaAutoBalance: "ignored"

--- a/kubernetes/apps/database/postgres/app/helmrelease.yaml
+++ b/kubernetes/apps/database/postgres/app/helmrelease.yaml
@@ -78,7 +78,7 @@ spec:
             name: postgres-cluster-app
       storage:
         size: 16Gi
-        storageClass: longhorn-cnpg-strict-local-wffc
+        storageClass: longhorn-cnpg-wffc-1replica
     recovery:
       method: pg_basebackup
       pgBaseBackup:


### PR DESCRIPTION
## Summary
- add `longhorn-cnpg-wffc-1replica` as a WFFC, one-replica Longhorn StorageClass using `dataLocality: best-effort`
- point the Postgres CNPG cluster at the new class for future replacement PVCs

## Validation
- `kustomize build kubernetes/apps/cnpg-system/cnpg/app`
- `kustomize build kubernetes/apps/database/postgres/app`
- `kustomize build kubernetes/apps/cnpg-system`
- `kustomize build kubernetes/apps/database`
- `kubeconform -strict -ignore-missing-schemas -skip Secret -summary /tmp/cnpg-system-render.yaml /tmp/database-render.yaml`

## Recovery note
After merge/reconcile, verify the live CNPG Cluster spec uses `longhorn-cnpg-wffc-1replica` before destroying the stuck replacement instance.