### PR TITLE
fix: remove stale forejo postgres user

### DIFF
--- a/kubernetes/apps/database/postgres/app/helmrelease.yaml
+++ b/kubernetes/apps/database/postgres/app/helmrelease.yaml
@@ -130,11 +130,6 @@ spec:
           login: true
           passwordSecret:
             name: postgres-user-harbor
-        - name: forejo
-          ensure: present
-          login: true
-          passwordSecret:
-            name: postgres-user-forejo
         - name: paperless
           ensure: present
           login: true


### PR DESCRIPTION
## Summary
- remove the stale `forejo` managed Postgres user from the postgres HelmRelease
- leaves no `forejo` references under `kubernetes/` after Forgejo decommission

## Validation
- `kustomize build kubernetes/apps/database/postgres/app`
- `rg forejo kubernetes --glob "*.yaml"` returned no matches
- CI will run flux-local