### PR TITLE
feat(storage): prepare beets and recyclarr Ceph migration

### DIFF
--- a/kubernetes/apps/default/beets/ks.yaml
+++ b/kubernetes/apps/default/beets/ks.yaml
@@ -12,8 +12,8 @@ spec:
   components:
     - ../../../../components/volsync
   dependsOn:
-    - name: longhorn
-      namespace: longhorn-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
     - name: onepassword
@@ -23,6 +23,8 @@ spec:
     substitute:
       APP: beets
       VOLSYNC_CAPACITY: 1Gi
+      VOLSYNC_SNAPSHOTCLASS: csi-ceph-blockpool
+      VOLSYNC_STORAGECLASS: ceph-block
     substituteFrom:
       - name: beets-secret
         kind: Secret

--- a/kubernetes/apps/default/recyclarr/ks.yaml
+++ b/kubernetes/apps/default/recyclarr/ks.yaml
@@ -12,8 +12,8 @@ spec:
   components:
     - ../../../../components/volsync
   dependsOn:
-    - name: longhorn
-      namespace: longhorn-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
   path: ./kubernetes/apps/default/recyclarr/app
@@ -23,6 +23,8 @@ spec:
       VOLSYNC_CAPACITY: 1Gi
       VOLSYNC_PUID: "1000"
       VOLSYNC_PGID: "1000"
+      VOLSYNC_SNAPSHOTCLASS: csi-ceph-blockpool
+      VOLSYNC_STORAGECLASS: ceph-block
   sourceRef:
     kind: GitRepository
     name: flux-system


### PR DESCRIPTION
## Summary\n- switch beets and recyclarr VolSync rendered PVCs/snapshots to Ceph\n- keep stable PVC names and HelmRelease existingClaim values unchanged\n- depend on rook-ceph-cluster instead of longhorn for the target apps\n\n## Validation\n- focused flux build render confirms beets/recyclarr PVC + ReplicationSource use ceph-block and HelmRelease existingClaim remains stable\n- diff check passed\n\nPhase 11 Plan 11-04 backup gates are PASS; live migration will use temporary *-ceph-stage PVCs and retained old Longhorn PV rollback guards.