### PR TITLE
fix: reduce gitlab runner check interval

### DIFF
--- a/kubernetes/apps/gitlab-runner/runner/app/helmrelease.yaml
+++ b/kubernetes/apps/gitlab-runner/runner/app/helmrelease.yaml
@@ -236,4 +236,4 @@ spec:
               read_only = true
 
     concurrent: 4
-    checkInterval: 30
+    checkInterval: 3


### PR DESCRIPTION
## Summary
- reduce GitLab Runner checkInterval from 30s to the documented 3s default to improve queued-job pickup latency

## Validation
- Not run locally; CI will run Flux validation