### PR TITLE
fix(postgres): restore app database for CNPG metrics exporter

### DIFF
--- a/kubernetes/apps/database/postgres/app/databases/app.yaml
+++ b/kubernetes/apps/database/postgres/app/databases/app.yaml
@@ -6,7 +6,11 @@ metadata:
   name: app
 spec:
   name: app
-  owner: app
-  ensure: absent
+  # Kept as an empty database owned by postgres (the app role stays retired).
+  # The cluster's application database is "app" (recovery bootstrap default), and
+  # the CNPG metrics exporter connects to it to run the default monitoring queries
+  # (cnpg_backends_total, cnpg_pg_*). Dropping it breaks all query-based metrics.
+  owner: postgres
+  ensure: present
   cluster:
     name: postgres-cluster


### PR DESCRIPTION
## Problem

The CNPG metrics dashboard panels are empty. Query-based metrics (`cnpg_backends_total`, `cnpg_pg_database_*`, `cnpg_pg_stat_*`, `cnpg_pg_settings_*`, …) are missing from VictoriaMetrics — only the built-in collectors (`cnpg_collector_*`, `cnpg_cache_*`, `cnpg_pgbouncer_*`) are present.

## Root cause

The CNPG metrics exporter connects to the cluster **application database** to run the default monitoring queries. That database is `app` (the recovery-bootstrap default, since `recovery.database` is empty). Phase 14.1 retired `app` via this `Database` CR (`ensure: absent`), so the exporter fails on every query:

```
Error collecting user query — failed to connect to user=cnpg_metrics_exporter database=app:
FATAL: database "app" does not exist
```

The scrape path itself is healthy (PodMonitor → VMPodScrape `operational`, targets up, correct `namespace`/`pod` labels) — the metrics were simply never produced.

## Fix

Recreate `app` as an **empty** database owned by `postgres` (the `app` *role* stays retired). The default monitoring queries are server/cluster-scoped, so an empty database is a sufficient connection target and all query-based metrics resume. A comment documents the dependency so it isn't dropped again.