### PR TITLE
feat(database): add CNPG Pooler and manual PodMonitors

### DIFF
--- a/kubernetes/apps/database/postgres/app/kustomization.yaml
+++ b/kubernetes/apps/database/postgres/app/kustomization.yaml
@@ -12,3 +12,6 @@ resources:
   - ./helmrelease.yaml
   - ./objectstore.yaml
   - ./scheduledbackup.yaml
+  - ./monitoring/cluster-podmonitor.yaml
+  - ./monitoring/pooler-podmonitor.yaml
+  - ./pooler/pooler-rw.yaml

--- a/kubernetes/apps/database/postgres/app/monitoring/cluster-podmonitor.yaml
+++ b/kubernetes/apps/database/postgres/app/monitoring/cluster-podmonitor.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/podmonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: postgres-cluster-instances
+spec:
+  jobLabel: cnpg-cluster
+  namespaceSelector:
+    matchNames:
+      - database
+  podMetricsEndpoints:
+    - port: metrics
+      honorLabels: true
+  selector:
+    matchLabels:
+      cnpg.io/cluster: postgres-cluster
+      cnpg.io/podRole: instance

--- a/kubernetes/apps/database/postgres/app/monitoring/pooler-podmonitor.yaml
+++ b/kubernetes/apps/database/postgres/app/monitoring/pooler-podmonitor.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/podmonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: postgres-cluster-pooler-rw
+spec:
+  jobLabel: cnpg-pooler
+  namespaceSelector:
+    matchNames:
+      - database
+  podMetricsEndpoints:
+    - port: metrics
+      honorLabels: true
+  selector:
+    matchLabels:
+      cnpg.io/poolerName: postgres-cluster-pooler-rw

--- a/kubernetes/apps/database/postgres/app/pooler/pooler-rw.yaml
+++ b/kubernetes/apps/database/postgres/app/pooler/pooler-rw.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/postgresql.cnpg.io/pooler_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: postgres-cluster-pooler-rw
+spec:
+  cluster:
+    name: postgres-cluster
+  instances: 3
+  type: rw
+  pgbouncer:
+    poolMode: transaction
+    parameters:
+      max_client_conn: "200"
+      default_pool_size: "20"
+      reserve_pool_size: "5"
+      reserve_pool_timeout: "3"
+      server_idle_timeout: "120"
+      server_lifetime: "3600"
+      query_wait_timeout: "30"
+      log_connections: "0"
+      log_disconnections: "0"
+  template:
+    metadata:
+      labels:
+        cnpg.io/poolerName: postgres-cluster-pooler-rw
+    spec:
+      priorityClassName: cluster-critical
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  cnpg.io/poolerName: postgres-cluster-pooler-rw
+      containers:
+        - name: pgbouncer
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi


### PR DESCRIPTION
## Summary
- add manual CNPG Cluster and Pooler PodMonitors under database/postgres
- add a CNPG RW transaction Pooler with three replicas and required anti-affinity
- wire the new resources into the postgres app kustomization while preserving the existing HelmRelease

## Validation
- mise exec -- flux-local test --enable-helm --all-namespaces --path kubernetes/flux/cluster -v --sources flux-system