### PR TITLE
fix(soularr): reduce failed job alert spam

### DIFF
--- a/kubernetes/apps/default/soularr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/soularr/app/helmrelease.yaml
@@ -18,9 +18,9 @@ spec:
           backoffLimit: 3
           concurrencyPolicy: Forbid
           successfulJobsHistory: 3
-          failedJobsHistory: 3
+          failedJobsHistory: 1
           activeDeadlineSeconds: 1800
-          ttlSecondsAfterFinished: 86400
+          ttlSecondsAfterFinished: 3600
         initContainers:
           wait-for-slskd:
             image:


### PR DESCRIPTION
Keep 1 failed job (was 3) and shorten finished-job TTL to 1 hour (was 24h) to reduce KubeJobFailed alert noise from transient outages.