### PR TITLE
feat(storage): prepare prowlarr and radarr Ceph migration

### DIFF
--- a/kubernetes/apps/default/prowlarr/ks.yaml
+++ b/kubernetes/apps/default/prowlarr/ks.yaml
@@ -12,8 +12,8 @@ spec:
   components:
     - ../../../../components/volsync
   dependsOn:
-    - name: longhorn
-      namespace: longhorn-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
   path: ./kubernetes/apps/default/prowlarr/app
@@ -21,6 +21,8 @@ spec:
     substitute:
       APP: prowlarr
       VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_SNAPSHOTCLASS: csi-ceph-blockpool
+      VOLSYNC_STORAGECLASS: ceph-block
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/default/radarr/ks.yaml
+++ b/kubernetes/apps/default/radarr/ks.yaml
@@ -12,8 +12,8 @@ spec:
   components:
     - ../../../../components/volsync
   dependsOn:
-    - name: longhorn
-      namespace: longhorn-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
   path: ./kubernetes/apps/default/radarr/app
@@ -21,6 +21,8 @@ spec:
     substitute:
       APP: radarr
       VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_SNAPSHOTCLASS: csi-ceph-blockpool
+      VOLSYNC_STORAGECLASS: ceph-block
   sourceRef:
     kind: GitRepository
     name: flux-system


### PR DESCRIPTION
## Summary
- switch prowlarr and radarr VolSync desired state from Longhorn to Ceph
- keep final PVC names stable by leaving HelmRelease existingClaim values unchanged
- preserve radarr NFS /data mount unchanged

## Validation
- rendered prowlarr and radarr Flux Kustomizations locally with strict substitution
- confirmed rendered PVC/ReplicationSource use ceph-block and csi-ceph-blockpool
- confirmed rendered HelmReleases still use existingClaim prowlarr/radarr

Note: flux-local is not installed in this CLI environment; CI will run the repository flux-local workflow.