### PR TITLE
ci(renovate): harden branch validation

### DIFF
--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -5,6 +5,8 @@ name: "Flux Local"
 on:
   pull_request:
     branches: ["main"]
+  push:
+    branches: ["renovate/**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
@@ -19,12 +21,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
       - name: Get Changed Files
         id: changed-files
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
-          files: kubernetes/**
+          files: |
+            kubernetes/**
+            .github/workflows/flux-local.yaml
 
   test:
     name: Flux Local Test
@@ -40,6 +46,35 @@ jobs:
         with:
           args: test --enable-helm --all-namespaces --path /github/workspace/kubernetes/flux/cluster -v --sources flux-system
 
+  kubeconform:
+    name: Flux Local Kubeconform
+    needs: pre-job
+    runs-on: ubuntu-latest
+    if: ${{ needs.pre-job.outputs.any_changed == 'true' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Render manifests with flux-local
+        uses: docker://ghcr.io/allenporter/flux-local:v8.2.0
+        with:
+          args: >-
+            build all
+            --enable-helm
+            --skip-invalid-kustomization-paths
+            --output-file /github/workspace/rendered.yaml
+            /github/workspace/kubernetes/flux/cluster
+
+      - name: Run kubeconform
+        uses: docker://ghcr.io/yannh/kubeconform:v0.7.0
+        with:
+          entrypoint: /kubeconform
+          args: >-
+            -strict
+            -summary
+            -ignore-missing-schemas
+            /github/workspace/rendered.yaml
+
   diff:
     name: Flux Local Diff
     needs: pre-job
@@ -52,7 +87,7 @@ jobs:
         resources: ["helmrelease", "kustomization"]
       max-parallel: 4
       fail-fast: false
-    if: ${{ needs.pre-job.outputs.any_changed == 'true' }}
+    if: ${{ github.event_name == 'pull_request' && needs.pre-job.outputs.any_changed == 'true' }}
     steps:
       - name: Checkout Pull Request Branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -109,14 +144,14 @@ jobs:
 
   flux-local-status:
     name: Flux Local Success
-    needs: ["test", "diff"]
+    needs: ["pre-job", "test", "kubeconform", "diff"]
     runs-on: ubuntu-latest
     if: ${{ always() }}
     steps:
-      - name: Any jobs failed?
-        if: ${{ contains(needs.*.result, 'failure') }}
+      - name: Required jobs passed?
+        if: ${{ needs.pre-job.result != 'success' || (needs.pre-job.outputs.any_changed == 'true' && (needs.test.result != 'success' || needs.kubeconform.result != 'success' || (github.event_name == 'pull_request' && needs.diff.result != 'success'))) }}
         run: exit 1
 
       - name: All jobs passed or skipped?
-        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        if: ${{ needs.pre-job.result == 'success' && (needs.pre-job.outputs.any_changed != 'true' || (needs.test.result == 'success' && needs.kubeconform.result == 'success' && (github.event_name != 'pull_request' || needs.diff.result == 'success'))) }}
         run: echo "All jobs passed or skipped" && echo "${{ toJSON(needs.*.result) }}"

--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -12,6 +12,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   pre-job:
     name: Flux Local Pre-Job
@@ -22,31 +26,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
+          fetch-depth: 20
 
       - name: Get Changed Files
         id: changed-files
-        run: |
-          set -euo pipefail
-          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-            BASE_REF="${{ github.event.pull_request.base.ref }}"
-          else
-            BASE_REF="${{ github.event.repository.default_branch }}"
-          fi
-          git fetch --no-tags origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}"
-          set +e
-          git diff --quiet --exit-code "origin/${BASE_REF}..HEAD" -- \
-            'kubernetes/**' \
-            '.github/workflows/flux-local.yaml'
-          diff_status=$?
-          set -e
-          if [[ "${diff_status}" -eq 1 ]]; then
-            echo "any_changed=true" >> "${GITHUB_OUTPUT}"
-          elif [[ "${diff_status}" -eq 0 ]]; then
-            echo "any_changed=false" >> "${GITHUB_OUTPUT}"
-          else
-            exit "${diff_status}"
-          fi
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        with:
+          base: ${{ github.event.repository.default_branch }}
+          filters: |
+            any_changed:
+              - "kubernetes/**"
+              - ".github/workflows/flux-local.yaml"
 
   test:
     name: Flux Local Test
@@ -169,5 +159,4 @@ jobs:
         run: exit 1
 
       - name: All jobs passed or skipped?
-        if: ${{ needs.pre-job.result == 'success' && (needs.pre-job.outputs.any_changed != 'true' || (needs.test.result == 'success' && needs.kubeconform.result == 'success' && (github.event_name != 'pull_request' || needs.diff.result == 'success'))) }}
         run: echo "All jobs passed or skipped" && echo "${{ toJSON(needs.*.result) }}"

--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -81,6 +81,8 @@ jobs:
             -ignore-missing-schemas
             -schema-location default
             -schema-location https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json
+            -skip
+            volsync.backube/v1alpha1/ReplicationDestination,volsync.backube/v1alpha1/ReplicationSource,cilium.io/v2/CiliumBGPClusterConfig,tuppr.home-operations.com/v1alpha1/KubernetesUpgrade,tuppr.home-operations.com/v1alpha1/TalosUpgrade,postgresql.cnpg.io/v1/Cluster,operator.victoriametrics.com/v1beta1/VMAlertmanagerConfig
             /github/workspace/rendered.yaml
 
   diff:

--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -80,9 +80,10 @@ jobs:
             -summary
             -ignore-missing-schemas
             -schema-location default
+            -schema-location https://kubernetes-schemas.pages.dev/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json
             -schema-location https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json
             -skip
-            volsync.backube/v1alpha1/ReplicationDestination,volsync.backube/v1alpha1/ReplicationSource,cilium.io/v2/CiliumBGPClusterConfig,tuppr.home-operations.com/v1alpha1/KubernetesUpgrade,tuppr.home-operations.com/v1alpha1/TalosUpgrade,postgresql.cnpg.io/v1/Cluster,operator.victoriametrics.com/v1beta1/VMAlertmanagerConfig
+            cilium.io/v2/CiliumBGPClusterConfig,postgresql.cnpg.io/v1/Cluster,operator.victoriametrics.com/v1beta1/VMAlertmanagerConfig
             /github/workspace/rendered.yaml
 
   diff:

--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -79,6 +79,8 @@ jobs:
             -strict
             -summary
             -ignore-missing-schemas
+            -schema-location default
+            -schema-location https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json
             /github/workspace/rendered.yaml
 
   diff:

--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -26,11 +26,22 @@ jobs:
 
       - name: Get Changed Files
         id: changed-files
-        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
-        with:
-          files: |
-            kubernetes/**
-            .github/workflows/flux-local.yaml
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            BASE_REF="${{ github.event.pull_request.base.ref }}"
+          else
+            BASE_REF="${{ github.event.repository.default_branch }}"
+          fi
+          git fetch --no-tags origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          if git diff --name-only "origin/${BASE_REF}..HEAD" -- \
+                'kubernetes/**' \
+                '.github/workflows/flux-local.yaml' \
+                | grep -q .; then
+            echo "any_changed=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "any_changed=false" >> "${GITHUB_OUTPUT}"
+          fi
 
   test:
     name: Flux Local Test

--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -34,13 +34,18 @@ jobs:
             BASE_REF="${{ github.event.repository.default_branch }}"
           fi
           git fetch --no-tags origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}"
-          if git diff --name-only "origin/${BASE_REF}..HEAD" -- \
-                'kubernetes/**' \
-                '.github/workflows/flux-local.yaml' \
-                | grep -q .; then
+          set +e
+          git diff --quiet --exit-code "origin/${BASE_REF}..HEAD" -- \
+            'kubernetes/**' \
+            '.github/workflows/flux-local.yaml'
+          diff_status=$?
+          set -e
+          if [[ "${diff_status}" -eq 1 ]]; then
             echo "any_changed=true" >> "${GITHUB_OUTPUT}"
-          else
+          elif [[ "${diff_status}" -eq 0 ]]; then
             echo "any_changed=false" >> "${GITHUB_OUTPUT}"
+          else
+            exit "${diff_status}"
           fi
 
   test:

--- a/.github/workflows/kyverno.yaml
+++ b/.github/workflows/kyverno.yaml
@@ -34,17 +34,22 @@ jobs:
             BASE_REF="${{ github.event.repository.default_branch }}"
           fi
           git fetch --no-tags origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}"
-          if git diff --name-only "origin/${BASE_REF}..HEAD" -- \
-                'kubernetes/**' \
-                'talos/**' \
-                'bootstrap/**' \
-                'cluster*.yaml' \
-                'nodes*.yaml' \
-                '.github/workflows/kyverno.yaml' \
-                | grep -q .; then
+          set +e
+          git diff --quiet --exit-code "origin/${BASE_REF}..HEAD" -- \
+            'kubernetes/**' \
+            'talos/**' \
+            'bootstrap/**' \
+            'cluster*.yaml' \
+            'nodes*.yaml' \
+            '.github/workflows/kyverno.yaml'
+          diff_status=$?
+          set -e
+          if [[ "${diff_status}" -eq 1 ]]; then
             echo "any_changed=true" >> "${GITHUB_OUTPUT}"
-          else
+          elif [[ "${diff_status}" -eq 0 ]]; then
             echo "any_changed=false" >> "${GITHUB_OUTPUT}"
+          else
+            exit "${diff_status}"
           fi
 
   test:

--- a/.github/workflows/kyverno.yaml
+++ b/.github/workflows/kyverno.yaml
@@ -5,6 +5,8 @@ name: "Kyverno"
 on:
   pull_request:
     branches: ["main"]
+  push:
+    branches: ["renovate/**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
@@ -24,10 +26,13 @@ jobs:
 
       - name: Get Changed Files
         id: changed
-        env:
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            BASE_REF="${{ github.event.pull_request.base.ref }}"
+          else
+            BASE_REF="${{ github.event.repository.default_branch }}"
+          fi
           git fetch --no-tags origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}"
           if git diff --name-only "origin/${BASE_REF}..HEAD" -- \
                 'kubernetes/**' \

--- a/.github/workflows/kyverno.yaml
+++ b/.github/workflows/kyverno.yaml
@@ -12,6 +12,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   pre-job:
     name: Kyverno Pre-Job
@@ -22,35 +26,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
+          fetch-depth: 20
 
       - name: Get Changed Files
         id: changed
-        run: |
-          set -euo pipefail
-          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-            BASE_REF="${{ github.event.pull_request.base.ref }}"
-          else
-            BASE_REF="${{ github.event.repository.default_branch }}"
-          fi
-          git fetch --no-tags origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}"
-          set +e
-          git diff --quiet --exit-code "origin/${BASE_REF}..HEAD" -- \
-            'kubernetes/**' \
-            'talos/**' \
-            'bootstrap/**' \
-            'cluster*.yaml' \
-            'nodes*.yaml' \
-            '.github/workflows/kyverno.yaml'
-          diff_status=$?
-          set -e
-          if [[ "${diff_status}" -eq 1 ]]; then
-            echo "any_changed=true" >> "${GITHUB_OUTPUT}"
-          elif [[ "${diff_status}" -eq 0 ]]; then
-            echo "any_changed=false" >> "${GITHUB_OUTPUT}"
-          else
-            exit "${diff_status}"
-          fi
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        with:
+          base: ${{ github.event.repository.default_branch }}
+          filters: |
+            any_changed:
+              - "kubernetes/**"
+              - "talos/**"
+              - "bootstrap/**"
+              - "cluster*.yaml"
+              - "nodes*.yaml"
+              - ".github/workflows/kyverno.yaml"
 
   test:
     name: Kyverno Test
@@ -138,5 +128,4 @@ jobs:
         run: exit 1
 
       - name: Kyverno checks complete
-        if: ${{ needs.pre-job.result == 'success' && (needs.pre-job.outputs.any_changed != 'true' || (needs.test.result == 'success' && needs.validate.result == 'success')) }}
         run: echo "${{ toJSON(needs.*.result) }}"

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -51,7 +51,6 @@
       automergeType: "branch",
       matchUpdateTypes: ["minor", "patch", "digest"],
       minimumReleaseAge: "3 days",
-      ignoreTests: true,
     },
     {
       matchUpdateTypes: ["major"],


### PR DESCRIPTION
## Summary
- run Flux Local and Kyverno validation on `renovate/**` branch pushes
- use pinned `dorny/paths-filter` for branch/PR path detection
- add rendered Flux kubeconform validation with built-in schemas, `kubernetes-schemas.pages.dev`, and the Datree CRDs catalog
- keep a minimal kubeconform skip list for three known offline schema incompatibilities: Cilium BGP placeholder substitution, CNPG webhook-defaulted `Cluster`, and VictoriaMetrics AlertmanagerConfig schema mismatch
- remove Renovate GitHub Actions `ignoreTests: true` bypass

## Validation
- parsed updated workflow YAML with `yq`
- checked diff whitespace with `git diff --check`
- re-reviewed updated `paths-filter` workflow changes with GSD code reviewer
- re-reviewed kubeconform CRD schema coverage fix with GSD code reviewer
- locally rendered with `flux-local build all` and ran kubeconform: 1,198 resources found, 1,170 valid, 0 invalid, 0 errors, 28 explicitly skipped

Planning artifacts are intentionally excluded because `.planning/` is ignored and `commit_docs=false`.
