### PR TITLE
fix(gitlab-runner): raise manager CPU limit

### DIFF
--- a/kubernetes/apps/gitlab-runner/runner/app/helmrelease.yaml
+++ b/kubernetes/apps/gitlab-runner/runner/app/helmrelease.yaml
@@ -92,7 +92,7 @@ spec:
         cpu: 50m
         memory: 128Mi
       limits:
-        cpu: 200m
+        cpu: 500m
         memory: 256Mi
 
     # config.toml for the K8s executor — controls per-job pod security.


### PR DESCRIPTION
Raise manager pod CPU limit from 200m to 500m to resolve active CPUThrottlingHigh alert.