### PR TITLE
feat(jellyfin): deploy media server

### DIFF
--- a/kubernetes/apps/default/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/default/jellyfin/app/helmrelease.yaml
@@ -1,0 +1,107 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: jellyfin
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: jellyfin
+  interval: 1h
+  values:
+    controllers:
+      jellyfin:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/jellyfin/jellyfin
+              tag: 10.10.7@sha256:e4d1dc5374344446a3a78e43dd211247f22afba84ea2e5dd9e5852511aea3a46
+            env:
+              TZ: America/Chicago
+              JELLYFIN_PublishedServerUrl: https://jellyfin.melotic.dev
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: &port 8096
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+                squat.ai/video: 1
+              limits:
+                memory: 4Gi
+                squat.ai/video: 1
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values: [k8s-trinity]
+            - weight: 50
+              preference:
+                matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values: [k8s-niobe, k8s-ghost]
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.melotic.dev"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+    persistence:
+      config:
+        existingClaim: jellyfin
+      cache:
+        type: emptyDir
+        globalMounts:
+          - path: /cache
+      media:
+        type: nfs
+        server: "${NAS_SERVER:=nas.internal}"
+        path: /var/nfs/shared/data
+        globalMounts:
+          - path: /data/media
+            subPath: media
+            readOnly: true
+      tmp:
+        type: emptyDir

--- a/kubernetes/apps/default/jellyfin/app/kustomization.yaml
+++ b/kubernetes/apps/default/jellyfin/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./nas.sops.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/default/jellyfin/app/nas.sops.yaml
+++ b/kubernetes/apps/default/jellyfin/app/nas.sops.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: jellyfin-nas
+stringData:
+  NAS_SERVER: ENC[AES256_GCM,data:wZkgytAMbTu6XqTUm0pUTLE2mP5K,iv:55bcqJATTvT0jkospFZxsf5bdEWawyaDhfboj2tRYPY=,tag:euJWohZh4fXVjOPXxcaMNQ==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6dVB2ZCtSQUxDa2pjck5s
+        L0Z6V0ZIWlhmUmR2M1ZFMGM0bmxvMGlWNGpFClN3dXFybHE4SGxiMHN5VmRrT0Ju
+        Um9CTTVXYjJxRUxiMHg0eGkza1FnV28KLS0tIFZQRTlETVUyZkNFcGt6d05ZRU14
+        M210TEcyTXhHckNrSEJoRmQ2a3lrVkkK/Fuhrs34ph6wRVQJ0CWo4PwEsHYOYNlW
+        m+uOa5qcvBpFXyco589dwBdq7ZNwl9DM2wFKbRrQR7+4SsK3UzKt7w==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1d8dtvf39qwejljcn0jj7f29xtlnuav9sagfwy76g2asc0d4zjpqsu0s3pd
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-05-30T16:21:02Z"
+  mac: ENC[AES256_GCM,data:smZPmNq33veV3NejF8xvYTfxN1vZRoseNFPkAFFRt3IS7zqY27tq2CGUpxM9FRYOEMFARnC86pSpLOzlakKPUnBAXgiPMhp3CHeg3mYiqemMK/F6C3G/EDY/1/bJIf3XBG3VIn+F+zJDyZrYf4qTDVXCn9mNGCy0mYXYlyU/+RI=,iv:ESBSpt/LinMfpoETBJykxsE1MEk5VALo8YzvZOQPaI4=,tag:ecf5btTDSFnNrgmNF9bnCg==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.1

--- a/kubernetes/apps/default/jellyfin/app/ocirepository.yaml
+++ b/kubernetes/apps/default/jellyfin/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: jellyfin
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/jellyfin/ks.yaml
+++ b/kubernetes/apps/default/jellyfin/ks.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app jellyfin
+  namespace: &namespace default
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: volsync
+      namespace: volsync-system
+  path: ./kubernetes/apps/default/jellyfin/app
+  postBuild:
+    substitute:
+      APP: jellyfin
+      VOLSYNC_CAPACITY: 10Gi
+      VOLSYNC_PUID: "1000"
+      VOLSYNC_PGID: "1000"
+    substituteFrom:
+      - name: jellyfin-nas
+        kind: Secret
+        optional: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: false

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - ./ghidra-server/ks.yaml
   - ./harbor/ks.yaml
   - ./home-assistant/ks.yaml
+  - ./jellyfin/ks.yaml
   - ./kopia-azure-sync/ks.yaml
   - ./kopia-verify/ks.yaml
   - ./lidarr/ks.yaml


### PR DESCRIPTION
Deploy Jellyfin to the default namespace with NFS media storage, hardware transcoding, volsync backup, and internal HTTPRoute.