### PR TITLE
feat(monitoring): move persistent volumes to ceph

### DIFF
--- a/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
@@ -65,7 +65,7 @@ spec:
         statefulset:
           volumeClaimTemplates:
             - name: config
-              storageClass: longhorn
+              storageClass: ceph-block
               accessMode: ReadWriteOnce
               size: 5Gi
     defaultPodOptions:

--- a/kubernetes/apps/monitoring/gatus/ks.yaml
+++ b/kubernetes/apps/monitoring/gatus/ks.yaml
@@ -9,6 +9,9 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
   path: ./kubernetes/apps/monitoring/gatus/app
   postBuild:
     substitute:

--- a/kubernetes/apps/monitoring/grafana/instance/grafana.yaml
+++ b/kubernetes/apps/monitoring/grafana/instance/grafana.yaml
@@ -103,4 +103,4 @@ spec:
       resources:
         requests:
           storage: 5Gi
-      storageClassName: longhorn
+      storageClassName: ceph-block

--- a/kubernetes/apps/monitoring/grafana/ks.yaml
+++ b/kubernetes/apps/monitoring/grafana/ks.yaml
@@ -32,6 +32,8 @@ spec:
   dependsOn:
     - name: grafana
     - name: victoria-metrics-k8s-stack
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
   path: ./kubernetes/apps/monitoring/grafana/instance
   postBuild:
     substituteFrom:

--- a/kubernetes/apps/monitoring/victoria-logs/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/victoria-logs/app/helmrelease.yaml
@@ -16,7 +16,7 @@ spec:
         registry: docker.io
       persistentVolume:
         enabled: true
-        storageClassName: longhorn
+        storageClassName: ceph-block
         size: 20Gi
       retentionPeriod: 14d
       route:

--- a/kubernetes/apps/monitoring/victoria-logs/ks.yaml
+++ b/kubernetes/apps/monitoring/victoria-logs/ks.yaml
@@ -11,6 +11,8 @@ spec:
       app.kubernetes.io/name: *app
   dependsOn:
     - name: grafana
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
   path: ./kubernetes/apps/monitoring/victoria-logs/app
   postBuild:
     substitute:

--- a/kubernetes/apps/monitoring/victoria-metrics-k8s-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics-k8s-stack/app/helmrelease.yaml
@@ -75,7 +75,7 @@ spec:
       spec:
         retentionPeriod: "31d"
         storage:
-          storageClassName: longhorn
+          storageClassName: ceph-block
           accessModes: ["ReadWriteOnce"]
           resources:
             requests:
@@ -101,7 +101,7 @@ spec:
         storage:
           volumeClaimTemplate:
             spec:
-              storageClassName: longhorn
+              storageClassName: ceph-block
               accessModes: ["ReadWriteOnce"]
               resources:
                 requests:

--- a/kubernetes/apps/monitoring/victoria-metrics-k8s-stack/ks.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics-k8s-stack/ks.yaml
@@ -12,6 +12,8 @@ spec:
   dependsOn:
     - name: prometheus-operator-crds
     - name: grafana
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
   path: ./kubernetes/apps/monitoring/victoria-metrics-k8s-stack/app
   postBuild:
     substitute:


### PR DESCRIPTION
## Summary
- move monitoring PVC desired storage classes from Longhorn to Ceph block
- add rook-ceph-cluster dependencies for monitoring workloads with persistent storage

## Validation
- flux-local test --enable-helm --all-namespaces --path kubernetes/flux/cluster -v --sources flux-system