### PR TITLE
fix(database): align Seerr postgres item naming

### DIFF
--- a/kubernetes/apps/database/postgres/app/roles/seerr.yaml
+++ b/kubernetes/apps/database/postgres/app/roles/seerr.yaml
@@ -26,4 +26,4 @@ spec:
         password: "{{ .password }}"
   dataFrom:
     - extract:
-        key: postgres-seerr
+        key: seerr-postgres


### PR DESCRIPTION
## Summary
- use the cnpg-database Component default item name seerr-postgres for the central Seerr role Secret
- keep cnpg.io/reload on the CNPG-consumed postgres-user-seerr target Secret
- rely on Seerr's existing Reloader annotation for app-local Secret changes

## Validation
- mise exec -- kustomize build kubernetes/apps/database/postgres/app
- mise exec -- kustomize build kubernetes/apps/default/seerr/app
- mise exec -- flux-local test --enable-helm --all-namespaces --path kubernetes/flux/cluster -v --sources flux-system