### PR TITLE
fix(volsync): prevent cache PVC shrink regression

### DIFF
--- a/kubernetes/apps/default/forejo/ks.yaml
+++ b/kubernetes/apps/default/forejo/ks.yaml
@@ -24,6 +24,7 @@ spec:
     substitute:
       APP: forejo
       VOLSYNC_CAPACITY: 25Gi
+      VOLSYNC_CACHE_CAPACITY: 25Gi
       VOLSYNC_PUID: "1000"
       VOLSYNC_PGID: "1000"
   sourceRef:

--- a/kubernetes/apps/default/ghidra-server/ks.yaml
+++ b/kubernetes/apps/default/ghidra-server/ks.yaml
@@ -23,6 +23,7 @@ spec:
     substitute:
       APP: ghidra-server
       VOLSYNC_CAPACITY: 20Gi
+      VOLSYNC_CACHE_CAPACITY: 20Gi
       GHIDRA_SERVER_IP: 10.60.80.7
       AUTHENTIK_LDAP_HOST: ghidra-ldap.melotic.dev
       AUTHENTIK_LDAP_BASE_DN: OU=ghidra,DC=ldap,DC=melotic,DC=dev

--- a/kubernetes/apps/default/lidarr/ks.yaml
+++ b/kubernetes/apps/default/lidarr/ks.yaml
@@ -25,6 +25,7 @@ spec:
       APP: lidarr
       PG_HOST: postgres-cluster-pooler-rw.database.svc.cluster.local
       VOLSYNC_CAPACITY: 16Gi
+      VOLSYNC_CACHE_CAPACITY: 16Gi
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/default/plex/ks.yaml
+++ b/kubernetes/apps/default/plex/ks.yaml
@@ -21,6 +21,7 @@ spec:
     substitute:
       APP: plex
       VOLSYNC_CAPACITY: 50Gi
+      VOLSYNC_CACHE_CAPACITY: 50Gi
       VOLSYNC_PUID: "1000"
       VOLSYNC_PGID: "1000"
   sourceRef:

--- a/kubernetes/components/volsync/replicationsource.yaml
+++ b/kubernetes/components/volsync/replicationsource.yaml
@@ -13,7 +13,7 @@ spec:
       - ${VOLSYNC_SNAP_ACCESSMODES:=ReadWriteOnce}
     cacheAccessModes:
       - ${VOLSYNC_CACHE_ACCESSMODES:=ReadWriteOnce}
-    cacheCapacity: ${VOLSYNC_CACHE_CAPACITY:=${VOLSYNC_CAPACITY:=8Gi}}
+    cacheCapacity: ${VOLSYNC_CACHE_CAPACITY:=8Gi}
     cacheStorageClassName: ${VOLSYNC_CACHE_STORAGECLASS:=ceph-block}
     compression: zstd-fastest
     copyMethod: Snapshot


### PR DESCRIPTION
## Summary

The nested Flux substitution in ReplicationSource `cacheCapacity`:

```yaml
cacheCapacity: ${VOLSYNC_CACHE_CAPACITY:=${VOLSYNC_CAPACITY:=8Gi}}
```

caused apps with `VOLSYNC_CAPACITY < 8Gi` (e.g. recyclarr=1Gi) to resolve cache capacity to their data volume size, attempting to shrink existing 8Gi cache PVCs and triggering 13 `VolSyncVolumeOutOfSync` alerts.

## Fix

Decouple source cache capacity from `VOLSYNC_CAPACITY`, matching the ReplicationDestination pattern:

```yaml
cacheCapacity: ${VOLSYNC_CACHE_CAPACITY:=8Gi}
```

Cache always defaults to 8Gi unless explicitly overridden via `VOLSYNC_CACHE_CAPACITY`.

## Validation

```
$ flux-local test --enable-helm --all-namespaces --path kubernetes/flux/cluster -v --sources flux-system
============================= 152 passed in 59.97s =============================
```

Rendered ReplicationSource template confirms `cacheCapacity: ${VOLSYNC_CACHE_CAPACITY:=8Gi}` — apps without explicit `VOLSYNC_CACHE_CAPACITY` will use 8Gi regardless of their `VOLSYNC_CAPACITY` setting.

## Live follow-up

After merge and reconciliation, the 13 VolSyncVolumeOutOfSync alerts should auto-resolve on the next replication trigger cycle (≤12h). No PVC deletion or cluster mutation needed.