### PR TITLE
fix(rook-ceph): extend cluster rollout timeout

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -9,6 +9,7 @@ spec:
     kind: OCIRepository
     name: rook-ceph-cluster
   interval: 1h
+  timeout: 30m
   values:
     cephImage:
       repository: quay.io/ceph/ceph


### PR DESCRIPTION
## Summary
- extend the Rook-Ceph cluster HelmRelease timeout to 30m
- prevent full-footprint rollouts from failing while CephCluster is still InProgress during pool backfill / MDS creation

## Context
PR #1139 applied live far enough to scale mons/mgrs, create CephFS, and start size-3 backfill, but Helm timed out after the default 5m while Rook still reported CephCluster InProgress. Helm then rolled the chart release record/resources back even though Ceph data remained healthy.

## Validation
- `pipx run --spec flux-local==8.2.0 flux-local test --enable-helm --all-namespaces --path kubernetes/flux/cluster -v --sources flux-system` (154 passed)
- `flux-local build all --enable-helm --skip-invalid-kustomization-paths` + workflow-equivalent `kubeconform` (1347 resources, 1282 valid, 0 invalid, 0 errors, 65 skipped)