### PR TITLE
fix: pin Rook Ceph to Squid

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
   values:
     cephImage:
       repository: quay.io/ceph/ceph
-      tag: v20.2.1
+      tag: v19.2.3-20250717
       allowUnsupported: false
     cephClusterSpec:
       cleanupPolicy:


### PR DESCRIPTION
## Summary\n- pin rook-ceph-cluster Ceph image to quay.io/ceph/ceph:v19.2.3-20250717\n- avoid the Tentacle raw-list bootstrap failure observed during first-node rebootstrap\n\n## Validation\n- mise exec -- uvx --from flux-local==8.2.0 flux-local test --enable-helm --all-namespaces --path kubernetes/flux/cluster -v --sources flux-system