### PR TITLE
fix: allow victoria-logs collector to read host logs

### DIFF
--- a/kubernetes/apps/monitoring/victoria-logs-collector/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/victoria-logs-collector/app/helmrelease.yaml
@@ -52,14 +52,17 @@ spec:
         memory: 512Mi
     podSecurityContext:
       enabled: true
-      runAsNonRoot: true
-      runAsUser: 1000
-      runAsGroup: 1000
-      fsGroup: 1000
+      runAsNonRoot: false
+      runAsUser: 0
+      runAsGroup: 0
+      fsGroup: 0
       fsGroupChangePolicy: OnRootMismatch
     securityContext:
       enabled: true
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true
+      runAsNonRoot: false
+      runAsUser: 0
+      runAsGroup: 0
       capabilities:
         drop: ["ALL"]


### PR DESCRIPTION
## Summary
- run victoria-logs-collector as UID 0 so it can read host container log files
- keep no privilege escalation, read-only root filesystem, and dropped capabilities

## Validation
- kustomize build kubernetes/apps/monitoring/victoria-logs-collector/app
- helm template victoria-logs-collector confirms root UID plus restricted container controls