### PR TITLE
fix(database): refine CNPG monitoring boundary

### DIFF
--- a/kubernetes/apps/database/postgres/app/helmrelease.yaml
+++ b/kubernetes/apps/database/postgres/app/helmrelease.yaml
@@ -61,6 +61,10 @@ spec:
       instances: 3
       monitoring:
         enabled: true
+        podMonitor:
+          enabled: false
+        prometheusRule:
+          enabled: true
       resources:
         requests:
           cpu: 100m

--- a/kubernetes/components/cnpg-database/externalsecret.yaml
+++ b/kubernetes/components/cnpg-database/externalsecret.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: "${APP}-postgres"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: "${APP}-postgres"
+    creationPolicy: Owner
+    template:
+      type: kubernetes.io/basic-auth
+      data:
+        dbname: "${PG_DATABASE}"
+        host: "${PG_HOST}"
+        jdbc-uri: "jdbc:postgresql://${PG_HOST}:5432/${PG_DATABASE}?password={{ .password }}&user=${PG_USER}"
+        password: "{{ .password }}"
+        pgpass: "${PG_HOST}:5432:${PG_DATABASE}:${PG_USER}:{{ .password }}"
+        port: "5432"
+        uri: "postgresql://${PG_USER}:{{ .password }}@${PG_HOST}:5432/${PG_DATABASE}"
+        user: "${PG_USER}"
+        username: "${PG_USER}"
+  dataFrom:
+    - extract:
+        key: "${ONEPASSWORD_ITEM}"

--- a/kubernetes/components/cnpg-database/externalsecret.yaml
+++ b/kubernetes/components/cnpg-database/externalsecret.yaml
@@ -5,6 +5,8 @@ kind: ExternalSecret
 metadata:
   name: "${APP}-postgres"
 spec:
+  refreshPolicy: Periodic
+  refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword
@@ -13,6 +15,7 @@ spec:
     creationPolicy: Owner
     template:
       engineVersion: v2
+      mergePolicy: Replace
       type: kubernetes.io/basic-auth
       data:
         dbname: "${PG_DATABASE:=${APP}}"

--- a/kubernetes/components/cnpg-database/externalsecret.yaml
+++ b/kubernetes/components/cnpg-database/externalsecret.yaml
@@ -14,15 +14,15 @@ spec:
     template:
       type: kubernetes.io/basic-auth
       data:
-        dbname: "${PG_DATABASE}"
-        host: "${PG_HOST}"
-        jdbc-uri: "jdbc:postgresql://${PG_HOST}:5432/${PG_DATABASE}?password={{ .password }}&user=${PG_USER}"
+        dbname: "${PG_DATABASE:=${APP}}"
+        host: "${PG_HOST:=postgres-cluster-rw.database.svc.cluster.local}"
+        jdbc-uri: "jdbc:postgresql://${PG_HOST:=postgres-cluster-rw.database.svc.cluster.local}:5432/${PG_DATABASE:=${APP}}?password={{ .password }}&user=${PG_USER:=${APP}}"
         password: "{{ .password }}"
-        pgpass: "${PG_HOST}:5432:${PG_DATABASE}:${PG_USER}:{{ .password }}"
+        pgpass: "${PG_HOST:=postgres-cluster-rw.database.svc.cluster.local}:5432:${PG_DATABASE:=${APP}}:${PG_USER:=${APP}}:{{ .password }}"
         port: "5432"
-        uri: "postgresql://${PG_USER}:{{ .password }}@${PG_HOST}:5432/${PG_DATABASE}"
-        user: "${PG_USER}"
-        username: "${PG_USER}"
+        uri: "postgresql://${PG_USER:=${APP}}:{{ .password }}@${PG_HOST:=postgres-cluster-rw.database.svc.cluster.local}:5432/${PG_DATABASE:=${APP}}"
+        user: "${PG_USER:=${APP}}"
+        username: "${PG_USER:=${APP}}"
   dataFrom:
     - extract:
-        key: "${ONEPASSWORD_ITEM}"
+        key: "${ONEPASSWORD_ITEM:=${APP}-postgres}"

--- a/kubernetes/components/cnpg-database/externalsecret.yaml
+++ b/kubernetes/components/cnpg-database/externalsecret.yaml
@@ -12,15 +12,16 @@ spec:
     name: "${APP}-postgres"
     creationPolicy: Owner
     template:
+      engineVersion: v2
       type: kubernetes.io/basic-auth
       data:
         dbname: "${PG_DATABASE:=${APP}}"
         host: "${PG_HOST:=postgres-cluster-rw.database.svc.cluster.local}"
-        jdbc-uri: "jdbc:postgresql://${PG_HOST:=postgres-cluster-rw.database.svc.cluster.local}:5432/${PG_DATABASE:=${APP}}?password={{ .password }}&user=${PG_USER:=${APP}}"
+        jdbc-uri: 'jdbc:postgresql://${PG_HOST:=postgres-cluster-rw.database.svc.cluster.local}:5432/${PG_DATABASE:=${APP}}?user=${PG_USER:=${APP}}&password={{ .password | urlquery }}'
         password: "{{ .password }}"
-        pgpass: "${PG_HOST:=postgres-cluster-rw.database.svc.cluster.local}:5432:${PG_DATABASE:=${APP}}:${PG_USER:=${APP}}:{{ .password }}"
+        pgpass: '${PG_HOST:=postgres-cluster-rw.database.svc.cluster.local}:5432:${PG_DATABASE:=${APP}}:${PG_USER:=${APP}}:{{ .password | replace "\\" "\\\\" | replace ":" "\\:" }}'
         port: "5432"
-        uri: "postgresql://${PG_USER:=${APP}}:{{ .password }}@${PG_HOST:=postgres-cluster-rw.database.svc.cluster.local}:5432/${PG_DATABASE:=${APP}}"
+        uri: 'postgresql://${PG_USER:=${APP}}:{{ .password | urlquery }}@${PG_HOST:=postgres-cluster-rw.database.svc.cluster.local}:5432/${PG_DATABASE:=${APP}}'
         user: "${PG_USER:=${APP}}"
         username: "${PG_USER:=${APP}}"
   dataFrom:

--- a/kubernetes/components/cnpg-database/kustomization.yaml
+++ b/kubernetes/components/cnpg-database/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./externalsecret.yaml


### PR DESCRIPTION
## Summary
- disable only the chart-rendered CNPG Cluster PodMonitor while preserving chart PrometheusRules
- add a non-consumed cnpg-database Component with sane Flux substitution defaults
- escape generated Postgres connection strings and make ESO sync/merge behavior explicit

## Validation
- mise exec -- kustomize build kubernetes/apps/database/postgres/app
- mise exec -- kustomize build kubernetes/components/cnpg-database
- mise exec -- flux-local test --enable-helm --all-namespaces --path kubernetes/flux/cluster -v --sources flux-system