### PR TITLE
fix: add gitlab runner s3 cache

### DIFF
--- a/kubernetes/apps/gitlab-runner/runner/app/externalsecret-cache.yaml
+++ b/kubernetes/apps/gitlab-runner/runner/app/externalsecret-cache.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gitlab-runner-cache-credentials
+spec:
+  secretStoreRef:
+    kind: SecretStore
+    name: gitlab-runner-cache-rgw
+  refreshInterval: 5m
+  target:
+    name: gitlab-runner-cache-credentials
+    template:
+      type: Opaque
+      data:
+        accesskey: "{{ .AccessKey }}"
+        secretkey: "{{ .SecretKey }}"
+  data:
+    - secretKey: AccessKey
+      remoteRef:
+        key: gitlab-runner-cache
+        property: AWS_ACCESS_KEY_ID
+    - secretKey: SecretKey
+      remoteRef:
+        key: gitlab-runner-cache
+        property: AWS_SECRET_ACCESS_KEY

--- a/kubernetes/apps/gitlab-runner/runner/app/helmrelease.yaml
+++ b/kubernetes/apps/gitlab-runner/runner/app/helmrelease.yaml
@@ -26,6 +26,7 @@ spec:
     # CI_SERVER_TOKEN before calling `gitlab-runner register`.
     secrets:
       - name: gitlab-runner-token
+      - name: gitlab-runner-cache-credentials
     runnerRegistrationToken: ""
     runnerToken: ""
 
@@ -101,6 +102,15 @@ spec:
           executor = "kubernetes"
           # Avoid long-polling request bottleneck (chart logs WARNING when =1).
           request_concurrency = 4
+          [runners.cache]
+            Type = "s3"
+            Path = "gitlab-runner"
+            Shared = true
+            [runners.cache.s3]
+              ServerAddress = "rook-ceph-rgw-gitlab-rgw.rook-ceph.svc:80"
+              BucketName = "gitlab-runner-cache"
+              BucketLocation = "us-east-1"
+              Insecure = true
           # FF_USE_FASTZIP: faster artifact upload (chart-recommended).
           # DOCKER_CONFIG: defense-in-depth default for Kaniko/Buildah jobs.
           # The build pod runs as uid 1000 (PSS=restricted), but the kaniko

--- a/kubernetes/apps/gitlab-runner/runner/app/helmrelease.yaml
+++ b/kubernetes/apps/gitlab-runner/runner/app/helmrelease.yaml
@@ -26,7 +26,6 @@ spec:
     # CI_SERVER_TOKEN before calling `gitlab-runner register`.
     secrets:
       - name: gitlab-runner-token
-      - name: gitlab-runner-cache-credentials
     runnerRegistrationToken: ""
     runnerToken: ""
 
@@ -97,6 +96,8 @@ spec:
 
     # config.toml for the K8s executor — controls per-job pod security.
     runners:
+      cache:
+        secretName: gitlab-runner-cache-credentials
       config: |
         [[runners]]
           executor = "kubernetes"

--- a/kubernetes/apps/gitlab-runner/runner/app/kustomization.yaml
+++ b/kubernetes/apps/gitlab-runner/runner/app/kustomization.yaml
@@ -4,6 +4,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./certificate.yaml
+  - ./externalsecret-cache.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./helmrepository.yaml
+  - ./objectbucketclaim.yaml
+  - ./rgw-secretstore.yaml

--- a/kubernetes/apps/gitlab-runner/runner/app/objectbucketclaim.yaml
+++ b/kubernetes/apps/gitlab-runner/runner/app/objectbucketclaim.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/objectbucket.io/objectbucketclaim_v1alpha1.json
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: gitlab-runner-cache
+spec:
+  additionalConfig:
+    bucketOwner: gitlab-rgw
+  bucketName: gitlab-runner-cache
+  storageClassName: gitlab-rgw-bucket

--- a/kubernetes/apps/gitlab-runner/runner/app/rgw-secretstore.yaml
+++ b/kubernetes/apps/gitlab-runner/runner/app/rgw-secretstore.yaml
@@ -1,0 +1,50 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/v1/serviceaccount.json
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gitlab-runner-cache-secret-reader
+automountServiceAccountToken: false
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/rbac.authorization.k8s.io/role_v1.json
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gitlab-runner-cache-secret-reader
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["gitlab-runner-cache"]
+    verbs: ["get"]
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/rbac.authorization.k8s.io/rolebinding_v1.json
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gitlab-runner-cache-secret-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: gitlab-runner-cache-secret-reader
+subjects:
+  - kind: ServiceAccount
+    name: gitlab-runner-cache-secret-reader
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/secretstore_v1.json
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: gitlab-runner-cache-rgw
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: gitlab-runner
+      server:
+        url: https://kubernetes.default.svc
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          key: ca.crt
+      auth:
+        serviceAccount:
+          name: gitlab-runner-cache-secret-reader


### PR DESCRIPTION
## Summary
- add a dedicated `gitlab-runner-cache` RGW ObjectBucketClaim
- map the generated OBC keys into `accesskey`/`secretkey` for the runner chart
- configure GitLab Runner `[runners.cache]` with S3 backend, shared cache, and RGW endpoint

## Why
- Kubernetes executor pods are ephemeral; without a distributed cache backend, CI cache is effectively disabled

## Validation
- CI will run flux-local
- local sanity render confirmed ObjectBucketClaim, SecretStore, ExternalSecret, and `[runners.cache]` are rendered