### PR TITLE
fix(gitlab): map OIDC groups claim for admin sync

### DIFF
--- a/kubernetes/apps/gitlab/gitlab/app/externalsecret.yaml
+++ b/kubernetes/apps/gitlab/gitlab/app/externalsecret.yaml
@@ -93,6 +93,7 @@ spec:
               secret: {{ .client_secret | quote }}
               redirect_uri: https://gitlab.melotic.dev/users/auth/openid_connect/callback
             gitlab:
+              groups_attribute: groups
               admin_groups: ["gitlab-admins"]
   data:
     - secretKey: client_id


### PR DESCRIPTION
## Summary
- add `groups_attribute: groups` to GitLab OIDC provider config
- keep existing Authentik groups scope and `gitlab-admins` admin group contract

## Validation
- `mise exec -- kustomize build kubernetes/apps/default/authentik/app`
- `mise exec -- kustomize build kubernetes/apps/gitlab/gitlab/app`
- OIDC config grep checks for groups scope, `groups_attribute`, and `admin_groups`
