### PR TITLE
fix(sonarr): use isolated postgres credentials

### DIFF
--- a/kubernetes/apps/default/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/sonarr/app/helmrelease.yaml
@@ -26,12 +26,12 @@ spec:
               SONARR__AUTH__REQUIRED: DisabledForLocalAddresses
               SONARR__LOG__DBENABLED: "False"
               SONARR__LOG__LEVEL: info
-              SONARR__POSTGRES__HOST: postgres-cluster-rw.database.svc.cluster.local
-              SONARR__POSTGRES__MAINDB: sonarr
+              SONARR__POSTGRES__HOST: ${PG_HOST}
+              SONARR__POSTGRES__MAINDB: ${PG_DATABASE}
               SONARR__POSTGRES__USER:
                 secretKeyRef:
-                  name: &pgsecret postgres-cluster-app
-                  key: user
+                  name: &pgsecret sonarr-postgres
+                  key: username
               SONARR__POSTGRES__PASSWORD:
                 secretKeyRef:
                   name: *pgsecret


### PR DESCRIPTION
## Summary
- switch Sonarr from postgres-cluster-app to sonarr-postgres
- keep Sonarr on direct RW via PG_HOST substitution
- preserve database name through PG_DATABASE substitution

## Validation
- static checks passed locally
- full flux-local validation runs in CI