### PR TITLE
fix: remove Longhorn-only Talos extensions

### DIFF
--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -58,10 +58,8 @@ nodes:
           officialExtensions:
             - siderolabs/amd-ucode
             - siderolabs/amdgpu
-            - siderolabs/iscsi-tools
             - siderolabs/nfs-utils
             - siderolabs/realtek-firmware
-            - siderolabs/util-linux-tools
 
   - hostname: "k8s-trinity"
     ipAddress: "10.60.85.11"
@@ -102,9 +100,7 @@ nodes:
           officialExtensions:
             - siderolabs/i915
             - siderolabs/intel-ucode
-            - siderolabs/iscsi-tools
             - siderolabs/nfs-utils
-            - siderolabs/util-linux-tools
 
   - hostname: "k8s-ghost"
     ipAddress: "10.60.85.12"
@@ -145,10 +141,8 @@ nodes:
           officialExtensions:
             - siderolabs/amd-ucode
             - siderolabs/amdgpu
-            - siderolabs/iscsi-tools
             - siderolabs/nfs-utils
             - siderolabs/realtek-firmware
-            - siderolabs/util-linux-tools
 
 # Global patches
 patches:


### PR DESCRIPTION
## Summary
- remove siderolabs/iscsi-tools and siderolabs/util-linux-tools from all node schematics after Longhorn removal
- keep siderolabs/nfs-utils because NFS workloads remain in use

## Validation
- grep confirms Longhorn-only Talos extensions are absent from talconfig.yaml
- grep confirms nfs-utils remains on all nodes

Note: live Talos apply/reboot remains operator-owned.