### PR TITLE
fix(volsync): default cacheCapacity to VOLSYNC_CAPACITY to match existing PVCs

### DIFF
--- a/kubernetes/components/volsync/replicationsource.yaml
+++ b/kubernetes/components/volsync/replicationsource.yaml
@@ -13,7 +13,7 @@ spec:
       - ${VOLSYNC_SNAP_ACCESSMODES:=ReadWriteOnce}
     cacheAccessModes:
       - ${VOLSYNC_CACHE_ACCESSMODES:=ReadWriteOnce}
-    cacheCapacity: ${VOLSYNC_CACHE_CAPACITY:=8Gi}
+    cacheCapacity: ${VOLSYNC_CACHE_CAPACITY:=${VOLSYNC_CAPACITY:=8Gi}}
     cacheStorageClassName: ${VOLSYNC_CACHE_STORAGECLASS:=ceph-block}
     compression: zstd-fastest
     copyMethod: Snapshot


### PR DESCRIPTION
Fixes VolSync backup stall caused by cacheCapacity defaulting to 8Gi while existing cache PVCs on non-resizable openebs-hostpath are sized per app's VOLSYNC_CAPACITY.