### PR TITLE
fix(harbor): use isolated postgres credentials

### DIFF
--- a/kubernetes/apps/default/harbor/app/helmrelease.yaml
+++ b/kubernetes/apps/default/harbor/app/helmrelease.yaml
@@ -67,10 +67,10 @@ spec:
     database:
       type: external
       external:
-        host: postgres-cluster-rw.database.svc.cluster.local
-        username: app
+        host: ${PG_HOST}
+        username: harbor
         coreDatabase: harbor
-        existingSecret: postgres-cluster-app
+        existingSecret: harbor-postgres
     core:
       priorityClassName: app-high
       image:


### PR DESCRIPTION
## Summary
- switch Harbor from postgres-cluster-app to harbor-postgres
- keep Harbor on direct RW via PG_HOST substitution
- preserve external database wiring

## Validation
- static checks passed locally
- full flux-local validation runs in CI