### PR TITLE
fix(talos): tune kubelet image garbage collection

### DIFF
--- a/talos/patches/global/machine-kubelet.yaml
+++ b/talos/patches/global/machine-kubelet.yaml
@@ -1,6 +1,8 @@
 machine:
   kubelet:
     extraConfig:
+      imageGCHighThresholdPercent: 70
+      imageGCLowThresholdPercent: 60
       serializeImagePulls: false
     nodeIP:
       validSubnets:


### PR DESCRIPTION
Lower kubelet image GC thresholds to prevent containerd image buildup from triggering Ceph mon free-space warnings.