### PR TITLE
feat: activate constrained rook ceph cluster

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -10,9 +10,11 @@ spec:
     name: rook-ceph-cluster
   interval: 1h
   values:
+    cephImage:
+      repository: quay.io/ceph/ceph
+      tag: v20.2.1
+      allowUnsupported: false
     cephClusterSpec:
-      cephVersion:
-        image: quay.io/ceph/ceph:v20.2.1
       cleanupPolicy:
         wipeDevicesFromOtherClusters: false
       crashCollector:
@@ -51,7 +53,7 @@ spec:
     route:
       dashboard:
         host:
-          name: rook.${SECRET_DOMAIN}
+          name: rook.melotic.dev
           path: /
           pathType: PathPrefix
         parentRefs:

--- a/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
@@ -23,3 +23,35 @@ spec:
     namespace: flux-system
   targetNamespace: *namespace
   wait: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &cluster rook-ceph-cluster
+  namespace: &namespace rook-ceph
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *cluster
+  dependsOn:
+    - name: rook-ceph
+      namespace: rook-ceph
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: *cluster
+      namespace: *namespace
+  interval: 1h
+  path: ./kubernetes/apps/rook-ceph/rook-ceph/cluster
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: true


### PR DESCRIPTION
## Summary
- enable the rook-ceph-cluster Flux Kustomization
- keep the cluster constrained to the existing staged Rook/Ceph values

## Validation
- flux-local test --enable-helm --all-namespaces --path kubernetes/flux/cluster -v --sources flux-system

Note: local Talos reshape files are intentionally not included in this PR.