### PR TITLE
fix(seerr): use isolated postgres credentials

### DIFF
--- a/kubernetes/apps/default/seerr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/seerr/app/helmrelease.yaml
@@ -20,13 +20,13 @@ spec:
               repository: ghcr.io/seerr-team/seerr
               tag: v3.2.0@sha256:c4cbd5121236ac2f70a843a0b920b68a27976be57917555f1c45b08a1e6b2aad
             env:
-              DB_HOST: postgres-cluster-rw.database.svc.cluster.local
-              DB_NAME: seerr
+              DB_HOST: ${PG_HOST}
+              DB_NAME: ${PG_DATABASE}
               DB_TYPE: postgres
               DB_USER:
                 secretKeyRef:
-                  name: &pgsecret postgres-cluster-app
-                  key: user
+                  name: &pgsecret seerr-postgres
+                  key: username
               DB_PASS:
                 secretKeyRef:
                   name: *pgsecret

--- a/kubernetes/apps/default/seerr/ks.yaml
+++ b/kubernetes/apps/default/seerr/ks.yaml
@@ -23,6 +23,7 @@ spec:
   postBuild:
     substitute:
       APP: seerr
+      PG_DATABASE: seerr
       PG_HOST: postgres-cluster-rw.database.svc.cluster.local
       VOLSYNC_CAPACITY: 5Gi
   sourceRef:


### PR DESCRIPTION
## Summary
- switch Seerr from postgres-cluster-app to seerr-postgres
- keep Seerr on direct RW via PG_HOST substitution
- preserve DB_TYPE postgres and existing app settings

## Validation
- mise exec -- kustomize build kubernetes/apps/default/seerr/app
- mise exec -- flux-local test --enable-helm --all-namespaces --path kubernetes/flux/cluster -v --sources flux-system