### PR TITLE
fix(kyverno): disable migrate-resources hook to unblock upgrade

### DIFF
--- a/kubernetes/apps/kyverno/kyverno/app/helmrelease.yaml
+++ b/kubernetes/apps/kyverno/kyverno/app/helmrelease.yaml
@@ -13,6 +13,9 @@ spec:
     remediation:
       retries: -1
   values:
+    crds:
+      migration:
+        enabled: false
     admissionController:
       replicas: 1
       priorityClassName: system-cluster-critical


### PR DESCRIPTION
Post-upgrade hook job unschedulable due to resource pressure.