### PR TITLE
fix(resources): reduce resource overcommit

### DIFF
--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -20,6 +20,7 @@ spec:
           resources:
             requests:
               cpu: 100m
+              memory: 512Mi
             limits:
               memory: 2Gi
       envoyService:
@@ -54,6 +55,7 @@ spec:
           resources:
             requests:
               cpu: 100m
+              memory: 512Mi
             limits:
               memory: 2Gi
       envoyService:

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -22,6 +22,26 @@ spec:
           osd_pool_default_size: "3"
         mon:
           mon_data_avail_warn: "20"
+      # Override chart defaults that over-reserve small-cluster Ceph daemons.
+      resources:
+        mon:
+          requests:
+            cpu: 100m
+            memory: 1Gi
+          limits:
+            memory: 2Gi
+        mgr:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            memory: 1Gi
+        osd:
+          requests:
+            cpu: 250m
+            memory: 4Gi
+          limits:
+            memory: 4Gi
       cleanupPolicy:
         wipeDevicesFromOtherClusters: false
       crashCollector:


### PR DESCRIPTION
Right-size Envoy and Rook-Ceph resource requests to clear KubeCPUOvercommit and KubeMemoryOvercommit without changing Longhorn.

- Add explicit 512Mi memory requests to both EnvoyProxy deployments so memory requests no longer default to the 2Gi limits.
- Override Rook-Ceph mon/mgr/osd CPU requests while preserving existing memory requests/limits.
- Leave Longhorn manifests untouched.

Live alert math before the fix: CPU requests were 1.589 cores over HA-safe capacity and memory requests were 2,386,563,072 bytes over HA-safe capacity.

Supersedes #1148, which GitHub cannot reopen after the branch was force-pushed/recreated.