### PR TITLE
fix(jellyfin): expose service through load balancer

### DIFF
--- a/kubernetes/apps/default/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/default/jellyfin/app/helmrelease.yaml
@@ -77,6 +77,10 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
     service:
       app:
+        type: LoadBalancer
+        annotations:
+          lbipam.cilium.io/ips: 10.60.80.8
+        externalTrafficPolicy: Local
         ports:
           http:
             port: *port


### PR DESCRIPTION
Switch Jellyfin service from ClusterIP to LoadBalancer with Cilium LB IPAM (10.60.80.8) and externalTrafficPolicy: Local.