### PR TITLE
fix(kyverno): re-enable CRD migration to restore ServiceAccount

### DIFF
--- a/kubernetes/apps/kyverno/kyverno/app/helmrelease.yaml
+++ b/kubernetes/apps/kyverno/kyverno/app/helmrelease.yaml
@@ -15,7 +15,7 @@ spec:
   values:
     crds:
       migration:
-        enabled: false
+        enabled: true
     admissionController:
       replicas: 1
       priorityClassName: system-cluster-critical


### PR DESCRIPTION
## Summary

Fixes the stale `kyverno-migrate-resources` Job failing with `serviceaccount kyverno/kyverno-migrate-resources not found`.

## Root Cause

The `crds.migration.enabled` value was overridden to `false`, which prevents the Kyverno chart from rendering the ServiceAccount, ClusterRole, and ClusterRoleBinding needed by the CRD migration post-upgrade hook Job. The chart default is `true`.

A previously-created hook Job remained in the cluster referencing the now-deleted SA, causing repeated pod creation failures.

## Fix

Remove the `enabled: false` override, restoring the chart default (`true`). This renders all migration RBAC resources and allows the idempotent migration Job to complete successfully on the next Flux reconciliation.

## Validation

```
flux-local test --enable-helm --path kubernetes/flux/cluster --sources flux-system
# 6 passed
```

## Post-merge

After Flux reconciles, the next helm upgrade will:
1. Render the ServiceAccount `kyverno-migrate-resources`
2. Run the post-upgrade migration hook successfully
3. The stale failed Job pod (`kyverno-migrate-resources-khp6b`) may need manual deletion if k8s doesn't replace it automatically