### PR TITLE
feat(storage): migrate simple app PVCs to Ceph

### DIFF
--- a/kubernetes/apps/database/dragonfly/app/helmrelease.yaml
+++ b/kubernetes/apps/database/dragonfly/app/helmrelease.yaml
@@ -62,7 +62,7 @@ spec:
       data:
         accessMode: ReadWriteOnce
         size: 1Gi
-        storageClass: longhorn
+        storageClass: ceph-block
         globalMounts:
           - path: /data
       tmp:

--- a/kubernetes/apps/database/dragonfly/ks.yaml
+++ b/kubernetes/apps/database/dragonfly/ks.yaml
@@ -10,8 +10,8 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
-    - name: longhorn
-      namespace: longhorn-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
   path: ./kubernetes/apps/database/dragonfly/app
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/default/ghidra-server/ks.yaml
+++ b/kubernetes/apps/default/ghidra-server/ks.yaml
@@ -12,8 +12,8 @@ spec:
   components:
     - ../../../../components/volsync
   dependsOn:
-    - name: longhorn
-      namespace: longhorn-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
     - name: authentik
@@ -23,6 +23,8 @@ spec:
     substitute:
       APP: ghidra-server
       VOLSYNC_CAPACITY: 20Gi
+      VOLSYNC_SNAPSHOTCLASS: csi-ceph-blockpool
+      VOLSYNC_STORAGECLASS: ceph-block
       GHIDRA_SERVER_IP: 10.60.80.7
       AUTHENTIK_LDAP_HOST: ghidra-ldap.melotic.dev
       AUTHENTIK_LDAP_BASE_DN: OU=ghidra,DC=ldap,DC=melotic,DC=dev

--- a/kubernetes/apps/default/harbor/app/helmrelease.yaml
+++ b/kubernetes/apps/default/harbor/app/helmrelease.yaml
@@ -44,6 +44,9 @@ spec:
       persistentVolumeClaim:
         registry:
           storageClass: nfs-construct
+        jobservice:
+          jobLog:
+            storageClass: ceph-block
         trivy:
           storageClass: ceph-block
           size: 16Gi

--- a/kubernetes/apps/default/harbor/ks.yaml
+++ b/kubernetes/apps/default/harbor/ks.yaml
@@ -9,6 +9,9 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
   path: ./kubernetes/apps/default/harbor/app
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/default/home-assistant/ks.yaml
+++ b/kubernetes/apps/default/home-assistant/ks.yaml
@@ -14,8 +14,8 @@ spec:
   dependsOn:
     - name: multus-networks
       namespace: kube-system
-    - name: longhorn
-      namespace: longhorn-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
   path: ./kubernetes/apps/default/home-assistant/app
@@ -25,6 +25,8 @@ spec:
       VOLSYNC_CAPACITY: 8Gi
       VOLSYNC_PUID: "1000"
       VOLSYNC_PGID: "1000"
+      VOLSYNC_SNAPSHOTCLASS: csi-ceph-blockpool
+      VOLSYNC_STORAGECLASS: ceph-block
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/default/plex/ks.yaml
+++ b/kubernetes/apps/default/plex/ks.yaml
@@ -12,8 +12,8 @@ spec:
   components:
     - ../../../../components/volsync
   dependsOn:
-    - name: longhorn
-      namespace: longhorn-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
   path: ./kubernetes/apps/default/plex/app
@@ -23,6 +23,8 @@ spec:
       VOLSYNC_CAPACITY: 50Gi
       VOLSYNC_PUID: "1000"
       VOLSYNC_PGID: "1000"
+      VOLSYNC_SNAPSHOTCLASS: csi-ceph-blockpool
+      VOLSYNC_STORAGECLASS: ceph-block
   sourceRef:
     kind: GitRepository
     name: flux-system


### PR DESCRIPTION
## Summary
- switch W1 simple-app storage dependencies from Longhorn to Rook-Ceph
- set Dragonfly and Harbor jobservice chart-managed PVC storage to ceph-block
- point ghidra-server, home-assistant, and Plex VolSync snapshots at ceph-block/csi-ceph-blockpool

## Validation
- kustomize build for ghidra-server, harbor, dragonfly, home-assistant, plex app directories
- source assertions from Plan 12-02 Task 1
- git diff --check

## Notes
- No live cluster mutation was performed.
- ExistingClaim workloads keep stable PVC names; live stable-swap happens in the operator checkpoint task.