### PR TITLE
fix(jellyfin): recover failed 10.11 migration

### DIFF
--- a/kubernetes/apps/default/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/default/jellyfin/app/helmrelease.yaml
@@ -14,11 +14,60 @@ spec:
       jellyfin:
         annotations:
           reloader.stakater.com/auto: "true"
+        initContainers:
+          migration-recovery:
+            image:
+              repository: docker.io/library/busybox
+              tag: 1.37.0
+            command:
+              - /bin/sh
+              - -c
+              - |
+                MARKER="/config/recovery-backups/10.11-migration-xml-disabled"
+                if [ -f "$MARKER" ]; then
+                  echo "migration-recovery: already applied, skipping"
+                  exit 0
+                fi
+                TS=$(date +%Y%m%d-%H%M%S)
+                BACKUP_DIR="/config/recovery-backups/${TS}"
+                mkdir -p "$BACKUP_DIR"
+                # Backup key files if they exist
+                for f in \
+                  /config/data/jellyfin.db \
+                  /config/data/library.db \
+                  /config/config/migrations.xml \
+                  /config/config/migration.xml \
+                  /config/migrations.xml \
+                  /config/migration.xml; do
+                  if [ -f "$f" ]; then
+                    cp "$f" "$BACKUP_DIR/$(echo "$f" | sed 's|/|_|g')"
+                    echo "backed up: $f"
+                  fi
+                done
+                # Rename legacy migration XML files out of the way
+                for f in \
+                  /config/config/migrations.xml \
+                  /config/config/migration.xml \
+                  /config/migrations.xml \
+                  /config/migration.xml; do
+                  if [ -f "$f" ]; then
+                    mv "$f" "${f}.disabled-${TS}"
+                    echo "disabled: $f -> ${f}.disabled-${TS}"
+                  fi
+                done
+                # Write marker so this is idempotent
+                mkdir -p /config/recovery-backups
+                echo "applied at ${TS}" > "$MARKER"
+                echo "migration-recovery: done"
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
         containers:
           app:
             image:
               repository: ghcr.io/jellyfin/jellyfin
-              tag: 10.10.7@sha256:e4d1dc5374344446a3a78e43dd211247f22afba84ea2e5a13cbe1a94e1ff2141
+              tag: 10.11.10@sha256:6497f0245de93fac642926c065b427362ca5e626e659f690516599c8c3817a38
             env:
               TZ: America/Chicago
               JELLYFIN_PublishedServerUrl: https://jellyfin.melotic.dev


### PR DESCRIPTION
Move Jellyfin forward to 10.11.10 with an initContainer that backs up and disables legacy migration XML blocking startup after the partial schema migration.