### PR TITLE
feat(database): add GitLab postgres identity scaffold

### DIFF
--- a/kubernetes/apps/database/postgres/app/databases/gitlab.yaml
+++ b/kubernetes/apps/database/postgres/app/databases/gitlab.yaml
@@ -5,9 +5,12 @@ metadata:
   name: gitlab
 spec:
   name: gitlab
-  owner: app
+  owner: gitlab
   cluster:
     name: postgres-cluster
+  schemas:
+    - name: public
+      owner: gitlab
   extensions:
     - name: pg_trgm
       ensure: present

--- a/kubernetes/apps/database/postgres/app/helmrelease.yaml
+++ b/kubernetes/apps/database/postgres/app/helmrelease.yaml
@@ -130,6 +130,11 @@ spec:
           login: true
           passwordSecret:
             name: postgres-user-paperless
+        - name: gitlab
+          ensure: present
+          login: true
+          passwordSecret:
+            name: postgres-user-gitlab
       storage:
         size: 16Gi
         storageClass: openebs-hostpath

--- a/kubernetes/apps/database/postgres/app/kustomization.yaml
+++ b/kubernetes/apps/database/postgres/app/kustomization.yaml
@@ -25,6 +25,7 @@ resources:
   - ./roles/atuin.yaml
   - ./roles/authentik.yaml
   - ./roles/forejo.yaml
+  - ./roles/gitlab.yaml
   - ./roles/harbor.yaml
   - ./roles/lidarr.yaml
   - ./roles/paperless.yaml

--- a/kubernetes/apps/database/postgres/app/roles/gitlab.yaml
+++ b/kubernetes/apps/database/postgres/app/roles/gitlab.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: postgres-user-gitlab
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: postgres-user-gitlab
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      mergePolicy: Replace
+      type: kubernetes.io/basic-auth
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+      data:
+        user: gitlab
+        username: gitlab
+        password: "{{ .password }}"
+  dataFrom:
+    - extract:
+        key: gitlab-postgres

--- a/kubernetes/apps/gitlab/gitlab/ks.yaml
+++ b/kubernetes/apps/gitlab/gitlab/ks.yaml
@@ -9,6 +9,8 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/cnpg-database
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
@@ -19,6 +21,11 @@ spec:
     - name: authentik
       namespace: default
   path: ./kubernetes/apps/gitlab/gitlab/app
+  postBuild:
+    substitute:
+      APP: gitlab
+      PG_DATABASE: gitlab
+      PG_HOST: postgres-cluster-rw.database.svc.cluster.local
   sourceRef:
     kind: GitRepository
     name: flux-system


### PR DESCRIPTION
## Summary
- add gitlab CNPG role and role password Secret source
- declare GitLab database and public schema ownership as gitlab
- wire GitLab Kustomization to cnpg-database and postgres dependency
- keep GitLab workload on postgres-cluster-app until ownership and smoke gates pass

## Validation
- targeted kustomize builds for postgres and GitLab passed locally
- full flux-local validation runs in CI