### PR TITLE
fix(authentik): use isolated postgres credentials

### DIFF
--- a/kubernetes/apps/default/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/default/authentik/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
       error_reporting:
         enabled: false
       postgresql:
-        host: postgres-cluster-rw.database.svc.cluster.local
+        host: ${PG_HOST}
         password: file:///postgres-creds/password
         user: file:///postgres-creds/username
     blueprints:
@@ -93,7 +93,7 @@ spec:
       volumes: &volumes
         - name: postgres-creds
           secret:
-            secretName: postgres-cluster-app
+            secretName: authentik-postgres
         - name: data
           persistentVolumeClaim:
             claimName: authentik-data


### PR DESCRIPTION
## Summary
- switch Authentik postgres volume from postgres-cluster-app to authentik-postgres
- keep Authentik on direct RW via PG_HOST substitution
- preserve file-based username/password chart wiring

## Validation
- static checks passed locally
- full flux-local validation runs in CI