### PR TITLE
feat(storage): prepare final starter Ceph migration wave

### DIFF
--- a/kubernetes/apps/default/atuin/ks.yaml
+++ b/kubernetes/apps/default/atuin/ks.yaml
@@ -12,8 +12,8 @@ spec:
   components:
     - ../../../../components/volsync
   dependsOn:
-    - name: longhorn
-      namespace: longhorn-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
   path: ./kubernetes/apps/default/atuin/app
@@ -23,6 +23,8 @@ spec:
       VOLSYNC_CAPACITY: 5Gi
       VOLSYNC_PUID: "1000"
       VOLSYNC_PGID: "1000"
+      VOLSYNC_SNAPSHOTCLASS: csi-ceph-blockpool
+      VOLSYNC_STORAGECLASS: ceph-block
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/default/aurral/ks.yaml
+++ b/kubernetes/apps/default/aurral/ks.yaml
@@ -12,8 +12,8 @@ spec:
   components:
     - ../../../../components/volsync
   dependsOn:
-    - name: longhorn
-      namespace: longhorn-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
     - name: onepassword
@@ -25,6 +25,8 @@ spec:
     substitute:
       APP: aurral
       VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_SNAPSHOTCLASS: csi-ceph-blockpool
+      VOLSYNC_STORAGECLASS: ceph-block
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/default/paperless-ngx/ks.yaml
+++ b/kubernetes/apps/default/paperless-ngx/ks.yaml
@@ -14,8 +14,8 @@ spec:
   dependsOn:
     - name: dragonfly
       namespace: database
-    - name: longhorn
-      namespace: longhorn-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
   path: ./kubernetes/apps/default/paperless-ngx/app
@@ -23,6 +23,8 @@ spec:
     substitute:
       APP: paperless-ngx
       VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_SNAPSHOTCLASS: csi-ceph-blockpool
+      VOLSYNC_STORAGECLASS: ceph-block
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/default/slskd/ks.yaml
+++ b/kubernetes/apps/default/slskd/ks.yaml
@@ -12,8 +12,8 @@ spec:
   components:
     - ../../../../components/volsync
   dependsOn:
-    - name: longhorn
-      namespace: longhorn-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
   path: ./kubernetes/apps/default/slskd/app
@@ -21,6 +21,8 @@ spec:
     substitute:
       APP: slskd
       VOLSYNC_CAPACITY: 2Gi
+      VOLSYNC_SNAPSHOTCLASS: csi-ceph-blockpool
+      VOLSYNC_STORAGECLASS: ceph-block
       AUTH_POLICY_NAME: slskd-auth
       AUTH_HTTPROUTE: slskd
   sourceRef:

--- a/kubernetes/apps/default/tautulli/ks.yaml
+++ b/kubernetes/apps/default/tautulli/ks.yaml
@@ -12,8 +12,8 @@ spec:
   components:
     - ../../../../components/volsync
   dependsOn:
-    - name: longhorn
-      namespace: longhorn-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
   path: ./kubernetes/apps/default/tautulli/app
@@ -23,6 +23,8 @@ spec:
       VOLSYNC_CAPACITY: 5Gi
       VOLSYNC_PUID: "1000"
       VOLSYNC_PGID: "1000"
+      VOLSYNC_SNAPSHOTCLASS: csi-ceph-blockpool
+      VOLSYNC_STORAGECLASS: ceph-block
   sourceRef:
     kind: GitRepository
     name: flux-system


### PR DESCRIPTION
Prepare the final Phase 11 starter preserved migration wave by moving slskd, tautulli, atuin, aurral, and paperless-ngx VolSync targets to ceph-block while keeping stable app PVC claim names for retained-PV swaps.