### PR TITLE
fix(gitlab): disable telemetry and configure smtp relay

### DIFF
--- a/kubernetes/apps/gitlab/gitlab/app/helmrelease.yaml
+++ b/kubernetes/apps/gitlab/gitlab/app/helmrelease.yaml
@@ -116,7 +116,16 @@ spec:
         enabled: false
       registry:
         enabled: false
+      smtp:
+        enabled: true
+        address: smtp-relay.default.svc.cluster.local
+        port: 587
+        authentication: none
+        starttls_auto: false
+        openssl_verify_mode: none
       appConfig:
+        enableUsagePing: false
+        enableSeatLink: false
         object_store:
           enabled: true
           connection:
@@ -164,6 +173,7 @@ spec:
               key: provider
         initialDefaults:
           signupEnabled: false
+          gitlabProductUsageData: false
       initialRootPassword:
         secret: gitlab-initial-root-password
         key: password


### PR DESCRIPTION
## Summary
- disable GitLab usage ping and seat-link telemetry through chart values
- disable initial product usage data collection default
- configure GitLab SMTP to use smtp-relay.default.svc.cluster.local:587 without SMTP auth/TLS

## Validation
- kustomize build kubernetes/apps/gitlab/gitlab/app
- helm template gitlab gitlab/gitlab --version 10.0.0 --namespace gitlab -f /tmp/gitlab-values.yaml