### PR TITLE
feat(database/postgres): add explicit CNPG Cluster manifest

### DIFF
--- a/kubernetes/apps/database/postgres/app/cluster/cluster.yaml
+++ b/kubernetes/apps/database/postgres/app/cluster/cluster.yaml
@@ -1,0 +1,135 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/postgresql.cnpg.io/cluster_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  labels:
+    app.kubernetes.io/instance: postgres
+    app.kubernetes.io/name: cluster
+    app.kubernetes.io/part-of: cloudnative-pg
+  name: postgres-cluster
+spec:
+  affinity:
+    enablePodAntiAffinity: true
+    podAntiAffinityType: required
+    topologyKey: kubernetes.io/hostname
+  bootstrap:
+    pg_basebackup:
+      database: app
+      owner: app
+      secret:
+        name: psql-apps-cluster-app
+      source: pgBaseBackupSource
+  enablePDB: true
+  enableSuperuserAccess: true
+  externalClusters:
+    - connectionParameters:
+        dbname: postgres
+        host: psql-apps-cluster-rw.default.svc.cluster.local
+        port: "5432"
+        sslmode: verify-full
+        user: streaming_replica
+      name: pgBaseBackupSource
+      sslCert:
+        key: tls.crt
+        name: psql-apps-cluster-replication
+      sslKey:
+        key: tls.key
+        name: psql-apps-cluster-replication
+      sslRootCert:
+        key: ca.crt
+        name: psql-apps-cluster-ca
+  failoverDelay: 0
+  imageCatalogRef:
+    apiGroup: postgresql.cnpg.io
+    kind: ClusterImageCatalog
+    major: 17
+    name: postgresql-minimal-trixie
+  imagePullPolicy: IfNotPresent
+  instances: 3
+  logLevel: info
+  managed:
+    roles:
+      - connectionLimit: -1
+        ensure: present
+        inRoles:
+          - pg_monitor
+          - pg_signal_backend
+        inherit: true
+        login: true
+        name: app
+        passwordSecret:
+          name: postgres-cluster-app
+  maxSyncReplicas: 0
+  minSyncReplicas: 0
+  monitoring:
+    customQueriesConfigMap:
+      - key: queries
+        name: cnpg-default-monitoring
+    disableDefaultQueries: false
+    enablePodMonitor: false
+  plugins:
+    - enabled: true
+      isWALArchiver: true
+      name: barman-cloud.cloudnative-pg.io
+      parameters:
+        barmanObjectName: azure-blob-store
+  postgresGID: 26
+  postgresUID: 26
+  postgresql:
+    parameters:
+      archive_mode: "on"
+      archive_timeout: 5min
+      dynamic_shared_memory_type: posix
+      full_page_writes: "on"
+      log_destination: csvlog
+      log_directory: /controller/log
+      log_filename: postgres
+      log_rotation_age: "0"
+      log_rotation_size: "0"
+      log_truncate_on_rotation: "false"
+      logging_collector: "on"
+      max_parallel_workers: "32"
+      max_replication_slots: "32"
+      max_worker_processes: "32"
+      shared_memory_type: mmap
+      shared_preload_libraries: ""
+      ssl_max_protocol_version: TLSv1.3
+      ssl_min_protocol_version: TLSv1.3
+      wal_keep_size: 512MB
+      wal_level: logical
+      wal_log_hints: "on"
+      wal_receiver_timeout: 5s
+      wal_sender_timeout: 5s
+    syncReplicaElectionConstraint:
+      enabled: false
+  primaryUpdateMethod: switchover
+  primaryUpdateStrategy: unsupervised
+  priorityClassName: cluster-critical
+  probes:
+    liveness:
+      isolationCheck:
+        connectionTimeout: 1000
+        enabled: true
+        requestTimeout: 1000
+  replicationSlots:
+    highAvailability:
+      enabled: true
+      slotPrefix: _cnpg_
+    synchronizeReplicas:
+      enabled: true
+    updateInterval: 30
+  resources:
+    limits:
+      memory: 1Gi
+    requests:
+      cpu: 100m
+      memory: 768Mi
+  smartShutdownTimeout: 180
+  startDelay: 3600
+  stopDelay: 1800
+  storage:
+    resizeInUseVolumes: true
+    size: 16Gi
+    storageClass: openebs-hostpath
+  switchoverDelay: 3600


### PR DESCRIPTION
## Summary
- add an explicit CNPG Cluster manifest copied from the scrubbed live postgres-cluster spec
- keep the manifest unreferenced by the postgres app kustomization for the Plan 14-03 adoption cutover
- preserve live bootstrap/externalClusters, managed.roles, monitoring, plugin, storage, topology, and PostgreSQL parameters exactly

## Validation
- canonical live-spec diff is empty
- kubeconform accepted the Cluster schema
- kustomize build kubernetes/apps/database/postgres/app
- flux-local test --enable-helm --all-namespaces --path kubernetes/flux/cluster -v --sources flux-system