### PR TITLE
feat(database): add varied postgres identity scaffold

### DIFF
--- a/kubernetes/apps/database/postgres/app/databases/atuin.yaml
+++ b/kubernetes/apps/database/postgres/app/databases/atuin.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/postgresql.cnpg.io/database_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: atuin
+spec:
+  name: atuin
+  owner: atuin
+  cluster:
+    name: postgres-cluster
+  schemas:
+    - name: public
+      owner: atuin

--- a/kubernetes/apps/database/postgres/app/databases/authentik.yaml
+++ b/kubernetes/apps/database/postgres/app/databases/authentik.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/postgresql.cnpg.io/database_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: authentik
+spec:
+  name: authentik
+  owner: authentik
+  cluster:
+    name: postgres-cluster
+  schemas:
+    - name: public
+      owner: authentik

--- a/kubernetes/apps/database/postgres/app/databases/forejo.yaml
+++ b/kubernetes/apps/database/postgres/app/databases/forejo.yaml
@@ -5,6 +5,9 @@ metadata:
   name: forejo
 spec:
   name: forejo
-  owner: app
+  owner: forejo
   cluster:
     name: postgres-cluster
+  schemas:
+    - name: public
+      owner: forejo

--- a/kubernetes/apps/database/postgres/app/databases/harbor.yaml
+++ b/kubernetes/apps/database/postgres/app/databases/harbor.yaml
@@ -5,6 +5,9 @@ metadata:
   name: harbor
 spec:
   name: harbor
-  owner: app
+  owner: harbor
   cluster:
     name: postgres-cluster
+  schemas:
+    - name: public
+      owner: harbor

--- a/kubernetes/apps/database/postgres/app/databases/paperless.yaml
+++ b/kubernetes/apps/database/postgres/app/databases/paperless.yaml
@@ -5,6 +5,9 @@ metadata:
   name: paperless
 spec:
   name: paperless
-  owner: app
+  owner: paperless
   cluster:
     name: postgres-cluster
+  schemas:
+    - name: public
+      owner: paperless

--- a/kubernetes/apps/database/postgres/app/helmrelease.yaml
+++ b/kubernetes/apps/database/postgres/app/helmrelease.yaml
@@ -105,6 +105,31 @@ spec:
           login: true
           passwordSecret:
             name: postgres-user-prowlarr
+        - name: atuin
+          ensure: present
+          login: true
+          passwordSecret:
+            name: postgres-user-atuin
+        - name: authentik
+          ensure: present
+          login: true
+          passwordSecret:
+            name: postgres-user-authentik
+        - name: harbor
+          ensure: present
+          login: true
+          passwordSecret:
+            name: postgres-user-harbor
+        - name: forejo
+          ensure: present
+          login: true
+          passwordSecret:
+            name: postgres-user-forejo
+        - name: paperless
+          ensure: present
+          login: true
+          passwordSecret:
+            name: postgres-user-paperless
       storage:
         size: 16Gi
         storageClass: openebs-hostpath

--- a/kubernetes/apps/database/postgres/app/kustomization.yaml
+++ b/kubernetes/apps/database/postgres/app/kustomization.yaml
@@ -3,6 +3,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./databases/atuin.yaml
+  - ./databases/authentik.yaml
   - ./databases/harbor.yaml
   - ./databases/forejo.yaml
   - ./databases/gitlab.yaml
@@ -20,7 +22,12 @@ resources:
   - ./monitoring/cluster-podmonitor.yaml
   - ./monitoring/pooler-podmonitor.yaml
   - ./pooler/pooler-rw.yaml
+  - ./roles/atuin.yaml
+  - ./roles/authentik.yaml
+  - ./roles/forejo.yaml
+  - ./roles/harbor.yaml
   - ./roles/lidarr.yaml
+  - ./roles/paperless.yaml
   - ./roles/prowlarr.yaml
   - ./roles/radarr.yaml
   - ./roles/seerr.yaml

--- a/kubernetes/apps/database/postgres/app/roles/atuin.yaml
+++ b/kubernetes/apps/database/postgres/app/roles/atuin.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: postgres-user-atuin
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: postgres-user-atuin
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      mergePolicy: Replace
+      type: kubernetes.io/basic-auth
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+      data:
+        user: atuin
+        username: atuin
+        password: "{{ .password }}"
+  dataFrom:
+    - extract:
+        key: atuin-postgres

--- a/kubernetes/apps/database/postgres/app/roles/authentik.yaml
+++ b/kubernetes/apps/database/postgres/app/roles/authentik.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: postgres-user-authentik
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: postgres-user-authentik
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      mergePolicy: Replace
+      type: kubernetes.io/basic-auth
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+      data:
+        user: authentik
+        username: authentik
+        password: "{{ .password }}"
+  dataFrom:
+    - extract:
+        key: authentik-postgres

--- a/kubernetes/apps/database/postgres/app/roles/forejo.yaml
+++ b/kubernetes/apps/database/postgres/app/roles/forejo.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: postgres-user-forejo
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: postgres-user-forejo
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      mergePolicy: Replace
+      type: kubernetes.io/basic-auth
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+      data:
+        user: forejo
+        username: forejo
+        password: "{{ .password }}"
+  dataFrom:
+    - extract:
+        key: forejo-postgres

--- a/kubernetes/apps/database/postgres/app/roles/harbor.yaml
+++ b/kubernetes/apps/database/postgres/app/roles/harbor.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: postgres-user-harbor
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: postgres-user-harbor
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      mergePolicy: Replace
+      type: kubernetes.io/basic-auth
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+      data:
+        user: harbor
+        username: harbor
+        password: "{{ .password }}"
+  dataFrom:
+    - extract:
+        key: harbor-postgres

--- a/kubernetes/apps/database/postgres/app/roles/paperless.yaml
+++ b/kubernetes/apps/database/postgres/app/roles/paperless.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: postgres-user-paperless
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: postgres-user-paperless
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      mergePolicy: Replace
+      type: kubernetes.io/basic-auth
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+      data:
+        user: paperless
+        username: paperless
+        password: "{{ .password }}"
+  dataFrom:
+    - extract:
+        key: paperless-postgres

--- a/kubernetes/apps/default/atuin/ks.yaml
+++ b/kubernetes/apps/default/atuin/ks.yaml
@@ -11,7 +11,10 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
+    - ../../../../components/cnpg-database
   dependsOn:
+    - name: postgres
+      namespace: database
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: volsync
@@ -20,6 +23,8 @@ spec:
   postBuild:
     substitute:
       APP: atuin
+      PG_DATABASE: atuin
+      PG_HOST: postgres-cluster-rw.database.svc.cluster.local
       VOLSYNC_CAPACITY: 5Gi
       VOLSYNC_PUID: "1000"
       VOLSYNC_PGID: "1000"

--- a/kubernetes/apps/default/authentik/ks.yaml
+++ b/kubernetes/apps/default/authentik/ks.yaml
@@ -9,7 +9,17 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/cnpg-database
+  dependsOn:
+    - name: postgres
+      namespace: database
   path: ./kubernetes/apps/default/authentik/app
+  postBuild:
+    substitute:
+      APP: authentik
+      PG_DATABASE: authentik
+      PG_HOST: postgres-cluster-rw.database.svc.cluster.local
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/default/forejo/ks.yaml
+++ b/kubernetes/apps/default/forejo/ks.yaml
@@ -11,6 +11,7 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
+    - ../../../../components/cnpg-database
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
@@ -22,6 +23,8 @@ spec:
   postBuild:
     substitute:
       APP: forejo
+      PG_DATABASE: forejo
+      PG_HOST: postgres-cluster-rw.database.svc.cluster.local
       VOLSYNC_CAPACITY: 25Gi
       VOLSYNC_PUID: "1000"
       VOLSYNC_PGID: "1000"

--- a/kubernetes/apps/default/harbor/ks.yaml
+++ b/kubernetes/apps/default/harbor/ks.yaml
@@ -9,10 +9,19 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/cnpg-database
   dependsOn:
+    - name: postgres
+      namespace: database
     - name: rook-ceph-cluster
       namespace: rook-ceph
   path: ./kubernetes/apps/default/harbor/app
+  postBuild:
+    substitute:
+      APP: harbor
+      PG_DATABASE: harbor
+      PG_HOST: postgres-cluster-rw.database.svc.cluster.local
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/default/paperless-ngx/ks.yaml
+++ b/kubernetes/apps/default/paperless-ngx/ks.yaml
@@ -11,8 +11,11 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
+    - ../../../../components/cnpg-database
   dependsOn:
     - name: dragonfly
+      namespace: database
+    - name: postgres
       namespace: database
     - name: rook-ceph-cluster
       namespace: rook-ceph
@@ -22,6 +25,10 @@ spec:
   postBuild:
     substitute:
       APP: paperless-ngx
+      ONEPASSWORD_ITEM: paperless-postgres
+      PG_DATABASE: paperless
+      PG_HOST: postgres-cluster-rw.database.svc.cluster.local
+      PG_USER: paperless
       VOLSYNC_CAPACITY: 5Gi
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
## Summary
- add per-app CNPG roles and role password Secret sources for Atuin/Auth/Harbor/Forejo/Paperless
- declare or update Database CRDs with public schema owners
- wire varied app Kustomizations to cnpg-database and postgres dependency
- keep workloads on postgres-cluster-app until per-app brownfield ownership and smoke gates pass

## Validation
- targeted kustomize builds for postgres and each varied app passed locally
- full flux-local validation runs in CI