### PR TITLE
fix(renovate): add HelmRepository namespaces

### DIFF
--- a/kubernetes/apps/kyverno/policy-reporter/app/helmrepository.yaml
+++ b/kubernetes/apps/kyverno/policy-reporter/app/helmrepository.yaml
@@ -4,6 +4,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: policy-reporter
+  namespace: kyverno
 spec:
   interval: 15m
   url: https://kyverno.github.io/policy-reporter


### PR DESCRIPTION
Add explicit metadata.namespace to policy-reporter HelmRepository so Renovate can correctly link chart datasources and avoid skipReason unknown-registry.