### PR TITLE
fix(jellyfin): roll back broken 10.11 image

### DIFF
--- a/kubernetes/apps/default/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/default/jellyfin/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
           app:
             image:
               repository: ghcr.io/jellyfin/jellyfin
-              tag: 10.11.10@sha256:6497f0245de93fac642926c065b427362ca5e626e659f690516599c8c3817a38
+              tag: 10.10.7@sha256:e4d1dc5374344446a3a78e43dd211247f22afba84ea2e5a13cbe1a94e1ff2141
             env:
               TZ: America/Chicago
               JELLYFIN_PublishedServerUrl: https://jellyfin.melotic.dev


### PR DESCRIPTION
Rolls back Jellyfin to 10.10.7, the 10.11.x line crashes on startup due to a database migration bug (jellyfin/jellyfin#15388).