### PR TITLE
feat: move CNPG storage target to OpenEBS

### DIFF
--- a/kubernetes/apps/database/postgres/app/helmrelease.yaml
+++ b/kubernetes/apps/database/postgres/app/helmrelease.yaml
@@ -78,7 +78,7 @@ spec:
             name: postgres-cluster-app
       storage:
         size: 16Gi
-        storageClass: longhorn-cnpg-wffc-1replica
+        storageClass: openebs-hostpath
     recovery:
       method: pg_basebackup
       pgBaseBackup:


### PR DESCRIPTION
## Summary
- update postgres CNPG desired storageClass from longhorn-cnpg-wffc-1replica to openebs-hostpath
- keep live instance replacement gated until Flux reconciles the desired storageClass
- rendered validation: mise exec -- uvx --from flux-local==8.2.0 flux-local test --enable-helm --all-namespaces --path kubernetes/flux/cluster -v --sources flux-system (151 passed)

## Safety
- no CNPG destroy/reconcile/Talos/Longhorn/Rook commands in this PR
- old postgres-cluster-16 PV was operator-patched to Retain before destroy was blocked
- Plan 10-08 remains one-instance-at-a-time and operator-gated