### PR TITLE
feat(database): add Seerr postgres identity scaffold

### DIFF
--- a/kubernetes/apps/database/postgres/app/databases/seerr.yaml
+++ b/kubernetes/apps/database/postgres/app/databases/seerr.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/postgresql.cnpg.io/database_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: seerr
+spec:
+  name: seerr
+  owner: seerr
+  cluster:
+    name: postgres-cluster

--- a/kubernetes/apps/database/postgres/app/helmrelease.yaml
+++ b/kubernetes/apps/database/postgres/app/helmrelease.yaml
@@ -80,6 +80,11 @@ spec:
             - pg_signal_backend
           passwordSecret:
             name: postgres-cluster-app
+        - name: seerr
+          ensure: present
+          login: true
+          passwordSecret:
+            name: postgres-user-seerr
       storage:
         size: 16Gi
         storageClass: openebs-hostpath

--- a/kubernetes/apps/database/postgres/app/kustomization.yaml
+++ b/kubernetes/apps/database/postgres/app/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ./databases/forejo.yaml
   - ./databases/gitlab.yaml
   - ./databases/paperless.yaml
+  - ./databases/seerr.yaml
   - ./externalsecret.yaml
   - ./externalsecret-backup.yaml
   - ./helmrelease.yaml
@@ -15,3 +16,4 @@ resources:
   - ./monitoring/cluster-podmonitor.yaml
   - ./monitoring/pooler-podmonitor.yaml
   - ./pooler/pooler-rw.yaml
+  - ./roles/seerr.yaml

--- a/kubernetes/apps/database/postgres/app/roles/seerr.yaml
+++ b/kubernetes/apps/database/postgres/app/roles/seerr.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: postgres-user-seerr
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: postgres-user-seerr
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      mergePolicy: Replace
+      type: kubernetes.io/basic-auth
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+      data:
+        user: seerr
+        username: seerr
+        password: "{{ .password }}"
+  dataFrom:
+    - extract:
+        key: postgres-seerr

--- a/kubernetes/apps/default/seerr/ks.yaml
+++ b/kubernetes/apps/default/seerr/ks.yaml
@@ -11,7 +11,10 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
+    - ../../../../components/cnpg-database
   dependsOn:
+    - name: postgres
+      namespace: database
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: volsync
@@ -20,6 +23,7 @@ spec:
   postBuild:
     substitute:
       APP: seerr
+      PG_HOST: postgres-cluster-rw.database.svc.cluster.local
       VOLSYNC_CAPACITY: 5Gi
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
## Summary
- add postgres-user-seerr ExternalSecret backed by the postgres-seerr 1Password item
- add CNPG managed role seerr without inherited broad roles
- declare Database/seerr with owner seerr and wire Seerr to the cnpg-database Component
- keep the Seerr workload on postgres-cluster-app until live ESO/CNPG readiness and SQL ownership migration pass

## Validation
- mise exec -- kustomize build kubernetes/apps/database/postgres/app
- mise exec -- kustomize build kubernetes/apps/default/seerr/app
- mise exec -- flux-local test --enable-helm --all-namespaces --path kubernetes/flux/cluster -v --sources flux-system