### PR TITLE
fix: restore alertmanager notification secrets

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/externalsecret-webhook.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/externalsecret-webhook.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: alertmanager-webhook
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: alertmanager-webhook-secret
+    template:
+      data:
+        WEBHOOK_URL: "{{ .WEBHOOK_URL }}"
+        WEBHOOK_TOKEN: "{{ .WEBHOOK_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: alertmanager

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/externalsecret.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: alertmanager
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: alertmanager-secret
+    template:
+      data:
+        PUSHOVER_API_TOKEN: "{{ .PUSHOVER_API_TOKEN }}"
+        PUSHOVER_API_KEY: "{{ .PUSHOVER_API_KEY }}"
+  dataFrom:
+    - extract:
+        key: pushover

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
@@ -4,6 +4,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./alertmanagerconfig.yaml
+  - ./externalsecret-webhook.yaml
+  - ./externalsecret.yaml
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml


### PR DESCRIPTION
## Summary
- restore the Alertmanager Pushover and webhook ExternalSecrets under kube-prometheus-stack
- keep the existing target secret names referenced by AlertmanagerConfig

## Validation
- kustomize build kubernetes/apps/monitoring/kube-prometheus-stack/app
- kubectl apply --dry-run=server -k kubernetes/apps/monitoring/kube-prometheus-stack/app