### PR TITLE
fix(cert-manager): add image tags alongside digests

### DIFF
--- a/kubernetes/apps/cert-manager/cert-manager/app/helmrelease.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/helmrelease.yaml
@@ -17,18 +17,28 @@ spec:
       enabled: true
     replicaCount: 1
     image:
+      repository: quay.io/jetstack/cert-manager-controller
+      tag: v1.20.2
       digest: sha256:fe0623d7d04a382c888f03343a3a2da716e0d96ad3d5d790c0ebcbcb2a4329a5
     webhook:
       image:
+        repository: quay.io/jetstack/cert-manager-webhook
+        tag: v1.20.2
         digest: sha256:baf651128b9f05c426cbd5e60e2036bf382c99ca270f49d0757d6f7d2452f4e5
     cainjector:
       image:
+        repository: quay.io/jetstack/cert-manager-cainjector
+        tag: v1.20.2
         digest: sha256:6f5a644135887b2aa7d5cc145072fa56421560e3586ff1f184358022d490f4e1
     acmesolver:
       image:
+        repository: quay.io/jetstack/cert-manager-acmesolver
+        tag: v1.20.2
         digest: sha256:cfa55e9c3dcfc6a3cba97575748c1549b04a30fd14d88a2fcb9e2dddef415e2f
     startupapicheck:
       image:
+        repository: quay.io/jetstack/cert-manager-startupapicheck
+        tag: v1.20.2
         digest: sha256:4e2a69b4a0cc9627905bbeecf720f95d5153ca39cacdab923d2748e73556792b
     dns01RecursiveNameservers: https://1.1.1.1:443/dns-query,https://1.0.0.1:443/dns-query
     dns01RecursiveNameserversOnly: true


### PR DESCRIPTION
Add explicit image repository and tag fields alongside digests so Renovate can update them together and prevent chart/image drift.