### PR TITLE
fix: allow buildkitd uidmap helpers

### DIFF
--- a/kubernetes/apps/gitlab-buildkit/buildkitd/app/helmrelease.yaml
+++ b/kubernetes/apps/gitlab-buildkit/buildkitd/app/helmrelease.yaml
@@ -58,7 +58,9 @@ spec:
               seccompProfile:
                 type: Localhost
                 localhostProfile: profiles/buildkit.json
-              capabilities: { drop: ["ALL"] }
+              capabilities:
+                add: ["SETGID", "SETUID"]
+                drop: ["ALL"]
     defaultPodOptions:
       automountServiceAccountToken: false
       securityContext:


### PR DESCRIPTION
## Summary
- add only SETUID and SETGID to buildkitd daemon capabilities
- keeps all other capabilities dropped, Localhost seccomp enabled, and runner build pods unchanged

## Why
- live diagnostic pod proved rootlesskit starts when uidmap helpers have SETUID/SETGID
- without these, buildkitd crashes with `newuidmap ... operation not permitted`

## Validation
- live diagnostic pod with SETUID/SETGID reached Ready and reported a BuildKit worker
- flux-local test --enable-helm --all-namespaces --path kubernetes/flux/cluster -v --sources flux-system (150 passed)