### PR TITLE
fix(gitlab): assign RGW buckets to shared owner

### DIFF
--- a/kubernetes/apps/gitlab/gitlab/app/objectbucketclaims.yaml
+++ b/kubernetes/apps/gitlab/gitlab/app/objectbucketclaims.yaml
@@ -5,6 +5,8 @@ kind: ObjectBucketClaim
 metadata:
   name: gitlab-artifacts
 spec:
+  additionalConfig:
+    bucketOwner: gitlab
   bucketName: gitlab-artifacts
   storageClassName: gitlab-rgw-bucket
 ---
@@ -14,6 +16,8 @@ kind: ObjectBucketClaim
 metadata:
   name: gitlab-lfs
 spec:
+  additionalConfig:
+    bucketOwner: gitlab
   bucketName: gitlab-lfs
   storageClassName: gitlab-rgw-bucket
 ---
@@ -23,6 +27,8 @@ kind: ObjectBucketClaim
 metadata:
   name: gitlab-uploads
 spec:
+  additionalConfig:
+    bucketOwner: gitlab
   bucketName: gitlab-uploads
   storageClassName: gitlab-rgw-bucket
 ---
@@ -32,6 +38,8 @@ kind: ObjectBucketClaim
 metadata:
   name: gitlab-packages
 spec:
+  additionalConfig:
+    bucketOwner: gitlab
   bucketName: gitlab-packages
   storageClassName: gitlab-rgw-bucket
 ---
@@ -41,6 +49,8 @@ kind: ObjectBucketClaim
 metadata:
   name: gitlab-mr-diffs
 spec:
+  additionalConfig:
+    bucketOwner: gitlab
   bucketName: gitlab-mr-diffs
   storageClassName: gitlab-rgw-bucket
 ---
@@ -50,6 +60,8 @@ kind: ObjectBucketClaim
 metadata:
   name: gitlab-tf-state
 spec:
+  additionalConfig:
+    bucketOwner: gitlab
   bucketName: gitlab-tf-state
   storageClassName: gitlab-rgw-bucket
 ---
@@ -59,6 +71,8 @@ kind: ObjectBucketClaim
 metadata:
   name: gitlab-ci-secure
 spec:
+  additionalConfig:
+    bucketOwner: gitlab
   bucketName: gitlab-ci-secure
   storageClassName: gitlab-rgw-bucket
 ---
@@ -68,6 +82,8 @@ kind: ObjectBucketClaim
 metadata:
   name: gitlab-dep-proxy
 spec:
+  additionalConfig:
+    bucketOwner: gitlab
   bucketName: gitlab-dep-proxy
   storageClassName: gitlab-rgw-bucket
 ---
@@ -77,6 +93,8 @@ kind: ObjectBucketClaim
 metadata:
   name: gitlab-backups
 spec:
+  additionalConfig:
+    bucketOwner: gitlab
   bucketName: gitlab-backups
   storageClassName: gitlab-rgw-bucket
 ---
@@ -86,5 +104,7 @@ kind: ObjectBucketClaim
 metadata:
   name: gitlab-tmp
 spec:
+  additionalConfig:
+    bucketOwner: gitlab
   bucketName: gitlab-tmp
   storageClassName: gitlab-rgw-bucket

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
@@ -16,6 +16,7 @@ spec:
       repository: ghcr.io/rook/ceph
     monitoring:
       enabled: true
+    obcAllowAdditionalConfigFields: "maxObjects,maxSize,bucketOwner"
     resources:
       requests:
         cpu: 100m

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./objectstoreuser.yaml
   - ./ocirepository.yaml

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/objectstoreuser.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/objectstoreuser.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/ceph.rook.io/cephobjectstoreuser_v1.json
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: gitlab
+spec:
+  store: gitlab-rgw
+  displayName: GitLab


### PR DESCRIPTION
## Summary
- enable Rook OBC bucketOwner additionalConfig support
- add a shared GitLab CephObjectStoreUser for gitlab-rgw
- set all GitLab ObjectBucketClaims to use bucketOwner: gitlab so Rook re-links the preserved bucket names to one RGW user

## Notes
- Rook v1.19.5 OBC Provision() re-runs on OBC updates and calls LinkBucket when the existing bucket owner differs from the requested bucketOwner.
- This avoids deleting/recreating OBCs or buckets.