### PR TITLE
fix(atuin): use isolated postgres credentials

### DIFF
--- a/kubernetes/apps/default/atuin/app/externalsecret.yaml
+++ b/kubernetes/apps/default/atuin/app/externalsecret.yaml
@@ -5,14 +5,18 @@ kind: ExternalSecret
 metadata:
   name: atuin
 spec:
+  refreshPolicy: Periodic
+  refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword
   target:
     name: atuin-secret
     template:
+      engineVersion: v2
+      mergePolicy: Replace
       data:
-        ATUIN_DB_URI: "postgres://app:{{ .password }}@postgres-cluster-rw.database.svc.cluster.local:5432/atuin"
+        ATUIN_DB_URI: "postgres://atuin:{{ .password | urlquery }}@${PG_HOST}:5432/${PG_DATABASE}"
   dataFrom:
     - extract:
-        key: postgres
+        key: atuin-postgres

--- a/kubernetes/apps/default/atuin/app/helmrelease.yaml
+++ b/kubernetes/apps/default/atuin/app/helmrelease.yaml
@@ -12,6 +12,8 @@ spec:
   values:
     controllers:
       atuin:
+        annotations:
+          reloader.stakater.com/auto: "true"
         containers:
           app:
             image:


### PR DESCRIPTION
## Summary
- switch Atuin DB URI source from shared postgres item to atuin-postgres
- keep Atuin on direct RW via PG_HOST substitution
- add Reloader annotation for credential Secret changes

## Validation
- static checks passed locally
- full flux-local validation runs in CI