### PR TITLE
fix(cnpg): remove obsolete Longhorn storage classes

### DIFF
--- a/kubernetes/apps/cnpg-system/cnpg/app/storageclass.yaml
+++ b/kubernetes/apps/cnpg-system/cnpg/app/storageclass.yaml
@@ -3,37 +3,6 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: longhorn-cnpg-strict-local
-allowVolumeExpansion: true
-provisioner: driver.longhorn.io
-reclaimPolicy: Delete
-volumeBindingMode: Immediate
-parameters:
-  numberOfReplicas: "1"
-  dataLocality: "strict-local"
-  staleReplicaTimeout: "2880"
-  replicaAutoBalance: "ignored"
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.34.1/storageclass.json
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: longhorn-cnpg-strict-local-wffc
-allowVolumeExpansion: true
-provisioner: driver.longhorn.io
-reclaimPolicy: Delete
-volumeBindingMode: WaitForFirstConsumer
-parameters:
-  numberOfReplicas: "1"
-  dataLocality: "strict-local"
-  strictTopology: "true"
-  staleReplicaTimeout: "2880"
-  replicaAutoBalance: "ignored"
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.34.1/storageclass.json
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
   name: longhorn-cnpg-wffc-1replica
 allowVolumeExpansion: true
 provisioner: driver.longhorn.io


### PR DESCRIPTION
## Summary
- remove obsolete `longhorn-cnpg-strict-local` and `longhorn-cnpg-strict-local-wffc` StorageClasses from GitOps
- keep only `longhorn-cnpg-wffc-1replica` for CNPG replacement PVCs

## Live prerequisite checked
- current Postgres PVCs are all using `longhorn-cnpg-wffc-1replica`

## Validation
- `kustomize build kubernetes/apps/cnpg-system/cnpg/app`
- `kustomize build kubernetes/apps/cnpg-system`
- `kubeconform -strict -ignore-missing-schemas -skip Secret -summary /tmp/cnpg-system-render.yaml`