### PR TITLE
fix(database): declare Seerr public schema owner

### DIFF
--- a/kubernetes/apps/database/postgres/app/databases/seerr.yaml
+++ b/kubernetes/apps/database/postgres/app/databases/seerr.yaml
@@ -9,3 +9,6 @@ spec:
   owner: seerr
   cluster:
     name: postgres-cluster
+  schemas:
+    - name: public
+      owner: seerr


### PR DESCRIPTION
## Summary
- add CNPG Database.spec.schemas for Seerr public schema ownership
- make fresh bootstrap declare database + schema ownership through GitOps
- keep existing app-owned table migration as a brownfield data migration concern, not a bootstrap requirement

## Validation
- mise exec -- kustomize build kubernetes/apps/database/postgres/app
- mise exec -- kustomize build kubernetes/apps/default/seerr/app
- mise exec -- flux-local test --enable-helm --all-namespaces --path kubernetes/flux/cluster -v --sources flux-system