### PR TITLE
fix(authentik): add grant_types to policy-reporter OAuth2 provider

### DIFF
--- a/kubernetes/apps/default/authentik/app/blueprints/policy-reporter.yaml
+++ b/kubernetes/apps/default/authentik/app/blueprints/policy-reporter.yaml
@@ -38,6 +38,9 @@ entries:
       redirect_uris:
         - url: "https://policy-reporter.melotic.dev/callback"
           matching_mode: strict
+      grant_types:
+        - authorization_code
+        - refresh_token
       property_mappings: *property_mappings
       signing_key: *signing_key
 


### PR DESCRIPTION
Policy Reporter OIDC login fails because the blueprint was missing explicit grant_types for the authorization_code flow.