### PR TITLE
fix(database): declare GitLab partition schema owners

### DIFF
--- a/kubernetes/apps/database/postgres/app/databases/gitlab.yaml
+++ b/kubernetes/apps/database/postgres/app/databases/gitlab.yaml
@@ -11,6 +11,10 @@ spec:
   schemas:
     - name: public
       owner: gitlab
+    - name: gitlab_partitions_dynamic
+      owner: gitlab
+    - name: gitlab_partitions_static
+      owner: gitlab
   extensions:
     - name: pg_trgm
       ensure: present


### PR DESCRIPTION
## Summary
- add gitlab_partitions_dynamic and gitlab_partitions_static to Database/gitlab schemas
- let CNPG manage GitLab non-public schema ownership
- fix gitlab role read permissions after credential isolation

## Validation
- targeted kustomize build for postgres passed locally
- full flux-local validation runs in CI