### PR TITLE
feat(database): add media postgres identity scaffold

### DIFF
--- a/kubernetes/apps/database/postgres/app/databases/lidarr.yaml
+++ b/kubernetes/apps/database/postgres/app/databases/lidarr.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/postgresql.cnpg.io/database_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: lidarr
+spec:
+  name: lidarr
+  owner: lidarr
+  cluster:
+    name: postgres-cluster
+  schemas:
+    - name: public
+      owner: lidarr

--- a/kubernetes/apps/database/postgres/app/databases/prowlarr.yaml
+++ b/kubernetes/apps/database/postgres/app/databases/prowlarr.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/postgresql.cnpg.io/database_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: prowlarr
+spec:
+  name: prowlarr
+  owner: prowlarr
+  cluster:
+    name: postgres-cluster
+  schemas:
+    - name: public
+      owner: prowlarr

--- a/kubernetes/apps/database/postgres/app/databases/radarr.yaml
+++ b/kubernetes/apps/database/postgres/app/databases/radarr.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/postgresql.cnpg.io/database_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: radarr
+spec:
+  name: radarr
+  owner: radarr
+  cluster:
+    name: postgres-cluster
+  schemas:
+    - name: public
+      owner: radarr

--- a/kubernetes/apps/database/postgres/app/databases/sonarr.yaml
+++ b/kubernetes/apps/database/postgres/app/databases/sonarr.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/postgresql.cnpg.io/database_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: sonarr
+spec:
+  name: sonarr
+  owner: sonarr
+  cluster:
+    name: postgres-cluster
+  schemas:
+    - name: public
+      owner: sonarr

--- a/kubernetes/apps/database/postgres/app/helmrelease.yaml
+++ b/kubernetes/apps/database/postgres/app/helmrelease.yaml
@@ -85,6 +85,26 @@ spec:
           login: true
           passwordSecret:
             name: postgres-user-seerr
+        - name: sonarr
+          ensure: present
+          login: true
+          passwordSecret:
+            name: postgres-user-sonarr
+        - name: radarr
+          ensure: present
+          login: true
+          passwordSecret:
+            name: postgres-user-radarr
+        - name: lidarr
+          ensure: present
+          login: true
+          passwordSecret:
+            name: postgres-user-lidarr
+        - name: prowlarr
+          ensure: present
+          login: true
+          passwordSecret:
+            name: postgres-user-prowlarr
       storage:
         size: 16Gi
         storageClass: openebs-hostpath

--- a/kubernetes/apps/database/postgres/app/kustomization.yaml
+++ b/kubernetes/apps/database/postgres/app/kustomization.yaml
@@ -6,8 +6,12 @@ resources:
   - ./databases/harbor.yaml
   - ./databases/forejo.yaml
   - ./databases/gitlab.yaml
+  - ./databases/lidarr.yaml
   - ./databases/paperless.yaml
+  - ./databases/prowlarr.yaml
+  - ./databases/radarr.yaml
   - ./databases/seerr.yaml
+  - ./databases/sonarr.yaml
   - ./externalsecret.yaml
   - ./externalsecret-backup.yaml
   - ./helmrelease.yaml
@@ -16,4 +20,8 @@ resources:
   - ./monitoring/cluster-podmonitor.yaml
   - ./monitoring/pooler-podmonitor.yaml
   - ./pooler/pooler-rw.yaml
+  - ./roles/lidarr.yaml
+  - ./roles/prowlarr.yaml
+  - ./roles/radarr.yaml
   - ./roles/seerr.yaml
+  - ./roles/sonarr.yaml

--- a/kubernetes/apps/database/postgres/app/roles/lidarr.yaml
+++ b/kubernetes/apps/database/postgres/app/roles/lidarr.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: postgres-user-lidarr
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: postgres-user-lidarr
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      mergePolicy: Replace
+      type: kubernetes.io/basic-auth
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+      data:
+        user: lidarr
+        username: lidarr
+        password: "{{ .password }}"
+  dataFrom:
+    - extract:
+        key: lidarr-postgres

--- a/kubernetes/apps/database/postgres/app/roles/prowlarr.yaml
+++ b/kubernetes/apps/database/postgres/app/roles/prowlarr.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: postgres-user-prowlarr
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: postgres-user-prowlarr
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      mergePolicy: Replace
+      type: kubernetes.io/basic-auth
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+      data:
+        user: prowlarr
+        username: prowlarr
+        password: "{{ .password }}"
+  dataFrom:
+    - extract:
+        key: prowlarr-postgres

--- a/kubernetes/apps/database/postgres/app/roles/radarr.yaml
+++ b/kubernetes/apps/database/postgres/app/roles/radarr.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: postgres-user-radarr
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: postgres-user-radarr
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      mergePolicy: Replace
+      type: kubernetes.io/basic-auth
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+      data:
+        user: radarr
+        username: radarr
+        password: "{{ .password }}"
+  dataFrom:
+    - extract:
+        key: radarr-postgres

--- a/kubernetes/apps/database/postgres/app/roles/sonarr.yaml
+++ b/kubernetes/apps/database/postgres/app/roles/sonarr.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: postgres-user-sonarr
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: postgres-user-sonarr
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      mergePolicy: Replace
+      type: kubernetes.io/basic-auth
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+      data:
+        user: sonarr
+        username: sonarr
+        password: "{{ .password }}"
+  dataFrom:
+    - extract:
+        key: sonarr-postgres

--- a/kubernetes/apps/default/lidarr/ks.yaml
+++ b/kubernetes/apps/default/lidarr/ks.yaml
@@ -11,7 +11,10 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
+    - ../../../../components/cnpg-database
   dependsOn:
+    - name: postgres
+      namespace: database
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: volsync
@@ -20,6 +23,8 @@ spec:
   postBuild:
     substitute:
       APP: lidarr
+      PG_DATABASE: lidarr
+      PG_HOST: postgres-cluster-rw.database.svc.cluster.local
       VOLSYNC_CAPACITY: 16Gi
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/default/prowlarr/ks.yaml
+++ b/kubernetes/apps/default/prowlarr/ks.yaml
@@ -11,7 +11,10 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
+    - ../../../../components/cnpg-database
   dependsOn:
+    - name: postgres
+      namespace: database
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: volsync
@@ -20,6 +23,8 @@ spec:
   postBuild:
     substitute:
       APP: prowlarr
+      PG_DATABASE: prowlarr
+      PG_HOST: postgres-cluster-rw.database.svc.cluster.local
       VOLSYNC_CAPACITY: 5Gi
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/default/radarr/ks.yaml
+++ b/kubernetes/apps/default/radarr/ks.yaml
@@ -11,7 +11,10 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
+    - ../../../../components/cnpg-database
   dependsOn:
+    - name: postgres
+      namespace: database
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: volsync
@@ -20,6 +23,8 @@ spec:
   postBuild:
     substitute:
       APP: radarr
+      PG_DATABASE: radarr
+      PG_HOST: postgres-cluster-rw.database.svc.cluster.local
       VOLSYNC_CAPACITY: 5Gi
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/default/sonarr/ks.yaml
+++ b/kubernetes/apps/default/sonarr/ks.yaml
@@ -11,7 +11,10 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
+    - ../../../../components/cnpg-database
   dependsOn:
+    - name: postgres
+      namespace: database
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: volsync
@@ -20,6 +23,8 @@ spec:
   postBuild:
     substitute:
       APP: sonarr
+      PG_DATABASE: sonarr
+      PG_HOST: postgres-cluster-rw.database.svc.cluster.local
       VOLSYNC_CAPACITY: 5Gi
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
## Summary
- add per-app CNPG roles and role password Secret sources for Sonarr/Radarr/Lidarr/Prowlarr
- declare media app Database CRDs with public schema owners
- wire media app Kustomizations to cnpg-database and postgres dependency
- keep workloads on postgres-cluster-app until per-app brownfield ownership and smoke gates pass

## Validation
- targeted kustomize builds for postgres and each media app passed locally
- full flux-local validation runs in CI