### PR TITLE
fix(storage): move repo app PVCs to Ceph

### DIFF
--- a/kubernetes/apps/default/forejo/ks.yaml
+++ b/kubernetes/apps/default/forejo/ks.yaml
@@ -12,8 +12,8 @@ spec:
   components:
     - ../../../../components/volsync
   dependsOn:
-    - name: longhorn
-      namespace: longhorn-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
     - name: postgres
@@ -23,6 +23,8 @@ spec:
     substitute:
       APP: forejo
       VOLSYNC_CAPACITY: 25Gi
+      VOLSYNC_SNAPSHOTCLASS: csi-ceph-blockpool
+      VOLSYNC_STORAGECLASS: ceph-block
       VOLSYNC_PUID: "1000"
       VOLSYNC_PGID: "1000"
   sourceRef:

--- a/kubernetes/apps/gitlab/gitlab/app/helmrelease.yaml
+++ b/kubernetes/apps/gitlab/gitlab/app/helmrelease.yaml
@@ -224,7 +224,7 @@ spec:
         persistence:
           enabled: true
           size: 50Gi
-          storageClass: longhorn
+          storageClass: ceph-block
           accessMode: ReadWriteOnce
         resources:
           requests:

--- a/kubernetes/apps/gitlab/gitlab/app/minio-helmrelease.yaml
+++ b/kubernetes/apps/gitlab/gitlab/app/minio-helmrelease.yaml
@@ -87,7 +87,7 @@ spec:
       data:
         accessMode: ReadWriteOnce
         size: 50Gi
-        storageClass: longhorn
+        storageClass: ceph-block
         globalMounts:
           - path: /data
       tmp:

--- a/kubernetes/apps/gitlab/gitlab/ks.yaml
+++ b/kubernetes/apps/gitlab/gitlab/ks.yaml
@@ -10,8 +10,8 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
-    - name: longhorn
-      namespace: longhorn-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: postgres
       namespace: database
     - name: dragonfly


### PR DESCRIPTION
## Summary
- switch Forejo VolSync PVC creation from Longhorn to ceph-block/csi-ceph-blockpool
- switch GitLab Gitaly persistence from Longhorn to ceph-block
- switch GitLab MinIO persistence from Longhorn to ceph-block so disposable data can be recreated on Ceph
- update Forejo and GitLab Kustomization dependencies from Longhorn to Rook-Ceph

## Validation
- flux-local test --enable-helm --all-namespaces --path kubernetes/flux/cluster -v --sources flux-system
- flux-local build all + kubeconform strict summary

## Phase 12 follow-up
After this PR is merged and Flux has reconciled, delete the old Longhorn PVCs so the controllers recreate empty Ceph-backed PVCs for GitLab disposable data and Forejo can proceed through the preserve-path restore gate.