### PR TITLE
fix(forejo): use isolated postgres credentials

### DIFF
--- a/kubernetes/apps/default/forejo/app/helmrelease.yaml
+++ b/kubernetes/apps/default/forejo/app/helmrelease.yaml
@@ -44,7 +44,7 @@ spec:
         - name: GITEA__DATABASE__PASSWD
           valueFrom:
             secretKeyRef:
-              name: postgres-cluster-app
+              name: forejo-postgres
               key: password
 
     gitea:
@@ -97,9 +97,9 @@ spec:
           SSH_LISTEN_PORT: 2222
         database:
           DB_TYPE: postgres
-          HOST: postgres-cluster-rw.database.svc.cluster.local:5432
+          HOST: ${PG_HOST}:5432
           NAME: forejo
-          USER: app
+          USER: forejo
           SSL_MODE: disable
         picture:
           DISABLE_GRAVATAR: false


### PR DESCRIPTION
## Summary
- switch Forejo from postgres-cluster-app to forejo-postgres
- keep Forejo on direct RW via PG_HOST substitution
- set database user to forejo

## Validation
- static checks passed locally
- full flux-local validation runs in CI