### PR TITLE
feat(gitlab): scaffold RGW object buckets

### DIFF
--- a/kubernetes/apps/gitlab/gitlab/app/kustomization.yaml
+++ b/kubernetes/apps/gitlab/gitlab/app/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ./helmrelease.yaml
   - ./helmrepository.yaml
   - ./httproute-webservice.yaml
+  - ./objectbucketclaims.yaml
   - ./minio-ocirepository.yaml
   - ./minio-helmrelease.yaml
   - ./minio-bucket-init.yaml

--- a/kubernetes/apps/gitlab/gitlab/app/objectbucketclaims.yaml
+++ b/kubernetes/apps/gitlab/gitlab/app/objectbucketclaims.yaml
@@ -1,0 +1,90 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/objectbucket.io/objectbucketclaim_v1alpha1.json
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: gitlab-artifacts
+spec:
+  bucketName: gitlab-artifacts
+  storageClassName: gitlab-rgw-bucket
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/objectbucket.io/objectbucketclaim_v1alpha1.json
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: gitlab-lfs
+spec:
+  bucketName: gitlab-lfs
+  storageClassName: gitlab-rgw-bucket
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/objectbucket.io/objectbucketclaim_v1alpha1.json
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: gitlab-uploads
+spec:
+  bucketName: gitlab-uploads
+  storageClassName: gitlab-rgw-bucket
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/objectbucket.io/objectbucketclaim_v1alpha1.json
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: gitlab-packages
+spec:
+  bucketName: gitlab-packages
+  storageClassName: gitlab-rgw-bucket
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/objectbucket.io/objectbucketclaim_v1alpha1.json
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: gitlab-mr-diffs
+spec:
+  bucketName: gitlab-mr-diffs
+  storageClassName: gitlab-rgw-bucket
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/objectbucket.io/objectbucketclaim_v1alpha1.json
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: gitlab-tf-state
+spec:
+  bucketName: gitlab-tf-state
+  storageClassName: gitlab-rgw-bucket
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/objectbucket.io/objectbucketclaim_v1alpha1.json
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: gitlab-ci-secure
+spec:
+  bucketName: gitlab-ci-secure
+  storageClassName: gitlab-rgw-bucket
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/objectbucket.io/objectbucketclaim_v1alpha1.json
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: gitlab-dep-proxy
+spec:
+  bucketName: gitlab-dep-proxy
+  storageClassName: gitlab-rgw-bucket
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/objectbucket.io/objectbucketclaim_v1alpha1.json
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: gitlab-backups
+spec:
+  bucketName: gitlab-backups
+  storageClassName: gitlab-rgw-bucket
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/objectbucket.io/objectbucketclaim_v1alpha1.json
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: gitlab-tmp
+spec:
+  bucketName: gitlab-tmp
+  storageClassName: gitlab-rgw-bucket

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -178,4 +178,36 @@ spec:
       name: csi-ceph-filesystem
       deletionPolicy: Delete
       isDefault: false
-    cephObjectStores: []
+    cephObjectStores:
+      - name: gitlab-rgw
+        spec:
+          metadataPool:
+            failureDomain: host
+            parameters:
+              min_size: "2"
+            replicated:
+              size: 3
+          dataPool:
+            failureDomain: host
+            parameters:
+              min_size: "2"
+            replicated:
+              size: 3
+          preservePoolsOnDelete: true
+          gateway:
+            port: 80
+            instances: 1
+            priorityClassName: system-cluster-critical
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 1Gi
+        storageClass:
+          enabled: true
+          name: gitlab-rgw-bucket
+          reclaimPolicy: Delete
+          volumeBindingMode: Immediate
+          parameters:
+            region: us-east-1


### PR DESCRIPTION
## Summary
- add a GitLab-specific Rook RGW object store and bucket StorageClass
- add ObjectBucketClaims for the ten stable GitLab buckets
- keep existing MinIO resources in place until RGW validation succeeds

## Validation
- mise exec -- kustomize build kubernetes/apps/rook-ceph/rook-ceph/cluster
- mise exec -- kustomize build kubernetes/apps/gitlab/gitlab/app
- mise exec -- helm template rook-ceph-cluster oci://ghcr.io/rook/rook-ceph-cluster --version v1.19.5 --namespace rook-ceph -f /tmp/gsd-15-01-rook-values.yaml