### PR TITLE
fix: allow buildkitd Harbor VIP egress

### DIFF
--- a/kubernetes/apps/gitlab-buildkit/buildkitd/app/ciliumnetworkpolicy.yaml
+++ b/kubernetes/apps/gitlab-buildkit/buildkitd/app/ciliumnetworkpolicy.yaml
@@ -50,3 +50,9 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
+    - toCIDRSet:
+        - cidr: 10.60.88.1/32
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP


### PR DESCRIPTION
## Summary
- allow buildkitd egress to the internal Harbor VIP on TCP/443
- keep arbitrary external registry egress via `world` on TCP/443

## Why
- Cilium `world` does not cover the internal Harbor VIP (`10.60.88.1`)
- BuildKit proof builds successfully but push to Harbor times out without this rule

## Validation
- CI will run flux-local
- live proof retry will run after merge/reconcile