### PR TITLE
fix(monitoring): raise kube-apiserver scrape size limit

### DIFF
--- a/kubernetes/apps/monitoring/victoria-metrics-k8s-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics-k8s-stack/app/helmrelease.yaml
@@ -208,6 +208,7 @@ spec:
             - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
               port: https
               scheme: https
+              max_scrape_size: 32MB
               tlsConfig:
                 caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
                 serverName: kubernetes


### PR DESCRIPTION
Set max_scrape_size: 32MB on the kubeApiServer VMServiceScrape endpoint to prevent scrape failures when responses exceed the default 16MB vmagent limit.