### PR TITLE
fix: allow buildkitd to reach internal envoy

### DIFF
--- a/kubernetes/apps/gitlab/buildkitd/app/ciliumnetworkpolicy.yaml
+++ b/kubernetes/apps/gitlab/buildkitd/app/ciliumnetworkpolicy.yaml
@@ -30,15 +30,16 @@ spec:
           rules:
             dns:
               - matchPattern: "*"
-    - toServices:
-        - k8sService:
-            serviceName: envoy-internal
-            namespace: network
+    - toEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": network
+            "k8s:app.kubernetes.io/component": proxy
+            "k8s:app.kubernetes.io/managed-by": envoy-gateway
+            "k8s:app.kubernetes.io/name": envoy
+            "k8s:gateway.envoyproxy.io/owning-gateway-name": envoy-internal
       toPorts:
         - ports:
-            - port: "80"
-              protocol: TCP
-            - port: "443"
+            - port: "10443"
               protocol: TCP
     - toEntities:
         - world


### PR DESCRIPTION
## Summary
- replace buildkitd CNP `toServices` rule with endpoint-label egress to `network/envoy-internal` pods on targetPort 10443
- keep `world:443` for arbitrary external registry pulls

## Why
- Cilium drop monitor showed Harbor traffic DNATs to Envoy pod `10.42.x.x:10443` with Envoy Gateway identity
- live test confirmed this endpoint-label rule allows `https://harbor.melotic.dev/v2/` from buildkitd

## Validation
- live patched CNP: buildkitd reached Harbor HTTPS and received expected 401 from `/v2/`
- CI will run flux-local and rendered diff