### PR TITLE
feat(lidarr): route postgres through CNPG Pooler

### DIFF
--- a/kubernetes/apps/default/lidarr/ks.yaml
+++ b/kubernetes/apps/default/lidarr/ks.yaml
@@ -24,7 +24,7 @@ spec:
     substitute:
       APP: lidarr
       PG_DATABASE: lidarr
-      PG_HOST: postgres-cluster-rw.database.svc.cluster.local
+      PG_HOST: postgres-cluster-pooler-rw.database.svc.cluster.local
       VOLSYNC_CAPACITY: 16Gi
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
## Summary
- change only Lidarr PG_HOST to postgres-cluster-pooler-rw
- keep isolated Lidarr credentials and database unchanged
- preserve direct RW rollback by reverting this host-only change

## Validation
- static checks passed locally
- full flux-local validation runs in CI