### PR TITLE
fix: repair victoria-logs collector startup

### DIFF
--- a/kubernetes/apps/monitoring/victoria-logs-collector/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/victoria-logs-collector/app/helmrelease.yaml
@@ -13,6 +13,9 @@ spec:
     fullnameOverride: victoria-logs-collector
     image:
       registry: docker.io
+      tag: v1.50.0@sha256:89693ad27a728bb6971e533eb7b121ad00cf38efdbdda2ec4bf056a348f5ca82
+    extraArgs:
+      tmpDataPath: /tmp
     remoteWrite:
       - url: http://victoria-logs-server.monitoring.svc.cluster.local:9428
     collector:


### PR DESCRIPTION
## Summary
- mount victoria-logs-collector scratch data at /tmp so read-only root filesystem can start
- pin vlagent image by digest while retaining allowed docker.io registry prefix

## Validation
- kustomize build kubernetes/apps/monitoring/victoria-logs-collector/app
- helm template victoria-logs-collector confirms /tmp mount and pinned image