### PR TITLE
feat(storage): add ghost as third Ceph OSD target

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -54,6 +54,9 @@ spec:
           - name: k8s-trinity
             devices:
               - name: /dev/disk/by-partlabel/r-rook-osd
+          - name: k8s-ghost
+            devices:
+              - name: /dev/disk/by-partlabel/r-rook-osd
     monitoring:
       enabled: true
       createPrometheusRules: true

--- a/talos/patches/k8s-ghost/storage-reshape.yaml
+++ b/talos/patches/k8s-ghost/storage-reshape.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1alpha1
+kind: RawVolumeConfig
+name: rook-osd
+provisioning:
+  diskSelector:
+    match: disk.transport == 'nvme' && system_disk
+  grow: true
+  minSize: 128GiB
+  maxSize: 1TiB

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -120,13 +120,8 @@ nodes:
           grow: false
           minSize: 32GiB
           maxSize: 32GiB
-      - name: longhorn
-        provisioning:
-          diskSelector:
-            match: disk.transport == 'nvme'
-          grow: true
-          minSize: 128GiB
-          maxSize: 1TiB
+    patches:
+      - "@./patches/k8s-ghost/storage-reshape.yaml"
     networkInterfaces:
       - deviceSelector:
           hardwareAddr: "58:47:ca:71:21:77"


### PR DESCRIPTION
## Summary
- add `k8s-ghost` as an explicit Rook-Ceph storage node using `/dev/disk/by-partlabel/r-rook-osd`
- replace ghost's Talos Longhorn user volume with the same `rook-osd` raw volume reshape pattern used for trinity
- keep PR-A safety scope unchanged: pool size/min-size, mon/mgr placement, and CephFS settings are not changed here

## Validation
- `task talos:generate-config`
- `mise exec -- flux-local test --enable-helm --all-namespaces --path kubernetes/flux/cluster -v --sources flux-system`
- rendered `flux-local build all` + `kubeconform -strict -summary`

## Operator-owned follow-up
- Talos apply for `k8s-ghost` is intentionally not run by this PR author
- after applying, verify `r-rook-osd` exists and `u-longhorn` is gone before treating the node as ready for the third OSD
