### PR TITLE
fix(grafana): raise memory limit to prevent OOMKilled

### DIFF
--- a/kubernetes/apps/monitoring/grafana/instance/grafana.yaml
+++ b/kubernetes/apps/monitoring/grafana/instance/grafana.yaml
@@ -75,9 +75,9 @@ spec:
               resources:
                 requests:
                   cpu: 50m
-                  memory: 256Mi
-                limits:
                   memory: 512Mi
+                limits:
+                  memory: 1Gi
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000


### PR DESCRIPTION
## Problem

Alertmanager fired a critical **OOMKilled** alert for the Grafana pod at 2026-05-28T10:56:49Z:

- **Pod:** `grafana-deployment-55d68fcd5c-tf5dx` (namespace: `monitoring`)
- **Container:** `grafana`
- **Reason:** OOMKilled (exitCode 137)
- **restartCount:** 1
- **Previous limit:** 512Mi

The container installs 8 plugins via `GF_INSTALL_PLUGINS` at startup, which causes memory spikes exceeding the 512Mi limit.

## Fix

Raise memory resources in `kubernetes/apps/monitoring/grafana/instance/grafana.yaml`:

| | Before | After |
|---|---|---|
| requests.memory | 256Mi | 512Mi |
| limits.memory | 512Mi | 1Gi |

## Validation

```
$ flux-local test --enable-helm --all-namespaces --path kubernetes/flux/cluster -v --sources flux-system
...
152 passed in 177.36s (0:02:57)
```

All 152 Kustomization/HelmRelease tests pass.