### PR TITLE
fix(volsync): move cache volumes to ceph-block

### DIFF
--- a/kubernetes/components/volsync/replicationdestination.yaml
+++ b/kubernetes/components/volsync/replicationdestination.yaml
@@ -14,8 +14,8 @@ spec:
       - ${VOLSYNC_ACCESSMODES:=ReadWriteOnce}
     cacheAccessModes:
       - ${VOLSYNC_CACHE_ACCESSMODES:=ReadWriteOnce}
-    cacheCapacity: ${VOLSYNC_CAPACITY:=5Gi}
-    cacheStorageClassName: ${VOLSYNC_CACHE_STORAGECLASS:=openebs-hostpath}
+    cacheCapacity: ${VOLSYNC_CACHE_CAPACITY:=8Gi}
+    cacheStorageClassName: ${VOLSYNC_CACHE_STORAGECLASS:=ceph-block}
     capacity: ${VOLSYNC_CAPACITY:=5Gi}
     cleanupCachePVC: true
     cleanupTempPVC: true

--- a/kubernetes/components/volsync/replicationsource.yaml
+++ b/kubernetes/components/volsync/replicationsource.yaml
@@ -13,8 +13,8 @@ spec:
       - ${VOLSYNC_SNAP_ACCESSMODES:=ReadWriteOnce}
     cacheAccessModes:
       - ${VOLSYNC_CACHE_ACCESSMODES:=ReadWriteOnce}
-    cacheCapacity: ${VOLSYNC_CAPACITY:=5Gi}
-    cacheStorageClassName: ${VOLSYNC_CACHE_STORAGECLASS:=openebs-hostpath}
+    cacheCapacity: ${VOLSYNC_CACHE_CAPACITY:=8Gi}
+    cacheStorageClassName: ${VOLSYNC_CACHE_STORAGECLASS:=ceph-block}
     compression: zstd-fastest
     copyMethod: Snapshot
     moverSecurityContext:


### PR DESCRIPTION
Cache PVCs previously defaulted to openebs-hostpath, causing local disk pressure on nodes. This switches the default to ceph-block and introduces a separate VOLSYNC_CACHE_CAPACITY variable (default 8Gi) to decouple cache sizing from source PVC capacity.