### PR TITLE
feat(kyverno): add Policy Reporter with native OIDC

### DIFF
--- a/kubernetes/apps/default/authentik/app/blueprints/policy-reporter.yaml
+++ b/kubernetes/apps/default/authentik/app/blueprints/policy-reporter.yaml
@@ -1,0 +1,57 @@
+---
+# yaml-language-server: $schema=https://goauthentik.io/blueprints/schema.json
+version: 1
+metadata:
+  name: Policy Reporter OAuth2 Provider and Application
+context:
+  authorization_flow:
+    !Find &authorization_flow [
+      authentik_flows.flow,
+      [slug, default-provider-authorization-implicit-consent],
+    ]
+  invalidation_flow:
+    !Find &invalidation_flow [
+      authentik_flows.flow,
+      [slug, default-provider-invalidation-flow],
+    ]
+  property_mappings: &property_mappings
+    - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+    - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+    - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+  signing_key:
+    !Find &signing_key [
+      authentik_crypto.certificatekeypair,
+      [name, authentik Self-signed Certificate],
+    ]
+entries:
+  # OAuth2 Provider for Policy Reporter
+  - model: authentik_providers_oauth2.oauth2provider
+    identifiers:
+      name: policy-reporter
+    attrs:
+      name: policy-reporter
+      authorization_flow: *authorization_flow
+      invalidation_flow: *invalidation_flow
+      client_type: confidential
+      client_id: !Env POLICY_REPORTER_CLIENT_ID
+      client_secret: !Env POLICY_REPORTER_CLIENT_SECRET
+      redirect_uris:
+        - url: "https://policy-reporter.melotic.dev/callback"
+          matching_mode: strict
+      property_mappings: *property_mappings
+      signing_key: *signing_key
+
+  # Application for Policy Reporter
+  - model: authentik_core.application
+    identifiers:
+      slug: policy-reporter
+    attrs:
+      name: Policy Reporter
+      slug: policy-reporter
+      provider:
+        !Find [authentik_providers_oauth2.oauth2provider, [name, policy-reporter]]
+      policy_engine_mode: any
+      meta_icon: https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/kyverno.svg
+      meta_description: Kyverno policy reporting dashboard
+      meta_publisher: Kyverno
+      open_in_new_tab: true

--- a/kubernetes/apps/default/authentik/app/kustomization.yaml
+++ b/kubernetes/apps/default/authentik/app/kustomization.yaml
@@ -23,6 +23,7 @@ configMapGenerator:
       - slskd.yaml=./blueprints/slskd.yaml
       - gatus.yaml=./blueprints/gatus.yaml
       - ghidra-server.yaml=./blueprints/ghidra-server.yaml
+      - policy-reporter.yaml=./blueprints/policy-reporter.yaml
       - outpost.yaml=./blueprints/outpost.yaml
       - flow-login.yaml=./blueprints/flow-login.yaml
       - brand.yaml=./blueprints/brand.yaml

--- a/kubernetes/apps/kyverno/kustomization.yaml
+++ b/kubernetes/apps/kyverno/kustomization.yaml
@@ -9,3 +9,4 @@ components:
 resources:
   - ./kyverno/ks.yaml
   - ./policies/ks.yaml
+  - ./policy-reporter/ks.yaml

--- a/kubernetes/apps/kyverno/policy-reporter/app/externalsecret.yaml
+++ b/kubernetes/apps/kyverno/policy-reporter/app/externalsecret.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: policy-reporter
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: policy-reporter-oidc
+    creationPolicy: Owner
+    template:
+      data:
+        clientId: "{{ .authentik_policy_reporter_client_id }}"
+        clientSecret: "{{ .authentik_policy_reporter_client_secret }}"
+  dataFrom:
+    - extract:
+        key: authentik-oidc
+      rewrite:
+        - regexp:
+            source: "(.*)"
+            target: "authentik_$1"

--- a/kubernetes/apps/kyverno/policy-reporter/app/helmrelease.yaml
+++ b/kubernetes/apps/kyverno/policy-reporter/app/helmrelease.yaml
@@ -22,8 +22,8 @@ spec:
       enabled: true
       openIDConnect:
         enabled: true
-        discoveryUrl: "https://auth.${SECRET_DOMAIN}/application/o/policy-reporter/.well-known/openid-configuration"
-        callbackUrl: "https://policy-reporter.${SECRET_DOMAIN}/callback"
+        discoveryUrl: "https://auth.melotic.dev/application/o/policy-reporter/.well-known/openid-configuration"
+        callbackUrl: "https://policy-reporter.melotic.dev/callback"
         clientId: ""
         clientSecret: ""
         secretRef: policy-reporter-oidc
@@ -39,7 +39,7 @@ spec:
             namespace: network
             sectionName: https
         hostnames:
-          - "policy-reporter.${SECRET_DOMAIN}"
+          - "policy-reporter.melotic.dev"
         rules:
           - matches:
               - path:

--- a/kubernetes/apps/kyverno/policy-reporter/app/helmrelease.yaml
+++ b/kubernetes/apps/kyverno/policy-reporter/app/helmrelease.yaml
@@ -1,0 +1,64 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: policy-reporter
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: policy-reporter
+      version: 3.7.4
+      sourceRef:
+        kind: HelmRepository
+        name: policy-reporter
+        namespace: kyverno
+  install:
+    remediation:
+      retries: -1
+  values:
+    ui:
+      enabled: true
+      openIDConnect:
+        enabled: true
+        discoveryUrl: "https://auth.${SECRET_DOMAIN}/application/o/policy-reporter/.well-known/openid-configuration"
+        callbackUrl: "https://policy-reporter.${SECRET_DOMAIN}/callback"
+        clientId: ""
+        clientSecret: ""
+        secretRef: policy-reporter-oidc
+        scopes:
+          - openid
+          - email
+          - profile
+        groupClaim: groups
+      httproute:
+        enabled: true
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        hostnames:
+          - "policy-reporter.${SECRET_DOMAIN}"
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+
+    plugin:
+      kyverno:
+        enabled: true
+
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 1234
+      runAsGroup: 1234
+      fsGroup: 1234
+      fsGroupChangePolicy: OnRootMismatch
+
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop: ["ALL"]

--- a/kubernetes/apps/kyverno/policy-reporter/app/helmrepository.yaml
+++ b/kubernetes/apps/kyverno/policy-reporter/app/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: policy-reporter
+spec:
+  interval: 15m
+  url: https://kyverno.github.io/policy-reporter

--- a/kubernetes/apps/kyverno/policy-reporter/app/kustomization.yaml
+++ b/kubernetes/apps/kyverno/policy-reporter/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./helmrepository.yaml

--- a/kubernetes/apps/kyverno/policy-reporter/ks.yaml
+++ b/kubernetes/apps/kyverno/policy-reporter/ks.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app policy-reporter
+  namespace: &namespace kyverno
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: kyverno
+      namespace: kyverno
+    - name: external-secrets-stores
+      namespace: external-secrets
+  interval: 1h
+  path: ./kubernetes/apps/kyverno/policy-reporter/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
Deploy Policy Reporter UI with built-in OpenID Connect authentication via Authentik OAuth2 provider. Uses the chart's native `ui.openIDConnect` support instead of proxy auth.