### PR TITLE
fix(radarr): use isolated postgres credentials

### DIFF
--- a/kubernetes/apps/default/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/radarr/app/helmrelease.yaml
@@ -26,12 +26,12 @@ spec:
               RADARR__AUTH__REQUIRED: DisabledForLocalAddresses
               RADARR__LOG__DBENABLED: "False"
               RADARR__LOG__LEVEL: info
-              RADARR__POSTGRES__HOST: postgres-cluster-rw.database.svc.cluster.local
-              RADARR__POSTGRES__MAINDB: radarr
+              RADARR__POSTGRES__HOST: ${PG_HOST}
+              RADARR__POSTGRES__MAINDB: ${PG_DATABASE}
               RADARR__POSTGRES__USER:
                 secretKeyRef:
-                  name: &pgsecret postgres-cluster-app
-                  key: user
+                  name: &pgsecret radarr-postgres
+                  key: username
               RADARR__POSTGRES__PASSWORD:
                 secretKeyRef:
                   name: *pgsecret


### PR DESCRIPTION
## Summary
- switch Radarr from postgres-cluster-app to radarr-postgres
- keep Radarr on direct RW via PG_HOST substitution
- preserve database name through PG_DATABASE substitution

## Validation
- static checks passed locally
- full flux-local validation runs in CI