### PR TITLE
feat: add Rook and OpenEBS storage scaffolding

### DIFF
--- a/kubernetes/apps/openebs-system/kustomization.yaml
+++ b/kubernetes/apps/openebs-system/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openebs-system
+components:
+  - ../../components/common
+  - ../../components/psa/privileged
+patches:
+  - path: ./namespace.yaml
+    target:
+      kind: Namespace
+      name: not-used
+resources:
+  - ./openebs/ks.yaml

--- a/kubernetes/apps/openebs-system/namespace.yaml
+++ b/kubernetes/apps/openebs-system/namespace.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/namespace.json
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: not-used
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/openebs-system/openebs/app/helmrelease.yaml
+++ b/kubernetes/apps/openebs-system/openebs/app/helmrelease.yaml
@@ -1,0 +1,80 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: openebs
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: openebs
+  interval: 1h
+  values:
+    preUpgradeHook:
+      enabled: false
+    localpv-provisioner:
+      enabled: true
+      analytics:
+        enabled: false
+      localpv:
+        image:
+          registry: quay.io/
+        basePath: /var/mnt/local-hostpath
+      hostpathClass:
+        enabled: true
+        name: openebs-hostpath
+        isDefaultClass: false
+        basePath: /var/mnt/local-hostpath
+      helperPod:
+        image:
+          registry: quay.io/
+    openebs-crds:
+      csi:
+        volumeSnapshots:
+          enabled: false
+          keep: false
+    zfs-localpv:
+      enabled: false
+      crds:
+        zfsLocalPv:
+          enabled: false
+        csi:
+          volumeSnapshots:
+            enabled: false
+    lvm-localpv:
+      enabled: false
+      crds:
+        lvmLocalPv:
+          enabled: false
+        csi:
+          volumeSnapshots:
+            enabled: false
+    mayastor:
+      enabled: false
+      localpv-provisioner:
+        enabled: false
+      crds:
+        enabled: false
+      loki:
+        enabled: false
+      alloy:
+        enabled: false
+      etcd:
+        enabled: false
+    engines:
+      local:
+        lvm:
+          enabled: false
+        zfs:
+          enabled: false
+        rawfile:
+          enabled: false
+      replicated:
+        mayastor:
+          enabled: false
+    loki:
+      enabled: false
+    alloy:
+      enabled: false
+    minio:
+      enabled: false

--- a/kubernetes/apps/openebs-system/openebs/app/kustomization.yaml
+++ b/kubernetes/apps/openebs-system/openebs/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/openebs-system/openebs/app/ocirepository.yaml
+++ b/kubernetes/apps/openebs-system/openebs/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: openebs
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.4.0
+  url: oci://ghcr.io/openebs/charts/openebs

--- a/kubernetes/apps/openebs-system/openebs/ks.yaml
+++ b/kubernetes/apps/openebs-system/openebs/ks.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app openebs
+  namespace: &namespace openebs-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: *app
+      namespace: *namespace
+  interval: 1h
+  path: ./kubernetes/apps/openebs-system/openebs/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  suspend: true
+  targetNamespace: *namespace
+  wait: true

--- a/kubernetes/apps/rook-ceph/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: rook-ceph
+components:
+  - ../../components/common
+  - ../../components/psa/privileged
+patches:
+  - path: ./namespace.yaml
+    target:
+      kind: Namespace
+      name: not-used
+resources:
+  - ./rook-ceph/ks.yaml

--- a/kubernetes/apps/rook-ceph/namespace.yaml
+++ b/kubernetes/apps/rook-ceph/namespace.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/namespace.json
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: not-used
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/externalsecret.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: rook-ceph-dashboard
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: rook-ceph-dashboard-password
+    template:
+      type: Opaque
+      data:
+        password: "{{ .ROOK_DASHBOARD_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: rook-ceph

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: rook-ceph
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: rook-ceph
+  interval: 1h
+  values:
+    csi:
+      cephFSKernelMountOptions: ms_mode=prefer-crc
+    image:
+      repository: ghcr.io/rook/ceph
+    monitoring:
+      enabled: true
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits: {}

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: rook-ceph
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: v1.19.5
+  url: oci://ghcr.io/rook/rook-ceph

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -1,0 +1,93 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: rook-ceph-cluster
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: rook-ceph-cluster
+  interval: 1h
+  values:
+    cephClusterSpec:
+      cephVersion:
+        image: quay.io/ceph/ceph:v19.2.3
+      cleanupPolicy:
+        wipeDevicesFromOtherClusters: false
+      crashCollector:
+        disable: false
+      csi:
+        readAffinity:
+          enabled: false
+      dashboard:
+        enabled: true
+        prometheusEndpoint: http://prometheus-operated.monitoring.svc.cluster.local:9090
+        ssl: false
+        urlPrefix: /
+      mgr:
+        count: 1
+        modules:
+          - name: pg_autoscaler
+            enabled: true
+      mon:
+        allowMultiplePerNode: true
+        count: 1
+      network:
+        connections:
+          requireMsgr2: true
+      storage:
+        useAllDevices: false
+        useAllNodes: false
+        nodes:
+          - name: k8s-niobe
+            devices:
+              - name: /dev/disk/by-partlabel/r-rook-osd
+    monitoring:
+      enabled: true
+      createPrometheusRules: true
+    toolbox:
+      enabled: true
+    route:
+      dashboard:
+        host:
+          name: rook.${SECRET_DOMAIN}
+          path: /
+          pathType: PathPrefix
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+    cephBlockPools:
+      - name: ceph-blockpool
+        spec:
+          failureDomain: host
+          replicated:
+            size: 1
+        storageClass:
+          enabled: true
+          name: ceph-block
+          allowVolumeExpansion: true
+          isDefault: false
+          mountOptions:
+            - discard
+          parameters:
+            csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
+            csi.storage.k8s.io/controller-expand-secret-namespace: "{{ .Release.Namespace }}"
+            csi.storage.k8s.io/controller-publish-secret-name: rook-csi-rbd-provisioner
+            csi.storage.k8s.io/controller-publish-secret-namespace: "{{ .Release.Namespace }}"
+            csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
+            csi.storage.k8s.io/node-stage-secret-namespace: "{{ .Release.Namespace }}"
+            csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
+            csi.storage.k8s.io/provisioner-secret-namespace: "{{ .Release.Namespace }}"
+            imageFeatures: deep-flatten,exclusive-lock,fast-diff,layering,object-map
+            imageFormat: "2"
+          reclaimPolicy: Delete
+          volumeBindingMode: Immediate
+    cephBlockPoolsVolumeSnapshotClass:
+      enabled: true
+      name: csi-ceph-blockpool
+      deletionPolicy: Delete
+      isDefault: false
+    cephFileSystems: []
+    cephObjectStores: []

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: rook-ceph-cluster
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: v1.19.5
+  url: oci://ghcr.io/rook/rook-ceph-cluster

--- a/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app rook-ceph
+  namespace: &namespace rook-ceph
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: *app
+      namespace: *namespace
+  interval: 1h
+  path: ./kubernetes/apps/rook-ceph/rook-ceph/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: true


### PR DESCRIPTION
## Summary

Adds the non-destructive Phase 10 storage scaffolding needed before the first Longhorn node reclaim:

- Rook-Ceph namespace and operator Flux scaffolding.
- Inactive constrained Rook-Ceph cluster source staged under `rook-ceph/cluster`.
- OpenEBS LocalPV hostpath source staged with the chart-generated `openebs-hostpath` class.
- OpenEBS activation is suspended until the later Talos/manual backing step creates and verifies `/var/mnt/local-hostpath`.

## Deployment behavior

Merging this PR is intentionally limited:

- Rook-Ceph operator scaffolding can reconcile.
- The CephCluster is **not activated** because `rook-ceph/rook-ceph/ks.yaml` only points at the operator app, not the `cluster` source.
- OpenEBS is **not activated** because `kubernetes/apps/openebs-system/openebs/ks.yaml` has `spec.suspend: true`.
- The net PR diff contains **no `talos/` changes**. Talos config is not deployed by GitOps anyway; any Talos apply remains a later explicit operator-gated step.

## Key decisions

- Use onedr0p's Rook/OpenEBS layout as the reference, adapted for this cluster's single-NVMe topology.
- Use the OpenEBS chart-generated `openebs-hostpath` StorageClass instead of a custom CNPG-only class.
- Keep all storage classes non-default.
- Disable OpenEBS snapshot CRDs so the existing snapshot-controller remains the owner.
- Stage Rook with explicit `k8s-niobe` `/dev/disk/by-partlabel/r-rook-osd` selection; do not use `useAllDevices` or `devicePathFilter`.

## Validation

- [x] `kustomize build kubernetes/apps/openebs-system`
- [x] `kustomize build kubernetes/apps/openebs-system/openebs/app`
- [x] `kustomize build kubernetes/apps/rook-ceph`
- [x] `kustomize build kubernetes/apps/rook-ceph/rook-ceph/cluster`
- [x] Rendered OpenEBS chart confirms `openebs-hostpath` is non-default and `WaitForFirstConsumer`.
- [x] Confirmed PR net diff has no `talos/` files.

`flux-local` is not installed locally; CI will run the repository Flux Local workflow.

## Before follow-up activation

- Ensure the `rook-ceph` 1Password item contains `ROOK_DASHBOARD_PASSWORD` before relying on the dashboard secret.
- Do not unsuspend OpenEBS or create PVCs against `openebs-hostpath` until `/var/mnt/local-hostpath` has explicit Talos backing on the required nodes.
- Do not activate the staged CephCluster until the later gated Rook/OSD plan approves the exact raw device selector and bootstrap settings.
