### PR TITLE
fix(kyverno): correct policy-reporter dependsOn reference

### DIFF
--- a/kubernetes/apps/kyverno/policy-reporter/ks.yaml
+++ b/kubernetes/apps/kyverno/policy-reporter/ks.yaml
@@ -12,7 +12,7 @@ spec:
   dependsOn:
     - name: kyverno
       namespace: kyverno
-    - name: external-secrets-stores
+    - name: onepassword
       namespace: external-secrets
   interval: 1h
   path: ./kubernetes/apps/kyverno/policy-reporter/app


### PR DESCRIPTION
Fix broken Flux dependency on non-existent external-secrets-stores Kustomization.