### PR TITLE
feat(rook-ceph): add trinity osd target

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -51,6 +51,9 @@ spec:
           - name: k8s-niobe
             devices:
               - name: /dev/disk/by-partlabel/r-rook-osd
+          - name: k8s-trinity
+            devices:
+              - name: /dev/disk/by-partlabel/r-rook-osd
     monitoring:
       enabled: true
       createPrometheusRules: true

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -74,7 +74,7 @@ spec:
         spec:
           failureDomain: host
           replicated:
-            size: 1
+            size: 2
         storageClass:
           enabled: true
           name: ceph-block

--- a/talos/patches/k8s-niobe/storage-reshape.yaml
+++ b/talos/patches/k8s-niobe/storage-reshape.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1alpha1
+kind: RawVolumeConfig
+name: rook-osd
+provisioning:
+  diskSelector:
+    match: disk.transport == 'nvme' && system_disk
+  grow: true
+  minSize: 128GiB
+  maxSize: 1TiB

--- a/talos/patches/k8s-trinity/storage-reshape.yaml
+++ b/talos/patches/k8s-trinity/storage-reshape.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1alpha1
+kind: RawVolumeConfig
+name: rook-osd
+provisioning:
+  diskSelector:
+    match: disk.transport == 'nvme' && system_disk
+  grow: true
+  minSize: 128GiB
+  maxSize: 1TiB

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -33,13 +33,8 @@ nodes:
           grow: false
           minSize: 32GiB
           maxSize: 32GiB
-      - name: longhorn
-        provisioning:
-          diskSelector:
-            match: disk.transport == 'nvme'
-          grow: true
-          minSize: 128GiB
-          maxSize: 1TiB
+    patches:
+      - "@./patches/k8s-niobe/storage-reshape.yaml"
     networkInterfaces:
       - deviceSelector:
           hardwareAddr: "00:24:27:88:e6:a8"
@@ -82,13 +77,8 @@ nodes:
           grow: false
           minSize: 32GiB
           maxSize: 32GiB
-      - name: longhorn
-        provisioning:
-          diskSelector:
-            match: disk.transport == 'nvme'
-          grow: true
-          minSize: 128GiB
-          maxSize: 1TiB
+    patches:
+      - "@./patches/k8s-trinity/storage-reshape.yaml"
     networkInterfaces:
       - deviceSelector:
           hardwareAddr: "04:0e:3c:92:31:01"


### PR DESCRIPTION
## Summary
- add k8s-trinity as an explicit Rook-Ceph OSD target
- preserve niobe and trinity Talos raw-volume source patches for rook-osd/r-rook-osd
- set ceph-blockpool replicated size to 2 after live second-OSD evidence
- keep k8s-ghost on Longhorn until selected by evidence

## Validation
- task talos:generate-config
- kustomize build kubernetes/apps/rook-ceph/rook-ceph/cluster
- git diff --check
- PR checks: Flux Local / Kyverno / CodeQL

## Notes
- Talos apply and Longhorn evacuation were operator-owned live steps.
- D-21 APPLY was approved after two OSDs were up/in, PGs active+clean, and capacity was ample.