### PR TITLE
fix(resources): add explicit memory requests to resolve KubeMemoryOvercommit

### DIFF
--- a/kubernetes/apps/default/atuin/app/helmrelease.yaml
+++ b/kubernetes/apps/default/atuin/app/helmrelease.yaml
@@ -51,6 +51,7 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 64Mi
               limits:
                 memory: 256Mi
     defaultPodOptions:

--- a/kubernetes/apps/default/multi-scrobbler/app/helmrelease.yaml
+++ b/kubernetes/apps/default/multi-scrobbler/app/helmrelease.yaml
@@ -64,6 +64,7 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 128Mi
               limits:
                 memory: 512Mi
     defaultPodOptions:

--- a/kubernetes/apps/default/paperless-ngx/app/helmrelease.yaml
+++ b/kubernetes/apps/default/paperless-ngx/app/helmrelease.yaml
@@ -98,6 +98,7 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                memory: 512Mi
               limits:
                 memory: 2Gi
           tika:
@@ -108,6 +109,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities: { drop: ["ALL"] }
             resources:
+              requests:
+                memory: 256Mi
               limits:
                 memory: 512Mi
           gotenberg:
@@ -122,6 +125,8 @@ spec:
               - --chromium-disable-javascript=true
               - --chromium-allow-list=file:///tmp/.*
             resources:
+              requests:
+                memory: 128Mi
               limits:
                 memory: 512Mi
     defaultPodOptions:

--- a/kubernetes/apps/default/searxng/app/helmrelease.yaml
+++ b/kubernetes/apps/default/searxng/app/helmrelease.yaml
@@ -48,6 +48,7 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 256Mi
               limits:
                 memory: 512Mi
     defaultPodOptions:

--- a/kubernetes/apps/default/seerr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/seerr/app/helmrelease.yaml
@@ -88,6 +88,7 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 256Mi
               limits:
                 memory: 2Gi
     defaultPodOptions:

--- a/kubernetes/apps/default/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/default/tautulli/app/helmrelease.yaml
@@ -46,6 +46,7 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 256Mi
               limits:
                 memory: 1Gi
     defaultPodOptions:

--- a/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
@@ -52,6 +52,7 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 128Mi
               limits:
                 memory: 256Mi
     defaultPodOptions:


### PR DESCRIPTION
Adds explicit memory requests to 7 apps that only had limits set (causing request=limit default). Reduces effective cluster memory requests by ~5.6Gi, resolving KubeMemoryOvercommit alert.

**Validation:** YAML valid, kustomize build passes for all affected directories.