### PR TITLE
fix(gitlab): restrict account creation via chart values

### DIFF
--- a/kubernetes/apps/gitlab/gitlab/app/helmrelease.yaml
+++ b/kubernetes/apps/gitlab/gitlab/app/helmrelease.yaml
@@ -158,10 +158,12 @@ spec:
           syncProfileFromProvider: [openid_connect]
           syncProfileAttributes: [name, email]
           allowSingleSignOn: [openid_connect]
-          blockAutoCreatedUsers: false
+          blockAutoCreatedUsers: true
           providers:
             - secret: gitlab-oidc
               key: provider
+        initialDefaults:
+          signupEnabled: false
       initialRootPassword:
         secret: gitlab-initial-root-password
         key: password


### PR DESCRIPTION
## Summary
- set GitLab OIDC auto-created users to blocked/pending approval via chart values
- set GitLab chart initial signup default to disabled
- keep the existing webservice lifecycle hook limited to the 1Password setup script; no Rails runner/API/script enforcement added

## Notes
- GitLab chart 10.0.0 does not expose a Helm value/template for Web IDE single-origin fallback; this PR intentionally stays HR-only and does not attempt to mutate Application Settings outside supported chart values.

## Validation
- kustomize build kubernetes/apps/gitlab/gitlab/app
- helm template gitlab gitlab/gitlab --version 10.0.0 --namespace gitlab -f /tmp/gitlab-values.yaml