### PR TITLE
feat(storage): prepare Ceph migration canary

### DIFF
--- a/kubernetes/apps/default/harbor/app/helmrelease.yaml
+++ b/kubernetes/apps/default/harbor/app/helmrelease.yaml
@@ -45,6 +45,7 @@ spec:
         registry:
           storageClass: nfs-construct
         trivy:
+          storageClass: ceph-block
           size: 16Gi
     existingSecretAdminPassword: harbor
     existingSecretSecretKey: harbor

--- a/kubernetes/apps/default/multi-scrobbler/ks.yaml
+++ b/kubernetes/apps/default/multi-scrobbler/ks.yaml
@@ -12,8 +12,8 @@ spec:
   components:
     - ../../../../components/volsync
   dependsOn:
-    - name: longhorn
-      namespace: longhorn-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
     - name: onepassword
@@ -23,6 +23,8 @@ spec:
     substitute:
       APP: multi-scrobbler
       VOLSYNC_CAPACITY: 1Gi
+      VOLSYNC_SNAPSHOTCLASS: csi-ceph-blockpool
+      VOLSYNC_STORAGECLASS: ceph-block
   sourceRef:
     kind: GitRepository
     name: flux-system


### PR DESCRIPTION
## Summary
- keep multi-scrobbler's PVC name stable as `multi-scrobbler`
- move only multi-scrobbler's VolSync storage/snapshot targets to Ceph
- move Harbor Trivy cache PVC template to `ceph-block`

## Validation
- flux-local test --enable-helm --all-namespaces --path kubernetes/flux/cluster -v --sources flux-system