### PR TITLE
fix(kyverno): system-cluster-critical for admission controller

### DIFF
--- a/kubernetes/apps/kyverno/kyverno/app/helmrelease.yaml
+++ b/kubernetes/apps/kyverno/kyverno/app/helmrelease.yaml
@@ -15,6 +15,7 @@ spec:
   values:
     admissionController:
       replicas: 1
+      priorityClassName: system-cluster-critical
       dnsConfig:
         options:
           - name: ndots


### PR DESCRIPTION
Admission controller pod Pending — insufficient resources after Policy Reporter addition. Elevates priority so it can preempt app workloads.