### PR TITLE
feat(storage): prepare sonarr lidarr sabnzbd and seerr Ceph migration

### DIFF
--- a/kubernetes/apps/default/lidarr/ks.yaml
+++ b/kubernetes/apps/default/lidarr/ks.yaml
@@ -12,8 +12,8 @@ spec:
   components:
     - ../../../../components/volsync
   dependsOn:
-    - name: longhorn
-      namespace: longhorn-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
   path: ./kubernetes/apps/default/lidarr/app
@@ -21,6 +21,8 @@ spec:
     substitute:
       APP: lidarr
       VOLSYNC_CAPACITY: 16Gi
+      VOLSYNC_SNAPSHOTCLASS: csi-ceph-blockpool
+      VOLSYNC_STORAGECLASS: ceph-block
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/default/sabnzbd/ks.yaml
+++ b/kubernetes/apps/default/sabnzbd/ks.yaml
@@ -12,8 +12,8 @@ spec:
   components:
     - ../../../../components/volsync
   dependsOn:
-    - name: longhorn
-      namespace: longhorn-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
   path: ./kubernetes/apps/default/sabnzbd/app
@@ -21,6 +21,8 @@ spec:
     substitute:
       APP: sabnzbd
       VOLSYNC_CAPACITY: 1Gi
+      VOLSYNC_SNAPSHOTCLASS: csi-ceph-blockpool
+      VOLSYNC_STORAGECLASS: ceph-block
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/default/seerr/ks.yaml
+++ b/kubernetes/apps/default/seerr/ks.yaml
@@ -12,8 +12,8 @@ spec:
   components:
     - ../../../../components/volsync
   dependsOn:
-    - name: longhorn
-      namespace: longhorn-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
   path: ./kubernetes/apps/default/seerr/app
@@ -21,6 +21,8 @@ spec:
     substitute:
       APP: seerr
       VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_SNAPSHOTCLASS: csi-ceph-blockpool
+      VOLSYNC_STORAGECLASS: ceph-block
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/default/sonarr/ks.yaml
+++ b/kubernetes/apps/default/sonarr/ks.yaml
@@ -12,8 +12,8 @@ spec:
   components:
     - ../../../../components/volsync
   dependsOn:
-    - name: longhorn
-      namespace: longhorn-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
   path: ./kubernetes/apps/default/sonarr/app
@@ -21,6 +21,8 @@ spec:
     substitute:
       APP: sonarr
       VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_SNAPSHOTCLASS: csi-ceph-blockpool
+      VOLSYNC_STORAGECLASS: ceph-block
   sourceRef:
     kind: GitRepository
     name: flux-system


### PR DESCRIPTION
## Summary\n- switch sonarr, lidarr, sabnzbd, and seerr VolSync desired PVCs to ceph-block\n- depend on the Rook-Ceph cluster before reconciling these app Kustomizations\n- keep HelmRelease existingClaim values stable for the live migration flow\n\n## Validation\n- rendered all four app Kustomizations locally with strict substitution\n- confirmed stable PVC names, ceph-block storage class, csi-ceph-blockpool snapshot class, and unchanged HelmRelease claims