### PR TITLE
fix(volsync): narrow VolSyncMissedInterval window to 1h to avoid stale alerts

### DIFF
--- a/kubernetes/apps/volsync-system/volsync/app/prometheusrule.yaml
+++ b/kubernetes/apps/volsync-system/volsync/app/prometheusrule.yaml
@@ -30,7 +30,7 @@ spec:
 
         - alert: VolSyncMissedInterval
           expr: |-
-            increase(volsync_missed_intervals_total{role="source"}[13h]) > 0
+            increase(volsync_missed_intervals_total{role="source"}[1h]) > 0
           annotations:
             summary: >-
               {{ $labels.obj_namespace }}/{{ $labels.obj_name }} missed a scheduled VolSync backup interval


### PR DESCRIPTION
## Problem

The `VolSyncMissedInterval` alert uses `increase(volsync_missed_intervals_total{role="source"}[13h]) > 0`, which fires for up to 13 hours after a single transient missed interval — even after the backup has recovered on its next scheduled 12h run. This caused 17 stale alerts firing simultaneously for sources that had already recovered.

## Root Cause

The 13h lookback window was chosen to exceed the 12h backup schedule, but this means any historical miss within that window keeps the alert active regardless of current state.

## Fix

Narrow the `increase()` window from `[13h]` to `[1h]`. Combined with `for: 15m`, this ensures the alert only fires when a missed interval is recent/ongoing. The existing `VolSyncSourceBackupStale` rule (`volsync_volume_out_of_sync == 1` for 1h, severity: critical) already covers prolonged backup failures.

## Validation

- `flux-local test --enable-helm --all-namespaces`: **152 passed**
- OPSEC grep: clean
- No monitoring gaps: `VolSyncSourceBackupStale` (critical) catches truly stale backups; this rule now only catches actively-missed intervals