### PR TITLE
feat(sonarr): route postgres through CNPG Pooler

### DIFF
--- a/kubernetes/apps/default/sonarr/ks.yaml
+++ b/kubernetes/apps/default/sonarr/ks.yaml
@@ -24,7 +24,7 @@ spec:
     substitute:
       APP: sonarr
       PG_DATABASE: sonarr
-      PG_HOST: postgres-cluster-rw.database.svc.cluster.local
+      PG_HOST: postgres-cluster-pooler-rw.database.svc.cluster.local
       VOLSYNC_CAPACITY: 5Gi
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
## Summary
- change only Sonarr PG_HOST to postgres-cluster-pooler-rw
- keep isolated Sonarr credentials and database unchanged
- preserve direct RW rollback by reverting this host-only change

## Validation
- static checks passed locally
- full flux-local validation runs in CI