### PR TITLE
fix(gitlab): use isolated postgres credentials

### DIFF
--- a/kubernetes/apps/gitlab/gitlab/app/helmrelease.yaml
+++ b/kubernetes/apps/gitlab/gitlab/app/helmrelease.yaml
@@ -70,9 +70,9 @@ spec:
         host: postgres-cluster-rw.database.svc.cluster.local
         port: 5432
         database: gitlab
-        username: app
+        username: gitlab
         password:
-          secret: postgres-cluster-app
+          secret: gitlab-postgres
           key: password
       redis:
         host: dragonfly.database.svc.cluster.local


### PR DESCRIPTION
## Summary
- switch GitLab from app/postgres-cluster-app to gitlab/gitlab-postgres
- keep GitLab on direct RW
- avoid any Pooler reference

## Validation
- static checks passed locally
- full flux-local validation runs in CI