### PR TITLE
feat: add Talos OpenEBS local-hostpath volume

### DIFF
--- a/talos/patches/global/machine-mounts.yaml
+++ b/talos/patches/global/machine-mounts.yaml
@@ -8,3 +8,10 @@ machine:
           - bind
           - rshared
           - rw
+      - destination: /var/mnt/local-hostpath
+        type: bind
+        source: /var/mnt/local-hostpath
+        options:
+          - bind
+          - rshared
+          - rw

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -25,6 +25,21 @@ nodes:
     machineSpec:
       secureboot: false
     controlPlane: true
+    userVolumes:
+      - name: local-hostpath
+        provisioning:
+          diskSelector:
+            match: system_disk
+          grow: false
+          minSize: 32GiB
+          maxSize: 32GiB
+      - name: longhorn
+        provisioning:
+          diskSelector:
+            match: disk.transport == 'nvme'
+          grow: true
+          minSize: 128GiB
+          maxSize: 1TiB
     networkInterfaces:
       - deviceSelector:
           hardwareAddr: "00:24:27:88:e6:a8"
@@ -59,6 +74,21 @@ nodes:
     machineSpec:
       secureboot: true
     controlPlane: true
+    userVolumes:
+      - name: local-hostpath
+        provisioning:
+          diskSelector:
+            match: system_disk
+          grow: false
+          minSize: 32GiB
+          maxSize: 32GiB
+      - name: longhorn
+        provisioning:
+          diskSelector:
+            match: disk.transport == 'nvme'
+          grow: true
+          minSize: 128GiB
+          maxSize: 1TiB
     networkInterfaces:
       - deviceSelector:
           hardwareAddr: "04:0e:3c:92:31:01"
@@ -92,6 +122,21 @@ nodes:
     machineSpec:
       secureboot: true
     controlPlane: true
+    userVolumes:
+      - name: local-hostpath
+        provisioning:
+          diskSelector:
+            match: system_disk
+          grow: false
+          minSize: 32GiB
+          maxSize: 32GiB
+      - name: longhorn
+        provisioning:
+          diskSelector:
+            match: disk.transport == 'nvme'
+          grow: true
+          minSize: 128GiB
+          maxSize: 1TiB
     networkInterfaces:
       - deviceSelector:
           hardwareAddr: "58:47:ca:71:21:77"
@@ -132,14 +177,6 @@ patches:
 
 # Controller patches
 controlPlane:
-  userVolumes:
-    - name: longhorn
-      provisioning:
-        diskSelector:
-          match: disk.transport == 'nvme'
-        grow: true
-        minSize: 128GiB
-        maxSize: 1TiB
   volumes:
     - name: EPHEMERAL
       provisioning:


### PR DESCRIPTION
## Summary
- add per-node Talos local-hostpath user volume alongside longhorn
- bind /var/mnt/local-hostpath into kubelet for OpenEBS hostpath provisioning
- move Longhorn user volume declaration from controlPlane-wide to per-node declarations so local-hostpath is rendered before longhorn

## Validation
- task talos:generate-config
- generated configs for k8s-niobe, k8s-trinity, and k8s-ghost include local-hostpath and longhorn user volumes

## Notes
- These Talos changes were already operator-applied during Phase 10 Plan 10-07 to get OpenEBS working
- Talos changes are not GitOps-applied; this PR persists the source-of-truth config only