### PR TITLE
fix(cnpg): retire legacy app database

### DIFF
--- a/kubernetes/apps/database/postgres/app/databases/app.yaml
+++ b/kubernetes/apps/database/postgres/app/databases/app.yaml
@@ -3,14 +3,10 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Database
 metadata:
-  name: authentik
+  name: app
 spec:
-  name: authentik
-  owner: authentik
+  name: app
+  owner: app
+  ensure: absent
   cluster:
     name: postgres-cluster
-  schemas:
-    - name: public
-      owner: authentik
-    - name: template
-      ensure: absent

--- a/kubernetes/apps/database/postgres/app/kustomization.yaml
+++ b/kubernetes/apps/database/postgres/app/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./databases/app.yaml
   - ./databases/atuin.yaml
   - ./databases/authentik.yaml
   - ./databases/harbor.yaml


### PR DESCRIPTION
## Summary
- add a CNPG Database resource to keep the legacy `app` database absent
- remove the empty `authentik.template` schema declaratively
- keep the legacy `app` role and `postgres-cluster-app` Secret for the follow-up gated cleanup

## Validation
- `mise exec -- kustomize build kubernetes/apps/database/postgres/app`
- `mise exec -- kubectl apply --dry-run=server -k kubernetes/apps/database/postgres/app`
- completed backups: `pre-app-retire-20260527021346`, `post-app-owner-transfer-20260527021626`
- verified no live workload consumers of `postgres-cluster-app`
- transferred remaining non-app object ownership to application roles; only `authentik.template` remains and is removed by this PR

## Follow-up
- after this reconciles, run a recovery drill from a post-cleanup backup before removing the legacy role/Secret