### PR TITLE
fix(volsync): maintenance ordering

### DIFF
--- a/kubernetes/apps/volsync-system/volsync/ks.yaml
+++ b/kubernetes/apps/volsync-system/volsync/ks.yaml
@@ -38,6 +38,11 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
+  dependsOn:
+    - name: onepassword
+      namespace: external-secrets
+    - name: volsync
+      namespace: volsync-system
   interval: 1h
   path: ./kubernetes/apps/volsync-system/volsync/maintenance
   prune: true


### PR DESCRIPTION
Adds Flux dependencies so VolSync maintenance waits for its secret provider and CRDs during bootstrap.