### PR TITLE
fix(kyverno): allow egress to Sigstore and registry endpoints

### DIFF
--- a/kubernetes/apps/kyverno/kyverno/app/ciliumnetworkpolicy.yaml
+++ b/kubernetes/apps/kyverno/kyverno/app/ciliumnetworkpolicy.yaml
@@ -29,3 +29,21 @@ spec:
           rules:
             dns:
               - matchPattern: "*"
+    # Sigstore (TUF, Rekor, Fulcio) for verifyImages keyless cosign
+    - toFQDNs:
+        - matchName: tuf-repo-cdn.sigstore.dev
+        - matchName: rekor.sigstore.dev
+        - matchName: fulcio.sigstore.dev
+        - matchName: oauth2.sigstore.dev
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    # Container registries for signature/attestation layer fetches
+    - toFQDNs:
+        - matchName: ghcr.io
+        - matchName: registry.k8s.io
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP


### PR DESCRIPTION
Adds FQDN egress rules so Kyverno can reach Sigstore for keyless cosign verification.