### PR TITLE
fix(kyverno): disable policy-reporter-ui OIDC until provisioned

### DIFF
--- a/kubernetes/apps/kyverno/policy-reporter/app/helmrelease.yaml
+++ b/kubernetes/apps/kyverno/policy-reporter/app/helmrelease.yaml
@@ -21,17 +21,7 @@ spec:
     ui:
       enabled: true
       openIDConnect:
-        enabled: true
-        discoveryUrl: "https://auth.melotic.dev/application/o/policy-reporter/.well-known/openid-configuration"
-        callbackUrl: "https://policy-reporter.melotic.dev/callback"
-        clientId: ""
-        clientSecret: ""
-        secretRef: policy-reporter-oidc
-        scopes:
-          - openid
-          - email
-          - profile
-        groupClaim: groups
+        enabled: false
       httproute:
         enabled: true
         parentRefs:

--- a/kubernetes/apps/kyverno/policy-reporter/app/kustomization.yaml
+++ b/kubernetes/apps/kyverno/policy-reporter/app/kustomization.yaml
@@ -3,6 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./helmrepository.yaml


### PR DESCRIPTION
UI pod crashloops on missing secret. OIDC provider not yet created in Authentik.