### PR TITLE
fix(gitlab): remove old RGW user

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/kustomization.yaml
@@ -4,5 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
-  - ./objectstoreuser.yaml
   - ./ocirepository.yaml

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/objectstoreuser.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/objectstoreuser.yaml
@@ -1,9 +1,0 @@
----
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/ceph.rook.io/cephobjectstoreuser_v1.json
-apiVersion: ceph.rook.io/v1
-kind: CephObjectStoreUser
-metadata:
-  name: gitlab
-spec:
-  store: gitlab-rgw
-  displayName: GitLab


### PR DESCRIPTION
## Summary
- remove the old rook-ceph namespace CephObjectStoreUser named gitlab
- keep the GitLab-namespaced CephObjectStoreUser gitlab-rgw and all OBC bucketOwner settings unchanged

## Pre-merge validation
- all 10 GitLab RGW buckets report owner gitlab-rgw via radosgw-admin in the gitlab-rgw realm
- new gitlab/CephObjectStoreUser gitlab-rgw is Ready
- old rook-ceph/CephObjectStoreUser gitlab is Ready before deletion, so Flux/Rook can delete it cleanly
- kustomize build kubernetes/apps/rook-ceph/rook-ceph/cluster