### PR TITLE
fix(gitlab): cut object storage to RGW

### DIFF
--- a/kubernetes/apps/gitlab/gitlab/app/externalsecret.yaml
+++ b/kubernetes/apps/gitlab/gitlab/app/externalsecret.yaml
@@ -47,32 +47,43 @@ metadata:
   name: gitlab-object-store-connection
 spec:
   secretStoreRef:
-    kind: ClusterSecretStore
-    name: onepassword
+    kind: SecretStore
+    name: gitlab-rgw
   refreshInterval: 5m
   target:
     name: gitlab-object-store-connection
     template:
+      engineVersion: v2
       type: Opaque
       data:
         connection: |
           provider: AWS
           region: us-east-1
-          aws_access_key_id: {{ .access_key | quote }}
-          aws_secret_access_key: {{ .secret_key | quote }}
-          endpoint: 'http://gitlab-minio.gitlab.svc.cluster.local:9000'
+          aws_access_key_id: {{ .AccessKey | quote }}
+          aws_secret_access_key: {{ .SecretKey | quote }}
+          endpoint: {{ .Endpoint | quote }}
           path_style: true
         s3cfg: |
           [default]
-          access_key = {{ .access_key }}
-          secret_key = {{ .secret_key }}
-          host_base = gitlab-minio.gitlab.svc.cluster.local:9000
-          host_bucket = gitlab-minio.gitlab.svc.cluster.local:9000/%(bucket)
-          use_https = False
+          access_key = {{ .AccessKey }}
+          secret_key = {{ .SecretKey }}
+          host_base = {{ .Endpoint | trimPrefix "https://" | trimPrefix "http://" }}
+          host_bucket = {{ .Endpoint | trimPrefix "https://" | trimPrefix "http://" }}/%(bucket)
+          use_https = {{ if hasPrefix "https://" .Endpoint }}True{{ else }}False{{ end }}
           signature_v2 = False
-  dataFrom:
-    - extract:
-        key: gitlab-minio
+  data:
+    - secretKey: AccessKey
+      remoteRef:
+        key: rook-ceph-object-user-gitlab-rgw-gitlab-rgw
+        property: AccessKey
+    - secretKey: SecretKey
+      remoteRef:
+        key: rook-ceph-object-user-gitlab-rgw-gitlab-rgw
+        property: SecretKey
+    - secretKey: Endpoint
+      remoteRef:
+        key: rook-ceph-object-user-gitlab-rgw-gitlab-rgw
+        property: Endpoint
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1

--- a/kubernetes/apps/gitlab/gitlab/app/kustomization.yaml
+++ b/kubernetes/apps/gitlab/gitlab/app/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./rgw-secretstore.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./helmrepository.yaml

--- a/kubernetes/apps/gitlab/gitlab/app/rgw-secretstore.yaml
+++ b/kubernetes/apps/gitlab/gitlab/app/rgw-secretstore.yaml
@@ -1,0 +1,50 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/v1/serviceaccount.json
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gitlab-rgw-secret-reader
+automountServiceAccountToken: false
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/rbac.authorization.k8s.io/role_v1.json
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gitlab-rgw-secret-reader
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["rook-ceph-object-user-gitlab-rgw-gitlab-rgw"]
+    verbs: ["get"]
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/rbac.authorization.k8s.io/rolebinding_v1.json
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gitlab-rgw-secret-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: gitlab-rgw-secret-reader
+subjects:
+  - kind: ServiceAccount
+    name: gitlab-rgw-secret-reader
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/secretstore_v1.json
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: gitlab-rgw
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: gitlab
+      server:
+        url: https://kubernetes.default.svc
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          key: ca.crt
+      auth:
+        serviceAccount:
+          name: gitlab-rgw-secret-reader


### PR DESCRIPTION
## Summary
- template gitlab-object-store-connection from the Rook-generated gitlab-rgw user Secret
- add a namespace-local Kubernetes SecretStore with minimal RBAC for that one Rook Secret
- keep GitLab bucket names and MinIO resources unchanged for rollback

## Data migration
- Existing MinIO object data is not mirrored in this PR by operator choice. If old MinIO objects exist, they may be inaccessible after the cutover until this PR is reverted or data is copied separately.

## Rollback
- Revert this PR to point gitlab-object-store-connection back at the 1Password-backed MinIO credentials.
- Wait for Flux to apply the revert, then restart any GitLab workloads that mount gitlab-object-store-connection.
- Any writes made to RGW during the cutover window would remain in RGW and would not appear while rolled back to MinIO.

## Validation
- kustomize build kubernetes/apps/gitlab/gitlab/app
- kubectl apply --dry-run=server for the rendered GitLab app manifests
- temporary ExternalSecret smoke verified the Kubernetes SecretStore could read the Rook Secret and render connection/s3cfg without printing credentials