### PR TITLE
fix(cnpg): restrict legacy app secret scope

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -230,7 +230,7 @@ persistence:
 ### PostgreSQL (CloudNativePG)
 - **RW endpoint**: `postgres-cluster-rw.database.svc.cluster.local`
 - **RO endpoint**: `postgres-cluster-r.database.svc.cluster.local`
-- Credentials come from the secret `postgres-cluster-app` (keys: `user`, `password`).
+- App credentials come from per-app secrets named `postgres-user-<app>`; the legacy `postgres-cluster-app` secret is only for the gated CNPG-managed `app` role in the `database` namespace.
 - CNPG uses `openebs-hostpath`; do not move it to Ceph unless a future plan explicitly changes it.
 - Apps like Sonarr/Radarr reference this via `secretKeyRef`.
 

--- a/kubernetes/apps/database/postgres/app/externalsecret.yaml
+++ b/kubernetes/apps/database/postgres/app/externalsecret.yaml
@@ -7,7 +7,7 @@ spec:
   externalSecretName: postgres-cluster-app
   namespaceSelectors:
     - matchLabels:
-        kustomize.toolkit.fluxcd.io/name: cluster-apps
+        kubernetes.io/metadata.name: database
   externalSecretSpec:
     secretStoreRef:
       kind: ClusterSecretStore


### PR DESCRIPTION
## Summary
- Restrict the legacy postgres-cluster-app ClusterExternalSecret to the database namespace only
- Keep the existing CNPG managed app role credential intact while preventing cluster-wide Secret fanout
- Update Copilot guidance so future app work uses per-app postgres-user-<app> credentials instead of postgres-cluster-app

## Validation
- mise exec -- kustomize build kubernetes/apps/database/postgres/app
- kubectl apply --server-side --dry-run=server --force-conflicts -f /tmp/postgres-kustomize.yaml
- flux build kustomization postgres --namespace database --kustomization-file kubernetes/apps/database/postgres/ks.yaml --path ./kubernetes/apps/database/postgres/app --dry-run
- live pod/workload/job/cronjob scans found no postgres-cluster-app consumers outside the CNPG managed role