### PR TITLE
fix: avoid VictoriaLogs missing message records

### DIFF
--- a/kubernetes/apps/monitoring/fluent-bit/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/fluent-bit/app/helmrelease.yaml
@@ -67,7 +67,7 @@ spec:
             Match                syslog.*
             Host                 victoria-logs-server.monitoring.svc.cluster.local
             Port                 9428
-            URI                  /insert/jsonline?_stream_fields=host,ident&_msg_field=message&_time_field=date
+            URI                  /insert/jsonline?_stream_fields=host,ident&_msg_field=message,log&_time_field=date
             Format               json_lines
             json_date_format     iso8601
             Compress             gzip

--- a/kubernetes/apps/monitoring/victoria-logs-collector/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/victoria-logs-collector/app/helmrelease.yaml
@@ -31,6 +31,17 @@ spec:
         - description
         - detail
         - output
+        - route
+        - route_name
+        - path
+        - x-envoy-origin-path
+        - method
+        - action
+        - controller
+        - hostname
+        - host
+        - component
+        - severity
       streamFields:
         - kubernetes.container_name
         - kubernetes.pod_name

--- a/kubernetes/apps/monitoring/victoria-logs/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/victoria-logs/app/helmrelease.yaml
@@ -19,6 +19,8 @@ spec:
         storageClassName: ceph-block
         size: 20Gi
       retentionPeriod: 14d
+      extraArgs:
+        defaultMsgValue: structured log record
       route:
         enabled: false
       serviceMonitor:


### PR DESCRIPTION
## Summary
- add structured-log fields as VictoriaLogs collector message fallbacks
- set a neutral VictoriaLogs default message for records that genuinely have no message-like field
- let Fluent Bit syslog fallback to raw log when RFC3164 parsing does not populate message

## Validation
- kustomize build for victoria-logs, victoria-logs-collector, and fluent-bit
- helm template confirms defaultMsgValue, collector msgField list, and Fluent Bit _msg_field fallbacks