### PR TITLE
fix(talos): remove longhorn mount & enable secureboot on niobe

### DIFF
--- a/talos/patches/global/machine-mounts.yaml
+++ b/talos/patches/global/machine-mounts.yaml
@@ -1,13 +1,6 @@
 machine:
   kubelet:
     extraMounts:
-      - destination: /var/mnt/longhorn
-        type: bind
-        source: /var/mnt/longhorn
-        options:
-          - bind
-          - rshared
-          - rw
       - destination: /var/mnt/local-hostpath
         type: bind
         source: /var/mnt/local-hostpath

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -23,7 +23,7 @@ nodes:
     ipAddress: "10.60.85.10"
     installDisk: "/dev/nvme0n1"
     machineSpec:
-      secureboot: false
+      secureboot: true
     controlPlane: true
     userVolumes:
       - name: local-hostpath


### PR DESCRIPTION
- **fix(resources): right-size envoy and ceph mon/mgr/osd requests**
- **fix(resources): clarify ceph request override rationale**
- **fix(talos): remove longhorn mount & enable secureboot on niobe**
