### PR TITLE
fix: tune Rook Ceph single-OSD config

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -15,6 +15,12 @@ spec:
       tag: v19.2.3-20250717
       allowUnsupported: false
     cephClusterSpec:
+      cephConfig:
+        global:
+          osd_pool_default_min_size: "1"
+          osd_pool_default_size: "1"
+        mon:
+          mon_data_avail_warn: "20"
       cleanupPolicy:
         wipeDevicesFromOtherClusters: false
       crashCollector:


### PR DESCRIPTION
## Summary\n- set Ceph default pool size/min-size to 1 for the constrained single-OSD bootstrap\n- lower mon_data_avail_warn to 20% so the 64G EPHEMERAL mon filesystem with ~19G free does not warn at the default 30% threshold\n- keep pool no-redundancy warnings visible\n\n## Validation\n- mise exec -- uvx --from flux-local==8.2.0 flux-local test --enable-helm --all-namespaces --path kubernetes/flux/cluster -v --sources flux-system