### PR TITLE
fix(gitlab): use namespaced RGW user

### DIFF
--- a/kubernetes/apps/gitlab/gitlab/app/kustomization.yaml
+++ b/kubernetes/apps/gitlab/gitlab/app/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ./helmrepository.yaml
   - ./httproute-webservice.yaml
   - ./objectbucketclaims.yaml
+  - ./objectstoreuser.yaml
   - ./minio-ocirepository.yaml
   - ./minio-helmrelease.yaml
   - ./minio-bucket-init.yaml

--- a/kubernetes/apps/gitlab/gitlab/app/objectbucketclaims.yaml
+++ b/kubernetes/apps/gitlab/gitlab/app/objectbucketclaims.yaml
@@ -6,7 +6,7 @@ metadata:
   name: gitlab-artifacts
 spec:
   additionalConfig:
-    bucketOwner: gitlab
+    bucketOwner: gitlab-rgw
   bucketName: gitlab-artifacts
   storageClassName: gitlab-rgw-bucket
 ---
@@ -17,7 +17,7 @@ metadata:
   name: gitlab-lfs
 spec:
   additionalConfig:
-    bucketOwner: gitlab
+    bucketOwner: gitlab-rgw
   bucketName: gitlab-lfs
   storageClassName: gitlab-rgw-bucket
 ---
@@ -28,7 +28,7 @@ metadata:
   name: gitlab-uploads
 spec:
   additionalConfig:
-    bucketOwner: gitlab
+    bucketOwner: gitlab-rgw
   bucketName: gitlab-uploads
   storageClassName: gitlab-rgw-bucket
 ---
@@ -39,7 +39,7 @@ metadata:
   name: gitlab-packages
 spec:
   additionalConfig:
-    bucketOwner: gitlab
+    bucketOwner: gitlab-rgw
   bucketName: gitlab-packages
   storageClassName: gitlab-rgw-bucket
 ---
@@ -50,7 +50,7 @@ metadata:
   name: gitlab-mr-diffs
 spec:
   additionalConfig:
-    bucketOwner: gitlab
+    bucketOwner: gitlab-rgw
   bucketName: gitlab-mr-diffs
   storageClassName: gitlab-rgw-bucket
 ---
@@ -61,7 +61,7 @@ metadata:
   name: gitlab-tf-state
 spec:
   additionalConfig:
-    bucketOwner: gitlab
+    bucketOwner: gitlab-rgw
   bucketName: gitlab-tf-state
   storageClassName: gitlab-rgw-bucket
 ---
@@ -72,7 +72,7 @@ metadata:
   name: gitlab-ci-secure
 spec:
   additionalConfig:
-    bucketOwner: gitlab
+    bucketOwner: gitlab-rgw
   bucketName: gitlab-ci-secure
   storageClassName: gitlab-rgw-bucket
 ---
@@ -83,7 +83,7 @@ metadata:
   name: gitlab-dep-proxy
 spec:
   additionalConfig:
-    bucketOwner: gitlab
+    bucketOwner: gitlab-rgw
   bucketName: gitlab-dep-proxy
   storageClassName: gitlab-rgw-bucket
 ---
@@ -94,7 +94,7 @@ metadata:
   name: gitlab-backups
 spec:
   additionalConfig:
-    bucketOwner: gitlab
+    bucketOwner: gitlab-rgw
   bucketName: gitlab-backups
   storageClassName: gitlab-rgw-bucket
 ---
@@ -105,6 +105,6 @@ metadata:
   name: gitlab-tmp
 spec:
   additionalConfig:
-    bucketOwner: gitlab
+    bucketOwner: gitlab-rgw
   bucketName: gitlab-tmp
   storageClassName: gitlab-rgw-bucket

--- a/kubernetes/apps/gitlab/gitlab/app/objectstoreuser.yaml
+++ b/kubernetes/apps/gitlab/gitlab/app/objectstoreuser.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/ceph.rook.io/cephobjectstoreuser_v1.json
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: gitlab-rgw
+spec:
+  clusterNamespace: rook-ceph
+  store: gitlab-rgw
+  displayName: GitLab

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -181,6 +181,8 @@ spec:
     cephObjectStores:
       - name: gitlab-rgw
         spec:
+          allowUsersInNamespaces:
+            - gitlab
           metadataPool:
             failureDomain: host
             parameters:


### PR DESCRIPTION
## Summary
- allow the gitlab namespace to create users for the gitlab-rgw object store
- add a GitLab-namespaced CephObjectStoreUser named gitlab-rgw
- relink all GitLab OBCs to bucketOwner: gitlab-rgw

## Notes
- leaves the existing rook-ceph/gitlab CephObjectStoreUser in place until the new namespaced user and bucket ownership are live-validated
- does not change gitlab-object-store-connection, so production GitLab remains on the current MinIO-backed secret