### PR TITLE
fix: add alertmanager webhook tailnet egress

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - ./ocirepository.yaml
   - ./prometheusrule.yaml
   - ./servicemonitor-exporters.yaml
+  - ./tailscale-egress.yaml

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/tailscale-egress.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/tailscale-egress.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/service_v1.json
+apiVersion: v1
+kind: Service
+metadata:
+  name: disco-ninja
+  annotations:
+    tailscale.com/tailnet-fqdn: disco-ninja.tail88eb4.ts.net.
+spec:
+  type: ExternalName
+  externalName: placeholder
+  ports:
+    - name: https
+      port: 443
+      protocol: TCP


### PR DESCRIPTION
## Summary
- add a Tailscale cluster-egress ExternalName Service for the webhook tailnet endpoint
- keep the existing Alertmanager webhook URL so TLS/SNI still uses the MagicDNS name

## Validation
- kustomize build kubernetes/apps/monitoring/kube-prometheus-stack/app
- kubectl apply --dry-run=server -k kubernetes/apps/monitoring/kube-prometheus-stack/app