### PR TITLE
fix: allow buildkitd registry egress

### DIFF
--- a/kubernetes/apps/gitlab-buildkit/buildkitd/app/ciliumnetworkpolicy.yaml
+++ b/kubernetes/apps/gitlab-buildkit/buildkitd/app/ciliumnetworkpolicy.yaml
@@ -44,15 +44,8 @@ spec:
               protocol: TCP
             - port: "8080"
               protocol: TCP
-    - toFQDNs:
-        - matchName: harbor.melotic.dev
-        - matchName: docker.io
-        - matchPattern: "*.docker.io"
-        - matchName: ghcr.io
-        - matchName: quay.io
-        - matchName: registry.k8s.io
-        - matchName: gcr.io
-        - matchPattern: "*.gcr.io"
+    - toEntities:
+        - world
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
## Summary
- allow buildkitd egress to `world` on TCP/443 for arbitrary CI registry pulls and Harbor pushes
- keep DNS and in-cluster Harbor egress rules intact

## Why
- CI builds may use base images from any registry, not a curated list
- proof pipeline reached buildkitd successfully but failed on registry/Harbor HTTPS egress

## Validation
- flux-local test --enable-helm --all-namespaces --path kubernetes/flux/cluster -v --sources flux-system (150 passed)