### PR TITLE
fix(forejo): use in-cluster URL for OIDC discovery

### DIFF
--- a/kubernetes/apps/default/forejo/app/helmrelease.yaml
+++ b/kubernetes/apps/default/forejo/app/helmrelease.yaml
@@ -10,6 +10,12 @@ spec:
     name: forejo
   interval: 1h
   values:
+    global:
+      hostAliases:
+        - ip: "10.43.149.86"
+          hostnames:
+            - "sso.melotic.dev"
+
     service:
       ssh:
         type: LoadBalancer
@@ -71,7 +77,7 @@ spec:
         - name: authentik
           provider: openidConnect
           existingSecret: forejo-oidc
-          autoDiscoverUrl: "http://authentik-server.default.svc.cluster.local/application/o/forejo/.well-known/openid-configuration"
+          autoDiscoverUrl: "https://sso.melotic.dev/application/o/forejo/.well-known/openid-configuration"
           iconUrl: "https://sso.melotic.dev/static/dist/assets/icons/icon.png"
           scopes: "email profile"
           adminGroup: forejo-admins

--- a/kubernetes/apps/default/forejo/app/helmrelease.yaml
+++ b/kubernetes/apps/default/forejo/app/helmrelease.yaml
@@ -71,7 +71,7 @@ spec:
         - name: authentik
           provider: openidConnect
           existingSecret: forejo-oidc
-          autoDiscoverUrl: "https://sso.melotic.dev/application/o/forejo/.well-known/openid-configuration"
+          autoDiscoverUrl: "http://authentik-server.default.svc.cluster.local/application/o/forejo/.well-known/openid-configuration"
           iconUrl: "https://sso.melotic.dev/static/dist/assets/icons/icon.png"
           scopes: "email profile"
           adminGroup: forejo-admins


### PR DESCRIPTION
Use a startup-safe discovery URL for Forgejo SSO.