### PR TITLE
feat: migrate monitoring to kube-prometheus-stack

### DIFF
--- a/kubernetes/apps/monitoring/fluent-bit/app/grafanadashboard.yaml
+++ b/kubernetes/apps/monitoring/fluent-bit/app/grafanadashboard.yaml
@@ -11,7 +11,7 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: VictoriaMetrics
+    - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   configMapRef:
     name: fluent-bit-dashboard-fluent-bit

--- a/kubernetes/apps/monitoring/fluent-bit/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/fluent-bit/app/helmrelease.yaml
@@ -45,14 +45,6 @@ spec:
             health_check      on
       inputs: |
         [INPUT]
-            Name              tail
-            Path              /var/log/containers/*.log
-            multiline.parser  docker, cri
-            Tag               kube.*
-            Mem_Buf_Limit     5MB
-            Skip_Long_Lines   On
-            Skip_Empty_Lines  On
-        [INPUT]
             Name              syslog
             Tag               syslog.*
             Mode              udp
@@ -60,35 +52,7 @@ spec:
             Port              5140
             Parser            syslog-rfc3164-local
             Buffer_Chunk_Size 64000
-      filters: |-
-        [FILTER]
-            Name                kubernetes
-            Match               kube.*
-            Merge_Log           On
-            Keep_Log            Off
-            K8S-Logging.Parser  On
-            K8S-Logging.Exclude On
-            Buffer_Size         128k
-            Annotations         Off
-            Namespace_Labels    Off
-        [FILTER]
-            Name                nest
-            Match               kube.*
-            Operation           lift
-            Nested_under        kubernetes
-            Add_prefix          k_
-        [FILTER]
-            Name                nest
-            Match               kube.*
-            Operation           lift
-            Nested_under        k_labels
-            Add_prefix          k_labels_
-        [FILTER]
-            Name                modify
-            Match               kube.*
-            Rename              k_labels_app.kubernetes.io/name app
-            Rename              k_labels_app app
-            Rename              k_labels_k8s-app app
+      filters: ""
       customParsers: |-
         [PARSER]
             Name                 syslog-rfc3164-local
@@ -98,16 +62,6 @@ spec:
             Time_Format          %b %d %H:%M:%S
             Time_System_Timezone On
       outputs: |-
-        [OUTPUT]
-            Name                 http
-            Match                kube.*
-            Host                 victoria-logs-server.monitoring.svc.cluster.local
-            Port                 9428
-            URI                  /insert/jsonline?_stream_fields=stream,k_namespace_name,k_pod_name,k_container_name,app&_msg_field=log,message,msg,log_message,event,text,error,err,description,detail,output&_time_field=date
-            Format               json_lines
-            json_date_format     iso8601
-            Compress             gzip
-            Log_response_payload false
         [OUTPUT]
             Name                 http
             Match                syslog.*

--- a/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/external-dns.yaml
+++ b/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/external-dns.yaml
@@ -11,6 +11,6 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: VictoriaMetrics
+    - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   url: https://grafana.com/api/dashboards/15038/revisions/3/download

--- a/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/kubernetes-api-server.yaml
+++ b/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/kubernetes-api-server.yaml
@@ -11,6 +11,6 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: VictoriaMetrics
+    - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   url: https://grafana.com/api/dashboards/15761/revisions/21/download

--- a/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/kubernetes-coredns.yaml
+++ b/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/kubernetes-coredns.yaml
@@ -11,6 +11,6 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: VictoriaMetrics
+    - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   url: https://grafana.com/api/dashboards/15762/revisions/22/download

--- a/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/kubernetes-global.yaml
+++ b/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/kubernetes-global.yaml
@@ -11,6 +11,6 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: VictoriaMetrics
+    - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   url: https://grafana.com/api/dashboards/15757/revisions/43/download

--- a/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/kubernetes-namespaces.yaml
+++ b/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/kubernetes-namespaces.yaml
@@ -11,6 +11,6 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: VictoriaMetrics
+    - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   url: https://grafana.com/api/dashboards/15758/revisions/46/download

--- a/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/kubernetes-nodes.yaml
+++ b/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/kubernetes-nodes.yaml
@@ -11,6 +11,6 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: VictoriaMetrics
+    - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   url: https://grafana.com/api/dashboards/15759/revisions/40/download

--- a/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/kubernetes-pods.yaml
+++ b/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/kubernetes-pods.yaml
@@ -11,6 +11,6 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: VictoriaMetrics
+    - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   url: https://grafana.com/api/dashboards/15760/revisions/39/download

--- a/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/kubernetes-volumes.yaml
+++ b/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/kubernetes-volumes.yaml
@@ -11,6 +11,6 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: VictoriaMetrics
+    - datasourceName: prometheus
       inputName: DS_OPENSHIFT_PROMETHEUS
   url: https://grafana.com/api/dashboards/11454/revisions/14/download

--- a/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/node-exporter-full.yaml
+++ b/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/node-exporter-full.yaml
@@ -11,6 +11,6 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: VictoriaMetrics
+    - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   url: https://grafana.com/api/dashboards/1860/revisions/42/download

--- a/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/vm-stack.yaml
+++ b/kubernetes/apps/monitoring/grafana/instance/grafanadashboards/vm-stack.yaml
@@ -11,6 +11,6 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: VictoriaMetrics
+    - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   url: https://grafana.com/api/dashboards/19105/revisions/7/download

--- a/kubernetes/apps/monitoring/grafana/instance/grafanadatasource.yaml
+++ b/kubernetes/apps/monitoring/grafana/instance/grafanadatasource.yaml
@@ -3,6 +3,24 @@
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDatasource
 metadata:
+  name: prometheus
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasource:
+    name: prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    url: http://prometheus-operated.monitoring.svc.cluster.local:9090
+    isDefault: true
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadatasource_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
   name: victorialogs
 spec:
   allowCrossNamespaceImport: true

--- a/kubernetes/apps/monitoring/grafana/ks.yaml
+++ b/kubernetes/apps/monitoring/grafana/ks.yaml
@@ -31,7 +31,7 @@ spec:
       app.kubernetes.io/name: grafana
   dependsOn:
     - name: grafana
-    - name: victoria-metrics-k8s-stack
+    - name: kube-prometheus-stack
     - name: rook-ceph-cluster
       namespace: rook-ceph
   path: ./kubernetes/apps/monitoring/grafana/instance

--- a/kubernetes/apps/monitoring/kromgo/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kromgo/app/helmrelease.yaml
@@ -21,7 +21,7 @@ spec:
               repository: ghcr.io/kashalls/kromgo
               tag: v0.10.0@sha256:965ecc92d68dc1a4a969397855367bbc70da03227a941ea607b73bb7e0b78fd6
             env:
-              PROMETHEUS_URL: http://vmsingle-vm-kube-stack.monitoring.svc.cluster.local:8428
+              PROMETHEUS_URL: http://prometheus-operated.monitoring.svc.cluster.local:9090
               SERVER_PORT: &port 80
               HEALTH_PORT: &healthPort 8080
             probes:

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/alertmanagerconfig.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/alertmanagerconfig.yaml
@@ -1,0 +1,97 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/alertmanagerconfig_v1alpha1.json
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: alertmanager
+spec:
+  route:
+    receiver: blackhole
+    groupBy: ["alertname", "job"]
+    groupWait: 1m
+    groupInterval: 10m
+    repeatInterval: 12h
+    routes:
+      - receiver: pushover
+        matchers:
+          - name: severity
+            value: critical
+            matchType: =
+        continue: true
+      - receiver: pushover
+        matchers:
+          - name: severity
+            value: warning
+            matchType: =
+        continue: true
+      - receiver: pushover
+        matchers:
+          - name: severity
+            value: error
+            matchType: =
+        continue: true
+      - receiver: webhook
+        matchers:
+          - name: severity
+            value: critical|warning|error
+            matchType: =~
+  inhibitRules:
+    - equal: ["namespace", "alertname"]
+      sourceMatch:
+        - name: severity
+          value: critical
+          matchType: =
+      targetMatch:
+        - name: severity
+          value: warning|info
+          matchType: =~
+  receivers:
+    - name: blackhole
+    - name: pushover
+      pushoverConfigs:
+        - html: true
+          sendResolved: true
+          sound: gamelan
+          ttl: 86400s
+          priority: '{{ if eq .Status "firing" }}1{{ else }}0{{ end }}'
+          title: >-
+            [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}]
+            {{ .CommonLabels.alertname }}
+          message: |-
+            {{- range .Alerts }}
+              {{- if ne .Annotations.description "" }}
+                {{ .Annotations.description }}
+              {{- else if ne .Annotations.summary "" }}
+                {{ .Annotations.summary }}
+              {{- else if ne .Annotations.message "" }}
+                {{ .Annotations.message }}
+              {{- else }}
+                Alert description not available
+              {{- end }}
+              {{- if gt (len .Labels.SortedPairs) 0 }}
+                <small>
+                  {{- range .Labels.SortedPairs }}
+                    <b>{{ .Name }}:</b> {{ .Value }}
+                  {{- end }}
+                </small>
+              {{- end }}
+            {{- end }}
+          token:
+            name: alertmanager-secret
+            key: PUSHOVER_API_TOKEN
+          userKey:
+            name: alertmanager-secret
+            key: PUSHOVER_API_KEY
+          urlTitle: View in Alertmanager
+    - name: webhook
+      webhookConfigs:
+        - sendResolved: true
+          urlSecret:
+            name: alertmanager-webhook-secret
+            key: WEBHOOK_URL
+          httpConfig:
+            authorization:
+              type: Bearer
+              credentials:
+                name: alertmanager-webhook-secret
+                key: WEBHOOK_TOKEN

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/grafanadashboard.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/grafanadashboard.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: prometheus
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_PROMETHEUS
+  url: https://grafana.com/api/dashboards/19105/revisions/9/download

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -1,0 +1,149 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kube-prometheus-stack
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: kube-prometheus-stack
+  interval: 1h
+  values:
+    cleanPrometheusOperatorObjectNames: true
+    crds:
+      enabled: false
+      upgradeJob:
+        enabled: false
+    grafana:
+      enabled: false
+      forceDeployDashboards: true
+      operator:
+        dashboardsConfigMapRefEnabled: true
+        folder: General
+        matchLabels:
+          dashboards: grafana
+    alertmanager:
+      route:
+        main:
+          enabled: true
+          hostnames:
+            - alertmanager.${SECRET_DOMAIN}
+          parentRefs:
+            - name: envoy-internal
+              namespace: network
+              sectionName: https
+      alertmanagerSpec:
+        alertmanagerConfiguration:
+          name: alertmanager
+        externalUrl: https://alertmanager.${SECRET_DOMAIN}
+        resources:
+          requests:
+            cpu: 25m
+            memory: 128Mi
+          limits:
+            memory: 256Mi
+        storage:
+          volumeClaimTemplate:
+            spec:
+              storageClassName: ceph-block
+              resources:
+                requests:
+                  storage: 1Gi
+    prometheus:
+      route:
+        main:
+          enabled: true
+          hostnames:
+            - prometheus.${SECRET_DOMAIN}
+          parentRefs:
+            - name: envoy-internal
+              namespace: network
+              sectionName: https
+      prometheusSpec:
+        externalUrl: https://prometheus.${SECRET_DOMAIN}
+        evaluationInterval: 1m
+        scrapeInterval: 1m
+        podMonitorSelectorNilUsesHelmValues: false
+        probeSelectorNilUsesHelmValues: false
+        ruleSelectorNilUsesHelmValues: false
+        scrapeConfigSelectorNilUsesHelmValues: false
+        serviceMonitorSelectorNilUsesHelmValues: false
+        retention: 31d
+        retentionSize: 40GB
+        resources:
+          requests:
+            cpu: 250m
+            memory: 1Gi
+          limits:
+            memory: 4Gi
+        storageSpec:
+          volumeClaimTemplate:
+            spec:
+              storageClassName: ceph-block
+              resources:
+                requests:
+                  storage: 50Gi
+    prometheusOperator:
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          memory: 256Mi
+      prometheusConfigReloader:
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            memory: 64Mi
+    nodeExporter:
+      enabled: false
+    kubeStateMetrics:
+      enabled: false
+    kubeProxy:
+      enabled: false
+    kubeEtcd:
+      service:
+        port: 2381
+        targetPort: 2381
+        selector:
+          component: kube-apiserver
+      serviceMonitor:
+        endpoints:
+          - port: http-metrics
+            scheme: http
+            path: /metrics
+            metricRelabelings:
+              - action: drop
+                regex: (etcd_request|apiserver_request_slo|apiserver_request_sli|apiserver_request)_duration_seconds_bucket;(0\.15|0\.2|0\.3|0\.35|0\.4|0\.45|0\.6|0\.7|0\.8|0\.9|1\.25|1\.5|1\.75|2|3|3\.5|4|4\.5|6|7|8|9|15|20|40|45|50)(\.0)?
+                sourceLabels:
+                  - __name__
+                  - le
+    kubeApiServer:
+      serviceMonitor:
+        metricRelabelings:
+          - action: drop
+            regex: (etcd_request|apiserver_request_slo|apiserver_request_sli|apiserver_request)_duration_seconds_bucket;(0\.15|0\.2|0\.3|0\.35|0\.4|0\.45|0\.6|0\.7|0\.8|0\.9|1\.25|1\.5|1\.75|2|3|3\.5|4|4\.5|6|7|8|9|15|20|40|45|50)(\.0)?
+            sourceLabels:
+              - __name__
+              - le
+          - action: drop
+            regex: apiserver_request_body_size_bytes_bucket|apiserver_watch_list_duration_seconds_bucket|apiserver_watch_cache_read_wait_seconds_bucket|apiserver_response_sizes_bucket|apiserver_watch_events_sizes_bucket|workqueue_work_duration_seconds_bucket
+            sourceLabels:
+              - __name__
+    kubeScheduler:
+      serviceMonitor:
+        metricRelabelings:
+          - action: drop
+            regex: scheduler_plugin_execution_duration_seconds_bucket|workqueue_work_duration_seconds_bucket
+            sourceLabels:
+              - __name__
+    kubeControllerManager:
+      serviceMonitor:
+        metricRelabelings:
+          - action: drop
+            regex: workqueue_work_duration_seconds_bucket
+            sourceLabels:
+              - __name__

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
         main:
           enabled: true
           hostnames:
-            - alertmanager.${SECRET_DOMAIN}
+            - alertmanager.melotic.dev
           parentRefs:
             - name: envoy-internal
               namespace: network
@@ -36,7 +36,7 @@ spec:
       alertmanagerSpec:
         alertmanagerConfiguration:
           name: alertmanager
-        externalUrl: https://alertmanager.${SECRET_DOMAIN}
+        externalUrl: https://alertmanager.melotic.dev
         resources:
           requests:
             cpu: 25m
@@ -55,13 +55,13 @@ spec:
         main:
           enabled: true
           hostnames:
-            - prometheus.${SECRET_DOMAIN}
+            - prometheus.melotic.dev
           parentRefs:
             - name: envoy-internal
               namespace: network
               sectionName: https
       prometheusSpec:
-        externalUrl: https://prometheus.${SECRET_DOMAIN}
+        externalUrl: https://prometheus.melotic.dev
         evaluationInterval: 1m
         scrapeInterval: 1m
         podMonitorSelectorNilUsesHelmValues: false

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./alertmanagerconfig.yaml
+  - ./grafanadashboard.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./prometheusrule.yaml
+  - ./servicemonitor-exporters.yaml

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/ocirepository.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kube-prometheus-stack
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 86.0.0
+  url: oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/prometheusrule.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/prometheusrule.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: home-ops-rules
+spec:
+  groups:
+    - name: dockerhub
+      rules:
+        - alert: DockerhubRateLimitRisk
+          annotations:
+            summary: Kubernetes cluster Dockerhub rate limit risk
+          expr: count(time() - container_last_seen{image=~"(docker.io).*",container!=""} < 30) > 100
+          labels:
+            severity: critical
+    - name: oom
+      rules:
+        - alert: OomKilled
+          annotations:
+            summary: Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} has been OOMKilled {{ $value }} times in the last 10 minutes.
+          expr: (kube_pod_container_status_restarts_total - kube_pod_container_status_restarts_total offset 10m >= 1) and ignoring (reason) min_over_time(kube_pod_container_status_last_terminated_reason{reason="OOMKilled"}[10m]) == 1
+          labels:
+            severity: critical

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/servicemonitor-exporters.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/servicemonitor-exporters.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: existing-node-exporter
+spec:
+  jobLabel: jobLabel
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: victoria-metrics-k8s-stack
+      app.kubernetes.io/name: prometheus-node-exporter
+  endpoints:
+    - port: metrics
+      scheme: http
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: existing-kube-state-metrics
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: victoria-metrics-k8s-stack
+      app.kubernetes.io/name: kube-state-metrics
+  endpoints:
+    - port: http
+      scheme: http

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/ks.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/ks.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app kube-prometheus-stack
+  namespace: &namespace monitoring
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: prometheus-operator-crds
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  path: ./kubernetes/apps/monitoring/kube-prometheus-stack/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: false

--- a/kubernetes/apps/monitoring/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kustomization.yaml
@@ -16,5 +16,6 @@ resources:
   - ./silence-operator/ks.yaml
   - ./smartctl-exporter/ks.yaml
   - ./unpoller/ks.yaml
+  - ./victoria-logs-collector/ks.yaml
   - ./victoria-logs/ks.yaml
   - ./victoria-metrics-k8s-stack/ks.yaml

--- a/kubernetes/apps/monitoring/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - ./gatus/ks.yaml
   - ./grafana/ks.yaml
   - ./kromgo/ks.yaml
+  - ./kube-prometheus-stack/ks.yaml
   - ./prometheus-operator-crds/ks.yaml
   - ./silence-operator/ks.yaml
   - ./smartctl-exporter/ks.yaml

--- a/kubernetes/apps/monitoring/silence-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/silence-operator/app/helmrelease.yaml
@@ -17,7 +17,7 @@ spec:
     remediation:
       retries: 3
   values:
-    alertmanagerAddress: http://vmalertmanager-vm-kube-stack.monitoring.svc.cluster.local:9093
+    alertmanagerAddress: http://alertmanager-operated.monitoring.svc.cluster.local:9093
     image:
       tag: 0.20.1@sha256:99f087838f39830f587ab7897708ad9155ccd71a5d71e76e81b9217e6eaa386f
     networkPolicy:

--- a/kubernetes/apps/monitoring/silence-operator/ks.yaml
+++ b/kubernetes/apps/monitoring/silence-operator/ks.yaml
@@ -10,7 +10,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
-    - name: victoria-metrics-k8s-stack
+    - name: kube-prometheus-stack
   path: ./kubernetes/apps/monitoring/silence-operator/app
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/monitoring/smartctl-exporter/app/grafanadashboard.yaml
+++ b/kubernetes/apps/monitoring/smartctl-exporter/app/grafanadashboard.yaml
@@ -11,6 +11,6 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: VictoriaMetrics
+    - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   url: https://grafana.com/api/dashboards/22604/revisions/2/download

--- a/kubernetes/apps/monitoring/unpoller/app/grafanadashboard-insights.yaml
+++ b/kubernetes/apps/monitoring/unpoller/app/grafanadashboard-insights.yaml
@@ -11,6 +11,6 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: VictoriaMetrics
+    - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   url: https://grafana.com/api/dashboards/11315/revisions/9/download

--- a/kubernetes/apps/monitoring/unpoller/app/grafanadashboard-pdu.yaml
+++ b/kubernetes/apps/monitoring/unpoller/app/grafanadashboard-pdu.yaml
@@ -11,6 +11,6 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: VictoriaMetrics
+    - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   url: https://grafana.com/api/dashboards/23027/revisions/1/download

--- a/kubernetes/apps/monitoring/unpoller/app/grafanadashboard-sites.yaml
+++ b/kubernetes/apps/monitoring/unpoller/app/grafanadashboard-sites.yaml
@@ -11,6 +11,6 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: VictoriaMetrics
+    - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   url: https://grafana.com/api/dashboards/11311/revisions/5/download

--- a/kubernetes/apps/monitoring/unpoller/app/grafanadashboard-uap.yaml
+++ b/kubernetes/apps/monitoring/unpoller/app/grafanadashboard-uap.yaml
@@ -11,6 +11,6 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: VictoriaMetrics
+    - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   url: https://grafana.com/api/dashboards/11314/revisions/10/download

--- a/kubernetes/apps/monitoring/unpoller/app/grafanadashboard-usw.yaml
+++ b/kubernetes/apps/monitoring/unpoller/app/grafanadashboard-usw.yaml
@@ -11,6 +11,6 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: VictoriaMetrics
+    - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   url: https://grafana.com/api/dashboards/11312/revisions/9/download

--- a/kubernetes/apps/monitoring/victoria-logs-collector/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/victoria-logs-collector/app/helmrelease.yaml
@@ -1,0 +1,60 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: victoria-logs-collector
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: victoria-logs-collector
+  interval: 1h
+  values:
+    fullnameOverride: victoria-logs-collector
+    remoteWrite:
+      - url: http://victoria-logs-server.monitoring.svc.cluster.local:9428
+    collector:
+      msgField:
+        - message
+        - msg
+        - log
+        - log_message
+        - event
+        - text
+        - error
+        - err
+        - description
+        - detail
+        - output
+      streamFields:
+        - kubernetes.container_name
+        - kubernetes.pod_name
+        - kubernetes.pod_namespace
+      includePodLabels: true
+      includePodAnnotations: false
+      includeNodeLabels: false
+      includeNodeAnnotations: false
+    persistence:
+      volume:
+        emptyDir: {}
+    podMonitor:
+      enabled: true
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+    podSecurityContext:
+      enabled: true
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+      fsGroupChangePolicy: OnRootMismatch
+    securityContext:
+      enabled: true
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop: ["ALL"]

--- a/kubernetes/apps/monitoring/victoria-logs-collector/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/victoria-logs-collector/app/helmrelease.yaml
@@ -11,6 +11,8 @@ spec:
   interval: 1h
   values:
     fullnameOverride: victoria-logs-collector
+    image:
+      registry: docker.io
     remoteWrite:
       - url: http://victoria-logs-server.monitoring.svc.cluster.local:9428
     collector:

--- a/kubernetes/apps/monitoring/victoria-logs-collector/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/victoria-logs-collector/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/monitoring/victoria-logs-collector/app/ocirepository.yaml
+++ b/kubernetes/apps/monitoring/victoria-logs-collector/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: victoria-logs-collector
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.3.4
+  url: oci://ghcr.io/victoriametrics/helm-charts/victoria-logs-collector

--- a/kubernetes/apps/monitoring/victoria-logs-collector/ks.yaml
+++ b/kubernetes/apps/monitoring/victoria-logs-collector/ks.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app victoria-logs-collector
+  namespace: &namespace monitoring
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: victoria-logs
+  path: ./kubernetes/apps/monitoring/victoria-logs-collector/app
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: false

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/grafanadashboard.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/grafanadashboard.yaml
@@ -10,7 +10,7 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: VictoriaMetrics
+    - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   url: https://grafana.com/api/dashboards/2842/revisions/18/download
 ---
@@ -25,7 +25,7 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: VictoriaMetrics
+    - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   url: https://grafana.com/api/dashboards/5336/revisions/9/download
 ---
@@ -40,6 +40,6 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: VictoriaMetrics
+    - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   url: https://grafana.com/api/dashboards/5342/revisions/9/download

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -51,7 +51,7 @@ spec:
           enabled: false
       dashboard:
         enabled: true
-        prometheusEndpoint: http://vmsingle-vm-kube-stack.monitoring.svc.cluster.local:8428
+        prometheusEndpoint: http://prometheus-operated.monitoring.svc.cluster.local:9090
         ssl: false
         urlPrefix: /
       mgr:

--- a/kubernetes/components/alerts/alertmanager/provider.yaml
+++ b/kubernetes/components/alerts/alertmanager/provider.yaml
@@ -6,4 +6,4 @@ metadata:
   name: alertmanager
 spec:
   type: alertmanager
-  address: http://vmalertmanager-vm-kube-stack.monitoring.svc.cluster.local:9093/api/v2/alerts/
+  address: http://alertmanager-operated.monitoring.svc.cluster.local:9093/api/v2/alerts/


### PR DESCRIPTION
## Summary
- add kube-prometheus-stack alongside the existing VictoriaMetrics stack
- replace Kubernetes container log collection with native victoria-logs-collector while keeping Fluent Bit for syslog
- rewire Grafana dashboards, Alertmanager integrations, Kromgo, and Rook to Prometheus/Alertmanager endpoints

## Validation
- kustomize build for affected apps/components
- helm template for kube-prometheus-stack and victoria-logs-collector
- CI Flux Local Success required before merge

Planning artifacts are intentionally not committed.