### PR TITLE
chore: archive v1.1 milestone

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -1,0 +1,35 @@
+# home-ops
+
+## What This Is
+
+GitOps source of truth for the Zion Talos Kubernetes cluster running media, home automation, monitoring, networking, storage, GitLab, and related platform services.
+
+## Current State
+
+Shipped version: **v1.1 Storage & Migration Foundations** (completed 2026-05-30).
+
+v1.1 replaced temporary foundations with durable platform paths:
+
+- Longhorn was removed from GitOps and live cluster operation.
+- Rook-Ceph/OpenEBS storage paths are established for current workloads.
+- GitLab and GitLab Runner were rebuilt and validated on the new storage/CI path.
+- kube-prometheus-stack is the production metrics/alerting path.
+- VictoriaLogs remains the production log backend with native collector ingestion and `_msg` repair.
+- Longhorn-only Talos source extensions (`iscsi-tools`, `util-linux-tools`) were removed; `nfs-utils` remains for active NFS workloads.
+
+## Next Milestone Goals
+
+No next milestone is defined yet. Use `/gsd-new-milestone` to gather requirements, research the next focus area, and generate the next roadmap.
+
+## Archived Context
+
+<details>
+<summary>v1.1 project context before milestone archive</summary>
+
+Milestone v1.1 changed the observability direction: v1.0 intentionally stayed on VictoriaMetrics while adopting onedr0p-style operational patterns, but v1.1 migrated metrics/alerting back to kube-prometheus-stack after memory-reduction gates and rollback boundaries were defined.
+
+Longhorn removal was a hard v1.1 requirement. GitLab object data was disposable because GitLab was not in use yet, while other Longhorn PVCs required explicit disposition: preserve with `pv-migrate`, preserve with Kopia/VolSync restore, preserve with app-native migration, recreate/destroy, or decommission first.
+
+GitLab already had Authentik OIDC wiring for the `groups` scope and `gitlab-admins` admin group, but v1.1 validated live GitLab behavior instead of assuming group-to-admin sync worked as intended. Because GitLab was not yet in use, a clean rebuild after Rook-Ceph readiness was acceptable once live evidence proved Gitaly contained no repositories that needed preservation.
+
+</details>

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,0 +1,25 @@
+# Roadmap: home-ops
+
+## Overview
+
+`home-ops` is the GitOps source of truth for the Zion Talos Kubernetes cluster.
+
+Milestone v1.0 established safer GitOps operations, scheduling/resource reliability, local GitLab foundations, security hardening, Multus VLAN attachments, media degraded-mode behavior, and an improved VictoriaMetrics/Grafana observability posture.
+
+Milestone v1.1 completed Storage & Migration Foundations: Longhorn was removed, Ceph/OpenEBS became the durable storage foundation, GitLab/GitLab Runner were rebuilt on the new platform path, kube-prometheus-stack became the production metrics/alerting stack, VictoriaLogs remained the log backend, and Longhorn-only Talos source extensions were removed.
+
+## Completed Milestones
+
+- [x] **v1.0 GitOps Safety & Platform Foundations** — archived in `.planning/milestones/v1.0-ROADMAP.md`.
+- [x] **v1.1 Storage & Migration Foundations** — archived in `.planning/milestones/v1.1-ROADMAP.md`; completed 2026-05-30.
+
+## Current Milestone
+
+No active milestone. Start the next milestone with `/gsd-new-milestone`.
+
+## Progress
+
+| Milestone | Phases | Plans | Status | Completed |
+|-----------|--------|-------|--------|-----------|
+| v1.0 GitOps Safety & Platform Foundations | Archived | Archived | Complete | 2026-05-15 |
+| v1.1 Storage & Migration Foundations | 10/10 | 58/58 | Complete | 2026-05-30 |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,0 +1,232 @@
+---
+gsd_state_version: 1.0
+milestone: v1.1
+milestone_name: Storage & Migration Foundations
+status: milestone-complete
+last_updated: "2026-05-30T21:55:00.000Z"
+last_activity: 2026-05-30
+progress:
+  total_phases: 10
+  completed_phases: 10
+  total_plans: 58
+  completed_plans: 58
+  percent: 100
+---
+
+# Project State
+
+## Project Reference
+
+See: .planning/PROJECT.md (updated 2026-05-15)
+
+**Core value:** The cluster must stay efficient, observable, and safe to change, even when hardware fails or workloads move.
+**Current focus:** Milestone v1.1 archived — ready for next milestone definition
+
+## Current Position
+
+- Milestone v1.1 is archived to `.planning/milestones/v1.1-ROADMAP.md` and `.planning/milestones/v1.1-REQUIREMENTS.md`; active requirements were cleared for the next milestone cycle.
+- Phase 17 and post-audit fixes completed: kube-prometheus-stack is the production metrics/alerting path, Alertmanager/Grafana/Kromgo/Rook consumers are rewired, VictoriaLogs remains with native collector `_msg` proof, VictoriaMetrics metrics/alerting GitOps and live resources are removed, Prometheus exporter coverage is restored, and historical metrics import is explicitly de-scoped.
+
+Phase: 17 (kube-prometheus-stack-migration-logging-repair) — COMPLETE
+Plan: 6 of 6
+Status: Verified PASS 6/6; v1.1 milestone archived and ready for next milestone
+Last activity: 2026-05-30
+
+## Performance Metrics
+
+**Velocity:**
+
+- Total plans completed: 25
+- Average duration: 0 min
+- Total execution time: 0.0 hours
+
+**By Phase:**
+
+| Phase | Plans | Total | Avg/Plan |
+|-------|-------|-------|----------|
+| 01 | 4 | - | - |
+| 05 | 3 | - | - |
+| 09 | 3 | - | - |
+| 14 | 8 | - | - |
+
+**Recent Trend:**
+
+- Last 5 plans: none
+- Trend: Stable
+
+| Phase 02 P01 | 43 | 2 tasks | 3 files |
+| Phase 01 P03 | 6 | 2 tasks | 7 files |
+| Phase 01 P04 | 2 | 2 tasks | 4 files |
+| Phase 01 P02 | 177 | 2 tasks | 62 files |
+| Phase 02 P02 | 83 | 2 tasks | 4 files |
+| Phase 02 P03 | 61 | 2 tasks | 6 files |
+| Phase 06 P02 | 0 min | 2 tasks | 3 files |
+| Phase 06 P03 | 0 min | 2 tasks | 3 files |
+| Phase 06 P04 | 0 min | 3 tasks | 0 files |
+| Phase 06 P05 | 10 min | 3 tasks | 0 files |
+| Phase 10 P04 | 3 min | 3 tasks | 9 files |
+| Phase 10 P03 | 3 min | 1 tasks | 4 files |
+| Phase 11 P01 | 31min | 1 tasks | 8 files |
+| Phase 11 P02 | 8min | 2 tasks | 9 files |
+| Phase 14 P01 | 16min | 3 tasks | 4 files |
+| Phase 14 P03 | 59min | 3 tasks | 4 files |
+| Phase 16 P01 | operator-gated | 1 tasks | 0 files |
+| Phase 16 P04 | operator-gated | 3 tasks | 1 files |
+| Phase 16 P04 | operator-gated | 3 tasks | 2 files |
+| Phase 16 P02 | implementation | 3 tasks | 15 files |
+| Phase 16 P05 | implementation | 3 tasks | 17 files |
+| Phase 16 P03 | operator-gated | 3 tasks | 0 files |
+| Phase 17 P01 | evidence | 2 tasks | 0 files |
+| Phase 17 P02 | implementation | 3 tasks | 9 files |
+| Phase 17 P03 | implementation | 2 tasks | 12 files |
+| Phase 17 P04 | implementation | 3 tasks | 13 files |
+| Phase 17 P05 | implementation | 3 tasks | 6 files |
+| Phase 17 P06 | implementation | 3 tasks | 17 files |
+
+## Accumulated Context
+
+### Decisions
+
+Decisions are logged in PROJECT.md Key Decisions table.
+
+Recent decisions affecting current work:
+
+- [v1.1]: `home-ops` remains GitHub-based; do not add root `.gitlab-ci.yml` or repoint Flux to GitLab.
+- [v1.1]: Internal Forgejo repository names must not be written to public planning or GitOps artifacts; use redacted evidence.
+- [v1.1]: Longhorn removal is mandatory, but migration-gated and evidence-gated.
+- [v1.1]: GitLab MinIO object data is disposable, but GitLab Gitaly is separate and may only be destroyed/rebuilt if live evidence proves no needed repositories exist.
+- [v1.1]: kube-prometheus-stack migration is mandatory after memory, parity, and rollback gates pass; keep VictoriaLogs unless separately replaced.
+- [v1.1]: GitLab Runner image-build proof must use BuildKit rootless under restricted PSS.
+- [v1.1]: Ceph OSD bootstrap must use explicit safe devices or Talos Raw Volumes; avoid unsafe/system/Longhorn/Talos state devices and avoid Raw Volume names containing `ceph`.
+- [v1.1]: Current nodes have one 1TB NVMe split into Talos `EPHEMERAL` and `u-longhorn`; there is no spare three-node OSD set, so Ceph bootstrap must reclaim Longhorn capacity node-by-node.
+- [v1.1]: CNPG Pooler/monitoring refactor and CNPG storage migration are separate, backup-gated work.
+- [v1.1]: Renovate branch automerge requires validation workflows on pushes to `renovate/**` as well as PRs to `main`.
+- [v1.1]: Phase 10 selected `k8s-niobe` as the first reclaim node after live evidence refresh.
+- [v1.1]: Phase 10 previously selected CNPG C2 as OpenEBS LocalPV hostpath destination, but the execution path is now superseded until topology blockers are resolved.
+- [v1.1]: Phase 10 Plan 10-01 DR, Forejo, Kopia restore-drill, NAS, Azure, and live target evidence passed.
+- [v1.1]: Phase 10 Plan 10-02 created non-destructive Rook-Ceph namespace/operator scaffolding only; CephCluster and OSD consumption remain deferred.
+- [v1.1]: Phase 10 Plan 10-04 scaffolded OpenEBS LocalPV hostpath source only; OpenEBS remains suspended because no Talos-backed `/var/mnt/local-hostpath` exists.
+- [v1.1]: Phase 10 Plan 10-04 kept OpenEBS/CNPG storage classes non-default and disabled OpenEBS snapshot CRDs so the existing snapshot-controller remains owner.
+- [Phase 10]: Phase 10 Plan 10-03 staged inactive Rook-Ceph cluster manifests with k8s-niobe-only /dev/disk/by-partlabel/r-rook-osd selection, mon=1, mgr=1, replicated size=1, and non-default RBD/snapshot classes; Renovate later changed the manifest image to quay.io/ceph/ceph:v20.2.1, so regenerated Plan 10-10 requires compatibility proof before activation.
+- [Phase 10]: Revised Plan 10-05 is non-destructive and must resolve CNPG/OpenEBS topology contradictions before any Longhorn, Talos, OpenEBS, or CephCluster mutation.
+- [Phase 10]: Plan 10-05 recorded operator approval for an OpenEBS/CNPG redesign direction: migrate CNPG to OpenEBS one pod at a time, verify CNPG backups/WAL/archive first, and keep destructive authorization false until downstream plans are regenerated or amended.
+- [Phase 10]: Downstream Plans 10-06 through 10-11 were regenerated to prove OpenEBS capacity, migrate CNPG to `openebs-hostpath`, evacuate `k8s-niobe`, reshape Talos to `rook-osd`, bootstrap constrained Rook-Ceph, and run RBD/snapshot smoke tests with explicit operator gates.
+- [Phase 10]: Plan 10-06 completed CNPG DR preflight, recorded an operator-approved Talos `local-hostpath` UserVolumeConfig design, generated local Talos configs preserving both `local-hostpath` and `longhorn`, refreshed live evidence, and left live capacity proof to Plan 10-07.
+- [Phase 10]: Initial Plan 10-07 operator apply on `k8s-niobe` confirmed `u-local-hostpath` cannot be created while `u-longhorn` consumes the disk; node, Longhorn, and CNPG remained healthy, but further node applies are blocked pending explicit Longhorn capacity reclaim.
+- [Phase 10]: Plan 10-07 audit found 10-07/10-08/10-09 circular and unsafe as written; `10-07-OPERATOR-COMMAND-RUNBOOK.md` now holds the approved wait checks, backup gate, niobe evacuation shape, and commands that are explicitly not approved yet.
+- [Phase 10]: Follow-up evidence at 2026-05-20T01:15:00Z showed `k8s-niobe` `u-local-hostpath` ready on `/dev/nvme0n1p5` and `u-longhorn` recreated on `/dev/nvme0n1p6`; CNPG and backup/WAL status were healthy, OpenEBS remained suspended, and Longhorn had 27 degraded volumes.
+- [Phase 10]: Follow-up evidence at 2026-05-20T01:23:32Z showed Longhorn improved to 26 healthy, 1 degraded (`monitoring/vmsingle-vm-kube-stack`), and 4 classified detached unknown volumes.
+- [Phase 10]: Follow-up evidence at 2026-05-20T01:28:24Z showed Longhorn degraded volumes cleared; remaining unknown volumes are classified detached volumes.
+- [Phase 10]: Operator rejected parallel `k8s-trinity`/`k8s-ghost` reshape after risk review; remaining Plan 10-07 node order is sequential with `k8s-trinity` first and `k8s-ghost` only after CNPG primary moves away.
+- [Phase 10]: Operator completed `k8s-trinity` and `k8s-ghost`; follow-up evidence at 2026-05-20T02:08:49Z showed all three nodes have `u-local-hostpath` and `u-longhorn` mounted, CNPG primary moved to `postgres-cluster-16` on `k8s-niobe`, and Longhorn was rebuilding with 24 degraded volumes.
+- [Phase 10]: Deep Longhorn analysis at 2026-05-20T02:34-02:35Z found active degraded volumes rebuilding on current disk UUIDs, while the 4 classified unknown volumes have stopped replicas on old trinity/ghost disk UUIDs and may require stale replica cleanup if they remain stuck.
+- [Phase 10]: Follow-up evidence at 2026-05-20T02:38:22Z showed Longhorn still at 24 healthy, 3 degraded, and 4 unknown; degraded volumes each have one `WO` current-disk replica, while the unknown volumes remain `attaching` with unsatisfied `volume-eviction-controller-*` tickets and stale old trinity/ghost disk UUID references.
+- [Phase 10]: Follow-up evidence at 2026-05-20T21:31:16Z after the operator rebooted `k8s-ghost` showed all nodes Ready, CNPG healthy, all node mounts intact, Longhorn 27 healthy and 4 unknown, and the only remaining block as stale `volume-eviction-controller-*` tickets on the classified unknown volumes.
+- [Phase 10]: Follow-up evidence at 2026-05-20T22:02:46Z showed `grafana-pvc` salvage succeeded by marking the old trinity replica failed/stopped and setting `salvageRequested=true` on the current niobe replica; remaining stale unknowns should use the same one-volume-at-a-time pattern.
+- [Phase 10]: Follow-up evidence at 2026-05-20T22:11:29Z showed the operator completed stale Longhorn recovery by manually deleting failed replicas to kick off rebuilds; Longhorn returned to 27 healthy and 4 classified detached unknown volumes.
+- [Phase 10]: PR #1100 merged OpenEBS activation as `ff859783`; latest observed Flux revision was `308bfb1f`, with OpenEBS installed and `phase10-openebs-probe` proving `openebs-hostpath` provisioning and cleanup.
+- [Phase 10]: PR #1102 merged CNPG desired storageClass change as `c6c757cd`; Flux webhook reconciled it, and live CNPG is healthy on `openebs-hostpath` with backup/WAL status healthy. The old `postgres-cluster-16` Longhorn PV is retained and classified detached/unknown.
+- [Phase 10]: Plan 10-09 completed Longhorn evacuation from `k8s-niobe`, removed the `k8s-niobe` Longhorn user volume, dropped old `u-longhorn` partition `/dev/nvme0n1p6`, and materialized ready Talos raw volume `r-rook-osd` at `/dev/disk/by-partlabel/r-rook-osd`; CNPG remained healthy with primary on `k8s-ghost`.
+- [Phase 10]: Do not commit the intermediate Talos source patch from Plan 10-09; the operator confirmed it is not the final Talos state and should remain local until downstream Rook/Ceph state is settled.
+- [Phase 10]: Plan 10-10 completed constrained Rook-Ceph bootstrap on `k8s-niobe`; Ceph `v20.2.1` raw-list discovery failed during empty bootstrap, so the cluster was cleaned and rebootstraped with Squid `v19.2.3-20250717`.
+- [Phase 10]: Plan 10-10 uses persistent Ceph config for the one-OSD bootstrap: default pool size/min-size `1` and `mon_data_avail_warn` `20`; no-redundancy warnings remain visible and accepted.
+- [Phase 10]: Plan 10-11 passed quiesced RBD/VolumeSnapshot smoke tests with temporary `phase10-smoke-*` resources, then cleaned up all Kubernetes resources, VolumeSnapshotContent objects, and smoke RBD images.
+- [Phase 10]: Phase 10 closes with no production workload migrated to Ceph; Phase 11 must provide explicit migration gates before any production PVC moves to `ceph-block`.
+- [Phase 11]: Plan 11-02 added source hardening for Kopia-native Azure sync, rclone `/volsync/**` exclusion, weekly/monthly VolSync retention, review-fixed backup/offsite/maintenance alerts, and SAS rotation documentation; preserved migrations remain blocked until live evidence rows are PASS.
+- [Phase 11]: Operator clarified Azure offsite sync is non-blocking for Phase 11 migration gates; multi-scrobbler live NAS/Kopia evidence passed for checkpoint freshness, Kopia verify, sample restore, NFS path/excludes, retention, and alert acceptance, while one-time Azure seed job `kopia-azure-sync-seed-phase11-20260522020644` continues as hardening.
+- [Phase 11]: Plan 11-03 migrated Harbor Trivy cache and multi-scrobbler to `ceph-block`; multi-scrobbler kept the stable PVC name via a retained-PV swap, and future preserved migrations should not use final `*-ceph` app PVC names unless explicitly approved.
+- [Phase 11]: Plan 11-04 helper/runbook/plan now encode the stable-name retained-PV pattern: final app PVC names stay stable, temporary stage PVCs use `*-ceph-stage`, and HelmRelease `existingClaim` values remain unchanged.
+- [Phase 11]: Plan 11-04 backup gates passed for beets, recyclarr, prowlarr, and radarr with fresh manual VolSync checkpoints, Kopia verify job `kopia-verify-phase11-20260522032147`, sample restore drills, NAS path evidence, retention, and alerts.
+- [Phase 11]: Plan 11-04 migrated beets, recyclarr, prowlarr, and radarr to stable-name `ceph-block` PVCs; same-session validation passed and old Longhorn PVs/volumes plus stage PVCs were cleaned up.
+- [Phase 11]: Azure offsite hardening verification passed after seed job `kopia-azure-sync-seed-phase11-20260522020644` completed and guarded job `kopia-azure-sync-verify-phase11-20260522041356` reported 6321 blobs / 30 GB in sync.
+- [Phase 11]: Plan 11-05 migrated sonarr, lidarr, sabnzbd, and seerr to stable-name `ceph-block` PVCs; post-cutover VolSync backups, Kopia verify, restore drills, app smoke checks, and Flux convergence passed, then old Longhorn PVs/volumes plus stage PVCs were cleaned up.
+- [Phase 11]: Plan 11-06 migrated slskd, tautulli, atuin, aurral, and paperless-ngx to stable-name `ceph-block` PVCs; backup gates, restore drills, app smoke checks, post-cutover VolSync, and Flux convergence passed, then old Longhorn PVs/volumes plus stage PVCs were cleaned up.
+- [Phase 11]: Plan 11-07 Task 1 preflight found D-18, Longhorn capacity/health, CNPG, and backup gates acceptable; operator rebaselined Ceph `MON_DISK_LOW` as threshold noise because the mon store is tiny and the raw OSD is healthy; D-20 selected `k8s-trinity`; no mutation occurred.
+- [Phase 11]: Plan 11-07 Task 2 approval recorded for `k8s-trinity`; operator stated they will run destructive Talos commands/apply and drain Longhorn replicas, so assistant must wait for operator live-step evidence before Rook/GitOps mutation.
+- [Phase 11]: Plan 11-07 Talos source/manifests were prepared for `k8s-trinity`; generated config includes `RawVolumeConfig rook-osd`, ghost remains on Longhorn, and no live Talos apply was run by the assistant.
+- [Phase 11]: Plan 11-07 completed second OSD expansion through PR #1126 (`c6a3bc58`); Flux reconciled `ceph-blockpool` size 2, Ceph has two OSDs up/in, and PGs are active+clean.
+- [Phase 12]: Plan 12-02 completed W1 simple/app-config PVC migrations for ghidra-server, harbor-jobservice, dragonfly, home-assistant, and plex; all five stable PVC names now bind to `ceph-block`, controllers are Ready, stage PVCs are gone, and old W1 Longhorn volumes were deleted after same-session validation.
+- [Phase 12]: Plan 12-06 completed full Rook-Ceph footprint readiness: 3 OSDs up/in, chart-default 3 mons and 2 mgrs live, all pools size 3/min_size 2, CephFS StorageClass and snapshot class present, policy-compliant CephFS smoke passed, and CNPG-07 closed as a D-05/D-07 do-not-migrate decision with CNPG healthy on `openebs-hostpath`. Remaining `MON_DISK_LOW` is mon d on `k8s-niobe`; the mon store is tiny, but niobe EPHEMERAL `/var` is 69 GB with containerd using most of the space.
+- [Phase 12]: Niobe EPHEMERAL reprovision prep was completed under the operator-owned Talos boundary. Assistant-completed Kubernetes/Ceph prep promoted CNPG primary to `postgres-cluster-20` on `k8s-ghost`, purged niobe `osd.0`, cordoned/drained `k8s-niobe`, and suspended the `rook-ceph` operator HelmRelease with `rook-ceph-operator` scaled to 0 so it did not recreate the old OSD before disk reprovision. The temporary maintenance state was Ceph `HEALTH_WARN` with quorum `b,c`, 2 OSDs up/in and undersized/degraded PGs; CNPG 2/3 ready with `postgres-cluster-18` evicted from niobe.
+- [Phase 12]: Niobe EPHEMERAL reprovision follow-up restored at 2026-05-24T15:35:32Z. Post-operator Talos work, niobe is Ready with `/var` on 137.37 GB EPHEMERAL and `r-rook-osd` as BlueStore. Rook was resumed, `osd.0` was recreated on niobe, and Ceph is `HEALTH_OK` with mons `b,c,d`, 3 OSDs up/in, and 81 PGs active+clean. CNPG recovered by destroying failed `postgres-cluster-18` with the CNPG plugin; `postgres-cluster-21` joined on niobe and CNPG is healthy with primary `postgres-cluster-20` plus standbys `postgres-cluster-19` and `postgres-cluster-21`.
+- [Phase 12]: Plan 12-07 closed the VolSync Longhorn default UAT gap through PR #1151 (`5923a4de`): shared VolSync defaults now use `ceph-block`, `csi-ceph-blockpool`, and `openebs-hostpath`; redundant app-level storage/snapshot substitutions were removed; full pinned `flux-local` validation reported `156 passed`; Phase 12 UAT is 7/7 passed and verifier scored 5/5 must-haves.
+- [Phase 17]: Completed kube-prometheus-stack migration through PRs #1258, #1260, #1261, #1263, #1264, #1268, #1270, #1274, and #1275; Prometheus/Alertmanager are production metrics/alerting, remaining consumers are rewired, VictoriaLogs remains with native collector `_msg` proof, VictoriaMetrics metrics/alerting resources are removed from GitOps and live cluster, exporter coverage is restored, and Longhorn-only Talos source extensions are removed.
+
+### Roadmap Evolution
+
+- Phase 7 added: Kyverno Tier-1 Enforce Promotion and Security Posture Closure.
+- Phase 04-06 extracted to Phase 7 as 07-01 so Phase 5/6 routing is no longer blocked by the audit-window hold.
+- Phase 8 completed: stayed on VictoriaMetrics, adopted onedr0p-style observability patterns, migrated Grafana to Grafana Operator, and applied safe cardinality pruning.
+- Phase 7 completed: Kyverno policies 01, 07, and 08 are Enforce; policies 02-06 remain Audit; namespace PSA labels use explicit profile components.
+- Phase 9 added: GitHub validation, Renovate branch CI, Talos/Longhorn reclaim inventory, Longhorn PVC disposition, and resource hygiene gates.
+- Phase 10 added: first-node Longhorn replica evacuation, Talos raw OSD volume creation, constrained Rook-Ceph bootstrap, and RBD/snapshot smoke tests.
+- Phase 11 added: initial Longhorn migration waves, migration runbooks, Kopia/VolSync checkpoints, disposable workload migration, and Ceph expansion to the next node.
+- Phase 12 added: preserved stateful workload migration and full Rook-Ceph readiness across intended nodes.
+- Phase 13 added: Longhorn reference removal and decommission gate.
+- Phase 14 added: CNPG ownership refactor and Pooler/monitoring boundaries.
+- Phase 15 added: GitLab rebuild or cutover on RGW object storage and Authentik OIDC admin group sync validation.
+- Phase 16 added: GitLab Runner BuildKit rootless proof and redacted SCM migration closure.
+- Phase 17 added: kube-prometheus-stack migration and Fluent Bit/VictoriaLogs `_msg` repair.
+- Phase 14.1 inserted after Phase 14: CNPG rescue, GitOps cleanup, and operational recovery plan (URGENT)
+- Phase 14.1 completed: stale CNPG desired-state was removed, Barman Cloud Plugin recovery was preserved, legacy `app` database/role and GitOps Secret source were retired, and restore drills passed.
+
+### Pending Todos
+
+Active pending todos:
+
+- Harden VolSync Kopia NAS backups — captured 2026-05-17; folded into Phase 13 context for high-confidence decommission-safety items only.
+- Right-size cluster resource requests and limits — captured 2026-05-24; live node usage shows substantial headroom and requests/limits need a full cluster pass.
+- Reconcile Kyverno policy warning backlog — captured 2026-05-24; merged policies still produce many live warnings and may need manifest remediation plus Renovate support.
+- Evaluate UniFi rsync backups over NFS — captured 2026-05-30; investigate UniFi Drive 4.2.2 rsync-over-SSH as a potential faster backup transport than current NFS-mounted jobs.
+
+8 v1.0 carry-forward todos moved to `.planning/todos/deferred/v1.0/` are covered by v1.1 phases:
+
+- Deploy PgBouncer for CNPG postgres-cluster — Phase 14
+- Migrate CI image-builder from kaniko to BuildKit rootless — Phase 16
+- Replace GitLab MinIO with Rook-Ceph S3 — Phase 15
+- Fix AlertManager source links — Phase 17
+- Tune GitLab runner CPU throttling — Phase 16
+- Tighten CNPG Postgres topology — Phase 14
+- Audit stale-pod metric queries — Phase 17
+- Audit unscoped workload resources — Phase 9
+
+### Blockers/Concerns
+
+- First Ceph OSD capacity must be reclaimed from an existing Longhorn `u-longhorn` user volume after Longhorn replica evacuation; there is no spare three-node OSD set.
+- Full Rook-Ceph capacity depends on incremental Longhorn migration and node-by-node OSD expansion.
+- Longhorn removal has no simple rollback after CRDs/PVs/volumes are removed; Phase 13 is evidence-gated.
+- GitLab Gitaly must not be treated as disposable unless live GitLab evidence proves no needed repositories exist.
+- SCM closure evidence must remain redacted.
+
+### Quick Tasks Completed
+
+| # | Description | Date | Commit | Directory |
+|---|-------------|------|--------|-----------|
+| 260525-veb | Restrict GitLab OIDC-created users and signup defaults with HelmRelease-only chart values; Web IDE single-origin fallback remains blocked because chart 10.0.0 has no HR value/template for it. | 2026-05-26 | b86e8dc2 | [260525-veb-resolve-these-gitlab-issues-check-the-re](./quick/260525-veb-resolve-these-gitlab-issues-check-the-re/) |
+| gitlab-chart-10 | Merge GitLab HelmRepository into the HelmRelease, upgrade chart to 10.0.0, and use the chart-rendered webservice HTTPRoute against envoy-internal. | 2026-05-26 | 04a4effc, b74ad4a0 | [20260526-gitlab-chart-10-helmrepository-merge](./quick/20260526-gitlab-chart-10-helmrepository-merge/) |
+| 260510-so1 | Review the rest of the dashboards and check they are not overly complex like the last PR was. | 2026-05-10 | f9c070a0 | [260510-so1-review-the-rest-of-the-dashboards-and-ch](./quick/260510-so1-review-the-rest-of-the-dashboards-and-ch/) |
+| 260516-boy | PR 1073 CI deduplication replaced with scoped Renovate PR automerge. | 2026-05-16 | 6c945f0f | [260516-boy-take-a-look-at-pr-https-github-com-melot](./quick/260516-boy-take-a-look-at-pr-https-github-com-melot/) |
+
+## Deferred Items
+
+| Category | Item | Status | Deferred At |
+|----------|------|--------|-------------|
+| Requirements | SEC-03 secret rotation workflow | Won't-do (v1) — no operational pain | 2026-04-27 |
+| Requirements | SCM-02 migrated GitLab MR validation | Included in v1.1 Phase 16 | 2026-05-15 |
+| Requirements | SCM-03 Forgejo migration/decommission | Included in v1.1 Phase 16 | 2026-05-15 |
+| Storage | GitLab MinIO to Rook-Ceph S3 | Included in v1.1 Phase 15 | 2026-05-15 |
+| Todos | 8 pending todos | Mapped into v1.1 phases | 2026-05-15 |
+| Debug | Authentik/GitLab/Kaniko/CNPG debug sessions | Resolved or superseded before v1.0 close | 2026-05-15 |
+
+## Session Continuity
+
+Last session: 2026-05-30T21:55:00.000-05:00
+Stopped at: v1.1 milestone archived; ready to start next milestone
+Resume file: None
+
+**Planned Phase:** None — next milestone definition workflow next
+
+## Operator Next Steps
+
+- Run `/gsd-new-milestone` when ready to define the next milestone.
+- Treat live Talos/destructive node operations as operator-owned unless explicitly reassigned.

--- a/.planning/milestones/v1.1-REQUIREMENTS.md
+++ b/.planning/milestones/v1.1-REQUIREMENTS.md
@@ -1,0 +1,190 @@
+# v1.1 Requirements Archive: Storage & Migration Foundations
+
+Archived: 2026-05-30  
+Status: Complete  
+Audit: `.planning/v1.1-MILESTONE-AUDIT.md`
+
+All v1.1 requirements below are archived as complete, satisfied by an accepted adjustment, or explicitly de-scoped in the milestone audit/outcome notes.
+
+# Requirements: home-ops
+
+**Defined:** 2026-05-15
+**Core Value:** The cluster must stay efficient, observable, and safe to change, even when hardware fails or workloads move.
+**Milestone:** v1.1 Storage & Migration Foundations
+
+## v1.1 Requirements
+
+Requirements for the v1.1 milestone. Each maps to roadmap phases after roadmapping.
+
+### Storage & Ceph Foundations
+
+- [x] **STOR-01**: Operator can review redacted node-by-node OSD capacity evidence before Rook-Ceph consumes any disk.
+- [x] **STOR-02**: Operator can ensure Rook-Ceph only targets explicit safe devices or Talos Raw Volumes; system, Longhorn, EPHEMERAL, STATE, META, formatted iSCSI/virtual, and ambiguous devices are excluded, and Raw Volume names avoid `ceph`.
+- [x] **STOR-03**: Operator can verify Rook-Ceph expands from the first reclaimed OSD to the accepted full footprint, with operator, CephCluster, mons, mgr, and OSDs healthy across intended nodes before post-storage platform migrations proceed. [Closed Phase 12: full Rook-Ceph footprint restored; see 12-CEPH-EXPANSION-EVIDENCE.md and 12-VERIFICATION.md]
+- [x] **STOR-04**: Operator can verify Ceph RBD StorageClass and VolumeSnapshotClass pass dynamic provision, attach, write, snapshot, restore, and delete smoke tests.
+- [x] **STOR-05**: Operator can verify RGW/S3 is reachable and can create/list the stable GitLab bucket set before GitLab object-storage cutover.
+
+### Longhorn Migration & Removal
+
+- [x] **LH-01**: Operator can approve a disposition for every live Longhorn-backed PVC before migration begins: `pv-migrate`, Kopia/VolSync restore, app-native migration, recreate/destroy, or decommission first.
+- [x] **LH-02**: Operator has a repeatable `pv-migrate` runbook for quiesced filesystem PVC migrations, including destination PVC creation, scale-down, final sync, validation, and rollback.
+- [x] **LH-03**: Operator can confirm every preserved VolSync-covered app has a fresh successful Kopia checkpoint and repository verification before migration.
+- [x] **LH-04**: Operator can migrate simple preserved app PVCs to Ceph in small batches, validate application health, and retain old Longhorn PVCs through the rollback window. [Closed Phase 12: preserved app PVC waves passed with validation; see 12-MIGRATION-WAVE-EVIDENCE.md and 12-VERIFICATION.md]
+- [x] **LH-05**: Operator can move disposable/recreate workloads to Ceph only after explicit approval of data loss; GitLab MinIO object data is already approved disposable.
+- [x] **LH-06**: Operator can migrate CNPG, GitLab Gitaly, and Forgejo storage through app-native, backup-gated, or fully quiesced migration paths instead of naive active database/repository PVC copies. [Closed Phase 12: Forejo backup-gated, Gitaly disposable-approved, CNPG do-not-migrate accepted; see 12-REPO-STORAGE-EVIDENCE.md, 12-CNPG-READINESS-EVIDENCE.md, and 12-VERIFICATION.md]
+- [x] **LH-07**: Operator can replace or remove Longhorn defaults, StorageClasses, Flux dependencies, VolSync defaults, dashboards/auth links, alerts, snapshots/jobs, and upgrade-plan references.
+- [x] **LH-08**: Operator can remove Longhorn from GitOps only after live evidence shows no Longhorn PVCs, PVs, VolumeAttachments, required VolumeSnapshots, StorageClasses in use, or GitOps dependencies remain.
+
+### GitLab Object Storage & SCM Closure
+
+- [x] **GLAB-01**: Operator can rebuild GitLab object storage on Rook-Ceph RGW/S3 while preserving the existing `gitlab-object-store-connection` Secret contract and stable bucket names.
+- [x] **GLAB-02**: Operator can destroy/rebuild GitLab MinIO object data rather than preserve it, while keeping MinIO rollback available until GitLab object-storage validation passes.
+- [x] **GLAB-03**: Operator can treat GitLab Gitaly separately from object storage and only destroy/rebuild it if live GitLab evidence proves no repositories need preservation.
+- [x] **GLAB-04**: Operator can validate Authentik OIDC group claims and GitLab `admin_groups` behavior so only members of the intended Authentik `gitlab-admins` group receive GitLab administrator access, with a documented fallback if GitLab edition/provider behavior cannot enforce it.
+- [x] **SCM-02**: Merge request author can see a migrated GitLab-hosted repository MR pass repository-relevant local-runner validation before merge; no-op pipelines do not count. [Closed Phase 16: proof MR/pipeline ran a real BuildKit image build and Harbor push; see 16-03-PROOF-EVIDENCE.md and 16-VERIFICATION.md]
+- [x] **SCM-03**: Operator can migrate, export, delete, or explicitly de-scope every existing Forgejo-hosted private repository before Forgejo/forejo-runner decommission. [Closed Phase 16: 16/16 redacted repos migrated/archive-covered and Forgejo runtime/GitOps/database residue removed; see 16-SCM-DISPOSITION.md and 16-VERIFICATION.md]
+- [x] **SCM-04**: Operator can record SCM closure evidence in redacted form so internal Forgejo repository names do not enter public planning or GitOps artifacts. [Closed Phase 16: placeholder-only evidence plus private archive checksum; see 16-SCM-DISPOSITION.md and 16-VERIFICATION.md]
+- [x] **SCM-05**: Operator can keep `melotic/home-ops` GitHub-based, with no root `.gitlab-ci.yml` and no Flux source repointing to GitLab.
+
+### CNPG & PostgreSQL
+
+- [x] **CNPG-01**: Operator can refactor CNPG ownership boundaries so the operator, Barman plugin, Postgres Cluster/Database/ObjectStore/ScheduledBackup resources, Poolers, monitoring resources, and storage classes are owned by the appropriate GitOps apps, with the current Helm chart/postRenderer Cluster ownership either safely replaced or documented as a backup-gated follow-up.
+- [x] **CNPG-02**: Operator can scrape CNPG cluster and Pooler metrics through manually owned PodMonitor resources, with no deprecated `Cluster.spec.monitoring.enablePodMonitor: true` usage.
+- [x] **CNPG-03**: Operator can deploy a CNPG-native RW PgBouncer Pooler with conservative transaction-pool sizing, anti-affinity, scraped metrics, and direct RW service rollback preserved.
+- [x] **CNPG-04**: Operator can move database consumers to the Pooler app-by-app only after compatibility validation; GitLab is excluded until separately proven compatible.
+- [x] **CNPG-05**: Operator can preserve intended one-instance-per-node `postgres-cluster` topology under normal three-node operation and document maintenance tradeoffs.
+- [x] **CNPG-06**: Operator can keep CNPG on the current best-effort Longhorn WFFC class until Ceph RBD is validated, without reintroducing strict-local Longhorn replacement behavior.
+- [x] **CNPG-07**: Operator can migrate CNPG storage to Ceph RBD separately from Pooler/monitoring refactors, gated by fresh base backup, healthy WAL archive, recovery path, one-instance-at-a-time replacement, and rollback window. [Closed Phase 12: do-not-migrate per D-05/D-07 - CNPG resiliency replaces Ceph RBD for this cluster; see 12-CNPG-READINESS-EVIDENCE.md]
+
+### GitLab CI & GitHub Automation
+
+- [x] **CI-01**: Operator can prove GitLab Runner builds and pushes an OCI image to Harbor with pinned BuildKit rootless via a persistent hardened buildkitd Deployment in the baseline-PSS `gitlab` namespace over mTLS `tcp://`, while the runner build pod stays restricted PSS as a thin `buildctl` client and no privileged pods, Docker-in-Docker, host Docker socket, or runner namespace PSS relaxation are introduced. The buildkitd daemon keeps the accepted `SETUID`/`SETGID` uidmap-helper exception required by rootlesskit; runner build pods do not gain capabilities. [Closed Phase 16: see 16-03-PROOF-EVIDENCE.md and 16-VERIFICATION.md]
+- [x] **CI-02**: Operator can use masked `HARBOR_*` variables for image-build proof without leaking credentials in job logs or manifests. [Closed Phase 16: proof used GitLab Harbor integration variables and log-audit zero-hit checks; see 16-03-PROOF-EVIDENCE.md]
+- [x] **CI-03**: Operator can tune GitLab Runner manager CPU throttling without weakening namespace-scoped RBAC or restricted security posture. [Closed Phase 16: runner manager CPU limit removed while restricted posture remained intact; see 16-VERIFICATION.md]
+- [x] **AUTO-01**: Operator can run kubeconform against rendered Flux output in GitHub Actions with a stable final check suitable for branch protection.
+- [x] **AUTO-02**: Operator can run required validation workflows on both PRs to `main` and pushes to `renovate/**`, while keeping PR-only comment/diff jobs PR-only.
+- [x] **AUTO-03**: Operator can make Renovate branch automerge independent of PR-only checks and remove GitHub Actions automerge reliance on `ignoreTests: true` once branch CI exists.
+
+### Observability & Logging
+
+- [x] **OBS-01**: Operator can make kube-prometheus-stack the production metrics/alerting path in v1.1 after memory, parity, and rollback gates pass.
+- [x] **OBS-02**: Operator can bound Prometheus RSS/cardinality before cutover with accepted retention, retention size, scrape/eval intervals, sample limits, metric drops, disabled irrelevant rules/components, and explicit resource budgets.
+- [x] **OBS-03**: Operator can keep Prometheus Operator CRD ownership outside kube-prometheus-stack and keep embedded Grafana disabled while Grafana Operator remains owner.
+- [x] **OBS-04**: Operator can validate Prometheus, Alertmanager, and Grafana source links/routes are user-reachable after cutover with a test alert.
+- [x] **OBS-05**: Operator can keep VictoriaMetrics available through the rollback window, then remove it from the primary metrics/alerting path or explicitly de-scope it.
+- [x] **LOG-01**: Operator can synthesize a top-level `_msg` in Fluent Bit from structured and raw log candidates before VictoriaLogs ingestion.
+- [x] **LOG-02**: Operator can keep VictoriaLogs stream fields bounded and exclude high-cardinality request, trace, path, user, and ID fields.
+- [x] **LOG-03**: Operator can verify representative structured GitLab logs display meaningful `_msg` values instead of `_msg: missing _msg field`.
+
+### Monitoring & Resource Hygiene
+
+- [x] **MON-01**: Operator can audit and update stale-pod alert/query logic for the active metrics stack so it does not produce misleading results.
+- [x] **MON-02**: Operator can fix AlertManager source links for the current and target alerting paths.
+- [x] **RES-01**: Operator can audit Sonarr, Prowlarr, and Harbor resource posture and either adjust resources or document recommendation-first sizing.
+- [x] **RES-02**: Operator can preserve the cluster convention of avoiding CPU limits unless a workload-specific exception is explicitly justified.
+
+## Future Requirements
+
+Deferred to future milestones after v1.1 foundations are proven.
+
+### Build & CI Evolution
+
+- **FUT-01**: Operator can add dedicated build runners or persistent BuildKit cache after rootless image builds are proven.
+
+### SCM Evidence Expansion
+
+- **FUT-02**: Operator can validate multiple migrated repositories after the first meaningful GitLab MR validation succeeds.
+
+### Storage Optimization
+
+- **FUT-03**: Operator can evaluate erasure-coded Ceph pools after replicated Ceph is proven and capacity pressure justifies the complexity.
+
+### Resource Automation
+
+- **FUT-04**: Operator can automate selected resource mutations after recommendation-first sizing remains safe.
+
+## Out of Scope
+
+Explicitly excluded from v1.1 to prevent scope creep.
+
+| Feature | Reason |
+|---------|--------|
+| Moving `home-ops` or Flux from GitHub to GitLab | The repository remains GitHub-based; GitLab replaces local Forgejo-hosted repositories only. |
+| Adding a root `.gitlab-ci.yml` to this repository | SCM validation belongs to migrated GitLab-hosted repositories, not `home-ops`. |
+| Privileged Docker-in-Docker runners or PSS relaxations for image builds | GitLab Runner must remain namespace-scoped and restricted. |
+| Rook `useAllDevices: true` or ambiguous OSD selection | Unsafe disk selection risks data loss on Talos nodes. |
+| Preserving unused GitLab MinIO object data | GitLab is not in use yet, so object data can be rebuilt on RGW/S3. |
+| Big-bang Longhorn removal | Longhorn removal requires PVC disposition, migration validation, rollback, and live removability evidence. |
+| Dual-write Forgejo and GitLab source-of-truth operation | A controlled cutover is safer than two active repository systems. |
+
+## Traceability
+
+Which phases cover which requirements. Updated during roadmap creation.
+
+| Requirement | Phase | Status |
+|-------------|-------|--------|
+| STOR-01 | Phase 9 | Complete |
+| STOR-02 | Phase 10 | Complete |
+| STOR-03 | Phase 12 | Complete |
+| STOR-04 | Phase 10 | Complete |
+| STOR-05 | Phase 15 | Complete |
+| LH-01 | Phase 9 | Complete |
+| LH-02 | Phase 11 | Complete |
+| LH-03 | Phase 11 | Complete |
+| LH-04 | Phase 12 | Complete |
+| LH-05 | Phase 11 | Complete |
+| LH-06 | Phase 12 | Complete |
+| LH-07 | Phase 13 | Complete |
+| LH-08 | Phase 13 | Complete |
+| GLAB-01 | Phase 15 | Complete |
+| GLAB-02 | Phase 15 | Complete |
+| GLAB-03 | Phase 15 | Complete |
+| GLAB-04 | Phase 15 | Complete |
+| SCM-02 | Phase 16 | Complete |
+| SCM-03 | Phase 16 | Complete |
+| SCM-04 | Phase 16 | Complete |
+| SCM-05 | Phase 9 | Complete |
+| CNPG-01 | Phase 14 | Complete |
+| CNPG-02 | Phase 14 | Complete |
+| CNPG-03 | Phase 14 | Complete |
+| CNPG-04 | Phase 14 | Complete |
+| CNPG-05 | Phase 14 | Complete |
+| CNPG-06 | Phase 10 | Complete |
+| CNPG-07 | Phase 12 | Satisfied - CNPG remains on openebs-hostpath; CNPG resiliency replaces Ceph RBD requirement (closed Phase 12 - see 12-CNPG-READINESS-EVIDENCE.md) |
+| CI-01 | Phase 16 | Complete |
+| CI-02 | Phase 16 | Complete |
+| CI-03 | Phase 16 | Complete |
+| AUTO-01 | Phase 9 | Complete |
+| AUTO-02 | Phase 9 | Complete |
+| AUTO-03 | Phase 9 | Complete |
+| OBS-01 | Phase 17 | Complete |
+| OBS-02 | Phase 17 | Complete |
+| OBS-03 | Phase 17 | Complete |
+| OBS-04 | Phase 17 | Complete |
+| OBS-05 | Phase 17 | Complete |
+| LOG-01 | Phase 17 | Complete |
+| LOG-02 | Phase 17 | Complete |
+| LOG-03 | Phase 17 | Complete |
+| MON-01 | Phase 17 | Complete |
+| MON-02 | Phase 17 | Complete |
+| RES-01 | Phase 9 | Complete |
+| RES-02 | Phase 9 | Complete |
+
+**Coverage:**
+- v1.1 requirements: 46 total
+- Mapped to phases: 46
+- Unmapped: 0
+
+---
+*Requirements defined: 2026-05-15*
+*Last updated: 2026-05-15 after Talos/live-cluster-informed roadmap revision*
+
+## Milestone Completion Outcomes
+
+Archived at v1.1 completion on 2026-05-30.
+
+- STOR-04: satisfied by Rook/Ceph dynamic provisioning and VolumeSnapshot validation evidence during Phases 10-12.
+- LH-02/LH-03/LH-05: satisfied or de-scoped by the accepted migration strategy, app-specific migration evidence, disposable workload approvals, and Longhorn removal gates.
+- LH-07/LH-08: satisfied by Phase 13 cleanup, later Talos extension source cleanup, and live VictoriaMetrics/Longhorn-adjacent residue checks during milestone audit.
+- OBS-01..OBS-05, LOG-01..LOG-03, MON-01..MON-02: satisfied by Phase 17 and post-audit fixes through PRs #1258, #1260, #1261, #1263, #1264, #1268, #1270, #1274, and #1275.
+- CNPG-07 remains intentionally adjusted: CNPG resiliency/openebs-hostpath replaces a Ceph RBD migration requirement for this cluster.

--- a/.planning/milestones/v1.1-ROADMAP.md
+++ b/.planning/milestones/v1.1-ROADMAP.md
@@ -1,0 +1,423 @@
+# v1.1 Milestone Archive: Storage & Migration Foundations
+
+Archived: 2026-05-30  
+Status: Complete  
+Audit: `.planning/v1.1-MILESTONE-AUDIT.md`
+
+This file preserves the full active roadmap at the time v1.1 was completed. The active `.planning/ROADMAP.md` has been collapsed to keep current planning context small.
+
+# Roadmap: home-ops
+
+## Overview
+
+`home-ops` is the GitOps source of truth for the Zion Talos Kubernetes cluster. Milestone v1.0 established safer GitOps operations, scheduling/resource reliability, local GitLab foundations, security hardening, Multus VLAN attachments, media degraded-mode behavior, and an improved VictoriaMetrics/Grafana observability posture.
+
+Milestone v1.1, **Storage & Migration Foundations**, replaces remaining temporary foundations with durable, validated ones. The live cluster has one 1TB NVMe per node split between Talos `EPHEMERAL` and a growable `u-longhorn` user volume mounted at `/var/mnt/longhorn`; there is no spare three-node OSD set. The storage sequence is therefore: prove inventory and safety gates, evacuate/reclaim one Longhorn-backed node/disk into a Talos raw OSD volume, bootstrap constrained Rook-Ceph, migrate Longhorn data incrementally, expand Ceph to the remaining nodes, remove Longhorn, then resume GitLab and SCM closure work.
+
+## Milestones
+
+- [x] **v1.0 milestone** - Phases 1-8 shipped 2026-05-15 ([roadmap archive](./milestones/v1.0-ROADMAP.md), [requirements archive](./milestones/v1.0-REQUIREMENTS.md), [audit archive](./milestones/v1.0-MILESTONE-AUDIT.md)).
+- [x] **v1.1 Storage & Migration Foundations** - Phases 9-17 completed 2026-05-30.
+
+## Phases
+
+<details>
+<summary>v1.0 milestone (Phases 1-8) - SHIPPED 2026-05-15</summary>
+
+- [x] **Phase 1: GitOps Safety & Operational Visibility** - 2/2 plans complete.
+- [x] **Phase 2: Resource Right-Sizing & Scheduling Reliability** - 3/3 completed summaries; roadmap listed 2 plans after consolidation.
+- [x] **Phase 3: Slim GitLab Migration & Local CI** - 5/8 plans completed; SCM-02 and SCM-03 accepted as next-milestone deferrals.
+- [x] **Phase 4: Exposure & Supply-Chain Hardening (Spike-Driven)** - 8/8 plans complete.
+- [x] **Phase 5: Curated Multus / VLAN Networking** - 3/3 plans complete.
+- [x] **Phase 6: Media Degraded-Mode Resilience** - 5/5 plans complete.
+- [x] **Phase 7: Kyverno Tier-1 Enforce Promotion and Security Posture Closure** - 1/1 plan complete.
+- [x] **Phase 8: Adopt onedr0p o11y patterns** - 4/4 plans complete.
+
+Accepted v1.0 deferrals:
+
+- SCM-02 migrated GitLab-hosted repository MR validation.
+- SCM-03 Forgejo migration/decommission.
+- GitLab MinIO-to-Rook-Ceph RGW/S3 replacement after OSD-capacity/bootstrap planning.
+
+</details>
+
+- [x] **Phase 9: GitHub Validation & Storage Reclaim Inventory** - 3/3 plans complete and verified 2026-05-15.
+- [x] **Phase 10: First-Node Reclaim & Constrained Rook-Ceph Bootstrap** - 11/11 plans complete; OpenEBS/CNPG detour has DR, Talos user-volume topology, OpenEBS activation/provisioning proof, CNPG migrated to OpenEBS, `k8s-niobe` reshaped to Talos raw volume `rook-osd`, constrained Rook-Ceph bootstrapped with one OSD up/in, and throwaway RBD/VolumeSnapshot smoke tests passed.
+- [x] **Phase 11: Initial Longhorn Migration Waves & Ceph Expansion** - 7/7 plans complete; repeatable migration gates are established, starter workloads moved to Ceph, and `k8s-trinity` was added as the second Rook-Ceph OSD with `ceph-blockpool` size 2.
+- [x] **Phase 12: Preserved Stateful Migration & Full Ceph Readiness** - Move preserved app/platform state through workload-appropriate backup-gated paths and reach the accepted full Rook-Ceph footprint. (completed 2026-05-24)
+- [x] **Phase 13: Longhorn Reference Removal & Decommission Gate** - 4/4 plans complete; Longhorn is removed from GitOps and the live Kubernetes API after evidence-gated decommission.
+- [x] **Phase 14: CNPG Refactor, Pooler & Monitoring Boundaries** - Refactor CNPG ownership boundaries and stabilize Postgres access after storage foundations are safe. (completed 2026-05-25)
+- [x] **Phase 15: GitLab Rebuild on RGW & OIDC Admin Sync** - 5/5 plans complete; GitLab rebuilt on Rook-Ceph RGW/S3 with preserved Secret/bucket contracts, MinIO decommissioned, Gitaly preserved, and Authentik `gitlab-admins` OIDC sync validated (verified PASS 5/5).
+- [x] **Phase 16: GitLab Runner BuildKit & Redacted SCM Closure** - BuildKit-to-Harbor proof, runner cache follow-up, and redacted Forgejo migration/decommission closure verified 2026-05-30.
+- [x] **Phase 17: kube-prometheus-stack Migration & Logging Repair** - 6/6 plans complete; kube-prometheus-stack is production metrics/alerting, VictoriaLogs retained with native collector `_msg` proof, and VictoriaMetrics metrics/alerting removed.
+
+## Phase Details
+
+### Phase 9: GitHub Validation & Storage Reclaim Inventory
+
+**Goal**: Operator has trustworthy GitHub validation, Renovate branch automerge checks, redacted evidence practices, current Longhorn/Talos inventories, a first-node reclaim plan, and resource hygiene baselines before storage is changed.
+
+**Depends on**: Phase 8
+
+**Requirements**: AUTO-01, AUTO-02, AUTO-03, STOR-01, LH-01, SCM-05, RES-01, RES-02
+
+**Success Criteria** (what must be TRUE):
+
+1. Operator can see kubeconform validate rendered Flux output as a stable GitHub Actions check.
+2. Renovate branch automerge has required validation workflows running on `push` to `renovate/**` as well as PRs to `main`, while PR-only comment/diff jobs stay PR-only.
+3. Operator can review redacted node-by-node Talos disk evidence showing one 1TB NVMe per node, current `EPHEMERAL` and `u-longhorn` partition sizes, Longhorn disk capacity, and the selected first reclaim target.
+4. Operator can review an approved disposition for every live Longhorn-backed PVC before migration begins.
+5. `melotic/home-ops` remains GitHub-based with no root `.gitlab-ci.yml`, no Flux source repointing to GitLab, and resource hygiene decisions preserve the no-CPU-limits convention unless explicitly justified.
+
+**Plans**:
+
+- **Wave 1**: `09-01-PLAN.md` — GitHub Actions/Renovate validation hardening.
+- **Wave 1**: `09-02-PLAN.md` — Read-only storage inventory, PVC disposition matrix, and first-node reclaim summary.
+- **Wave 1**: `09-03-PLAN.md` — Sonarr/Prowlarr/Harbor resource hygiene, OOM history, and evidence-backed tuning.
+
+### Phase 10: First-Node Reclaim & Constrained Rook-Ceph Bootstrap
+
+**Goal**: Operator can safely create the first Ceph OSD by evacuating one Longhorn disk, changing Talos raw/user-volume layout for that node, and bootstrapping constrained Rook-Ceph block storage without consuming unsafe devices.
+
+**Depends on**: Phase 9
+
+**Requirements**: STOR-02, STOR-04, CNPG-06
+
+**Success Criteria** (what must be TRUE):
+
+1. Longhorn replicas are evacuated from the selected first node/disk and remaining Longhorn volumes stay healthy enough for the migration window.
+2. Talos config replaces reclaimed `u-longhorn` capacity on that node with an explicitly named raw OSD volume whose name avoids `ceph`.
+3. Rook-Ceph targets only the explicit reclaimed raw volume; system, Longhorn, `EPHEMERAL`, `STATE`, `META`, formatted iSCSI/virtual, ambiguous devices, and `useAllDevices` are excluded.
+4. The initial Ceph RBD StorageClass and VolumeSnapshotClass pass dynamic provision, attach, write, snapshot, restore, and delete smoke tests before real workload cutover.
+5. CNPG remains off Ceph RBD during Phase 10; any CNPG maintenance, temporary topology degradation, or storage-path change during first-node reclaim is explicitly operator-approved, backup/WAL-gated, and does not reintroduce strict-local Longhorn replacement behavior.
+
+**Plans**:
+
+- [x] `10-01-PLAN.md` — DR/Kopia/Forejo/live evidence and CNPG path decision gates.
+- [x] `10-02-PLAN.md` — Rook namespace/operator scaffolding only.
+- [x] `10-04-PLAN.md` — C2 OpenEBS LocalPV hostpath path.
+- [x] `10-03-PLAN.md` — constrained Rook cluster source staging.
+- [x] `10-05-PLAN.md` — CNPG/OpenEBS topology correction and destructive-work authorization gate.
+- [x] `10-06-PLAN.md` — CNPG backup/WAL/ObjectStore recovery, OpenEBS capacity, and live evidence gates.
+- [x] `10-07-PLAN.md` — Talos-backed OpenEBS local-hostpath activation and non-default provisioning proof.
+- [x] `10-08-PLAN.md` — CNPG one-instance-at-a-time migration to `openebs-hostpath`.
+- [x] `10-09-PLAN.md` — Longhorn evacuation from `k8s-niobe` and Talos `rook-osd` raw-volume reshape.
+- [x] `10-10-PLAN.md` — Rook/Ceph compatibility proof and constrained one-OSD bootstrap.
+- [x] `10-11-PLAN.md` — throwaway RBD/VolumeSnapshot smoke tests and phase closeout.
+
+### Phase 11: Initial Longhorn Migration Waves & Ceph Expansion
+
+**Goal**: Operator has repeatable migration/backup gates, moves approved disposable and low-risk workloads first, and uses freed Longhorn capacity to add more safe Ceph OSDs.
+
+**Depends on**: Phase 10
+
+**Requirements**: LH-02, LH-03, LH-05
+
+**Success Criteria** (what must be TRUE):
+
+1. Operator has a repeatable `pv-migrate` runbook for quiesced filesystem PVC migrations, including destination PVC creation, scale-down, final sync, validation, and rollback.
+2. Every preserved VolSync-covered app has a fresh successful Kopia checkpoint and repository verification before migration.
+3. Disposable/recreate workloads move to Ceph only after explicit approval of data loss, with GitLab MinIO object data still held for the later GitLab phase.
+4. At least one additional node/disk is reclaimed from Longhorn and added to Rook-Ceph after early migrations free enough Longhorn capacity.
+
+**Plans**: 7 plans
+
+Plans:
+**Wave 0**
+
+- [x] 11-01-PLAN.md — Evidence scaffolds and fish-compatible pv-migrate runbook
+
+**Wave 1**
+
+- [x] 11-02-PLAN.md — Backup hardening: kopia-azure-sync CronJob, VolSync retention, alerts, and backup gate evidence
+
+**Wave 2** *(blocked on Wave 1 completion)*
+
+- [x] 11-03-PLAN.md — harbor-trivy disposable migration + multi-scrobbler preserved canary
+
+**Wave 3** *(blocked on Wave 2 completion)*
+
+- [x] 11-04-PLAN.md — Preserved pairs 1+2: beets+recyclarr, prowlarr+radarr
+
+**Wave 4** *(blocked on Wave 3 completion)*
+
+- [x] 11-05-PLAN.md — Preserved pairs 3+4: sonarr+lidarr, sabnzbd+seerr
+
+**Wave 5** *(blocked on Wave 4 completion)*
+
+- [x] 11-06-PLAN.md — Preserved pairs 5+6 + individual: slskd+tautulli, atuin+aurral, paperless-ngx
+
+**Wave 6** *(blocked on Wave 5 completion)*
+
+- [x] 11-07-PLAN.md — Ceph OSD expansion: second-node evacuation, Talos reshape, Rook OSD add, pool size=2 gate
+
+### Phase 12: Preserved Stateful Migration & Full Ceph Readiness
+
+**Goal**: Preserved application and platform state moves from Longhorn to Ceph through workload-appropriate, backup-gated migration paths until the accepted full Rook-Ceph footprint is healthy.
+
+**Depends on**: Phase 11
+
+**Requirements**: STOR-03, LH-04, LH-06, CNPG-07
+
+**Success Criteria** (what must be TRUE):
+
+1. Operator can migrate simple preserved app PVCs to Ceph in small batches, validate application health, and retain old Longhorn PVCs through the rollback window.
+2. CNPG storage migration to Ceph RBD is separate from Pooler/monitoring refactors and gated by fresh base backup, healthy WAL archive, recovery path, one-instance-at-a-time replacement, and rollback window.
+3. CNPG, GitLab Gitaly, and Forgejo storage use app-native, backup-gated, or fully quiesced migration paths instead of naive active database/repository PVC copies.
+4. GitLab Gitaly is preserved unless live evidence proves it contains no needed repositories.
+5. Rook-Ceph operator, CephCluster, mons, mgr, and OSDs reach accepted health with OSDs spread across intended nodes before post-storage platform migrations proceed.
+
+**Plans**: 7 plans
+
+Plans:
+**Wave 1**
+
+- [x] 12-01-PLAN.md — Wave 0 evidence-ledger scaffolds + preflight verification (A1-A5)
+- [x] 12-02-PLAN.md — W1 simple-app PVC migrations to ceph-block (ghidra-server, harbor-jobservice, dragonfly, home-assistant, plex)
+
+**Wave 2** *(blocked on Wave 1 completion)*
+
+- [x] 12-03-PLAN.md — W2 repository PVC migrations to ceph-block (Forejo, GitLab Gitaly; REDACTED evidence)
+
+**Wave 3** *(blocked on Wave 2 completion)*
+
+- [x] 12-04-PLAN.md — W3 monitoring PVC migrations to ceph-block (gatus, grafana, vmsingle, vmalertmanager, victoria-logs; storage-only)
+
+**Wave 4** *(blocked on Wave 3 completion)*
+
+- [x] 12-05-PLAN.md — W4 k8s-ghost OSD reshape (D-22 last-host evac + Talos r-rook-osd + Rook PR A add-node)
+
+**Wave 5** *(blocked on Wave 4 completion)*
+
+- [x] 12-06-PLAN.md — W5 Rook PR B full footprint (size 3/min_size 2, mon/mgr unpin, CephFS, snapshot class) + CephFS smoke + CNPG-07 closure + REQUIREMENTS.md update
+- [x] 12-07-PLAN.md — UAT gap closure: VolSync component defaults move off Longhorn to Ceph primary/snapshot and OpenEBS Kopia cache defaults.
+
+### Phase 13: Longhorn Reference Removal & Decommission Gate
+
+**Goal**: Longhorn is removed from GitOps and the live cluster only after evidence proves no workloads, snapshots, storage classes, dashboards, alerts, or dependencies still require it.
+
+**Depends on**: Phase 12
+
+**Requirements**: LH-07, LH-08
+
+**Success Criteria** (what must be TRUE):
+
+1. Longhorn defaults, StorageClasses, Flux dependencies, VolSync defaults, dashboards/auth links, alerts, snapshots/jobs, and upgrade-plan references are replaced or removed.
+2. Operator can verify live evidence shows no Longhorn PVCs, PVs, VolumeAttachments, required VolumeSnapshots, StorageClasses in use, or GitOps dependencies remain.
+3. Longhorn removal occurs only after the migration rollback window and evidence gates pass.
+
+**Plans**: 4 plans
+
+Plans:
+
+**Wave 0**
+
+- [x] `13-01-PLAN.md` — Baseline live/rendered evidence, active alerts, Ceph health, Talos audit, snapshot/content disposition, and Tuppr schema proof.
+
+**Wave 1** *(blocked on Wave 0 completion)*
+
+- [x] `13-02-PLAN.md` — Ceph defaults, VolSync/Tuppr dependency cleanup, unused CNPG Longhorn class removal, and stale project instruction cleanup.
+- [x] `13-03-PLAN.md` — Authentik/dashboard surface removal, alert/backup audit, and manual Longhorn decommission runbook.
+
+**Wave 2** *(blocked on Wave 1 completion and human gates)*
+
+- [x] `13-04-PLAN.md` — Final snapshot disposition, live/rendered decommission gate, direct Longhorn GitOps deletion, and post-reconcile validation.
+
+### Phase 14: CNPG Refactor, Pooler & Monitoring Boundaries
+
+**Goal**: Operator has a clearer CNPG ownership model, safer Postgres connection handling, and clean CNPG monitoring boundaries after storage foundations are safe.
+
+**Depends on**: Phase 13
+
+**Requirements**: CNPG-01, CNPG-02, CNPG-03, CNPG-04, CNPG-05
+
+**Success Criteria** (what must be TRUE):
+
+1. The `cloudnative-pg/cluster` chart remains the fresh-bootstrap/recovery/Cluster and chart PrometheusRule owner; the rejected Helm detach/adopt path is not executed.
+2. CNPG cluster and Pooler metrics are scraped through manually owned PodMonitor resources, the chart-rendered duplicate Cluster PodMonitor is disabled, and no deprecated `Cluster.spec.monitoring.enablePodMonitor: true` usage is introduced.
+3. Postgres consumers use per-app roles and app-local Secrets, with the broad shared `postgres-cluster-app` replication retired after GitLab is isolated.
+4. A CNPG-native RW PgBouncer Pooler is available with conservative transaction-pool sizing, anti-affinity, metrics, and direct RW service rollback preserved.
+5. Database consumers move to the Pooler app-by-app only after credential isolation and compatibility validation, while GitLab remains excluded.
+
+**Plans**: 8 plans
+
+Plans:
+
+**Wave 1**
+
+- [x] `14-01-PLAN.md` — Manual Cluster/Pooler PodMonitors + RW transaction Pooler (additive, no consumer changes).
+
+**Wave 2** *(blocked on Wave 1 completion)*
+
+- [x] `14-02-PLAN.md` — Historical artifact: authored explicit `Cluster/postgres-cluster` manifest from live spec; not aggregated after chart-retention pivot.
+
+**Wave 3** *(blocked on Wave 1 completion; supersedes old chart-detach Plan 14-03)*
+
+- [x] `14-03-PLAN.md` — Keep chart/alerts, disable only the chart Cluster PodMonitor, and scaffold the app-facing `cnpg-database` Component.
+
+**Wave 4** *(blocked on Wave 3 completion)*
+
+- [x] `14-04-PLAN.md` — Seerr credential-isolation proof: per-app role/Database/Secret, direct RW retained, negative GitLab access proof.
+
+**Wave 5** *(blocked on Wave 4 proof)*
+
+- [x] `14-05-PLAN.md` — Migrate media *arr Postgres consumers to per-app roles and Secrets, one app at a time, direct RW retained and host substitution wired.
+
+**Wave 6** *(blocked on Wave 5 completion)*
+
+- [x] `14-06-PLAN.md` — Migrate remaining non-GitLab varied consumers (Atuin/Auth/Harbor/Forgejo/Paperless) to per-app roles and Secrets.
+
+**Wave 7** *(blocked on Wave 6 completion)*
+
+- [x] `14-07-PLAN.md` — Dedicated GitLab credential isolation and gated retirement of broad `postgres-cluster-app` replication.
+
+**Wave 8** *(blocked on Wave 7 completion)*
+
+- [x] `14-08-PLAN.md` — Move approved low-risk isolated consumers to the CNPG RW Pooler app-by-app; GitLab remains direct RW.
+
+### Phase 14.1: CNPG Rescue, GitOps Cleanup & Operational Recovery
+
+**Goal**: CNPG desired state is reduced to an auditable, fresh-bootstrap-safe operating model with recovery/bootstrap residue, legacy shared credentials, app-facing Secret defaults, and operator recovery procedures cleaned up or explicitly gated.
+
+**Depends on**: Phase 14
+
+**Requirements**: CNPG-01, CNPG-02, CNPG-03, CNPG-04, CNPG-05
+
+**Success Criteria** (what must be TRUE):
+
+1. The live `postgres-cluster` health, backup/WAL archiving, Pooler state, role/Database CRDs, ExternalSecrets, and app consumers are inventoried without exposing secret values or broad log-scraped connection strings.
+2. The `database/postgres` GitOps surface has one clear source of truth for the CNPG Cluster, recovery/bootstrap behavior, backups, Pooler, monitoring, Database CRDs, and managed roles; stale or historical manifests are removed, renamed, or explicitly quarantined so future agents cannot accidentally re-aggregate them.
+3. The legacy `app` role, `postgres-cluster-app` ClusterExternalSecret, and `app` recovery/bootstrap residue have an explicit retirement path or a documented fresh-bootstrap/recovery gate; no workload depends on the broad shared credential before retirement.
+4. App-facing PostgreSQL connection Secret generation has sane defaults (`ONEPASSWORD_ITEM=${APP}-postgres`, direct RW host by default, per-app database/user defaults) so app Kustomizations only override real deviations.
+5. Operator recovery procedures cover failed CNPG instance replacement, planned node maintenance/switchover, backup/restore validation, and rollback boundaries while preserving `openebs-hostpath`, strict anti-affinity, chart-owned Cluster/recovery/PrometheusRules, and no live-only steady-state drift.
+
+**Plans**: 1 plan
+
+Plans:
+
+- [x] `14.1-PLAN.md` — CNPG rescue cleanup: stale desired-state removal, plugin recovery validation, legacy app database/role retirement, and restore-drill gates.
+
+### Phase 15: GitLab Rebuild on RGW & OIDC Admin Sync
+
+**Goal**: GitLab is rebuilt or cut over onto Rook-Ceph RGW/S3 with stable bucket and Secret contracts while disposable MinIO object data, separate Gitaly preservation decisions, and Authentik OIDC administrator group sync remain safely bounded.
+
+**Depends on**: Phase 14.1
+
+**Requirements**: STOR-05, GLAB-01, GLAB-02, GLAB-03, GLAB-04
+
+**Success Criteria** (what must be TRUE):
+
+1. RGW/S3 is reachable and can create/list the stable GitLab bucket set before GitLab object-storage cutover.
+2. GitLab object storage is rebuilt on Rook-Ceph RGW/S3 while preserving the existing `gitlab-object-store-connection` Secret contract and stable bucket names.
+3. Operator can destroy/rebuild GitLab MinIO object data without preserving it, while MinIO rollback remains available until GitLab object-storage validation passes or the old GitLab install is intentionally discarded.
+4. GitLab Gitaly is handled separately from object storage and the GitLab install is rebuilt cleanly only if live evidence proves no repositories need preservation.
+5. Authentik emits a `groups` claim including `gitlab-admins`, GitLab consumes the OIDC provider `admin_groups` setting, and live login tests prove only intended group members receive administrator access or a fallback is documented.
+
+**Plans**: 5 plans
+
+Plans:
+
+**Wave 1**
+
+- [x] `15-01-PLAN.md` — RGW object store, bucket StorageClass, GitLab OBCs, and live S3 bucket smoke.
+
+**Wave 2** *(blocked on Wave 1 credential-scope approval)*
+
+- [x] `15-02-PLAN.md` — Bridge approved RGW credentials into preserved `gitlab-object-store-connection` Secret contract.
+
+**Wave 3** *(blocked on Wave 2 Secret contract readiness)*
+
+- [x] `15-03-PLAN.md` — In-place GitLab RGW cutover with Gitaly preservation and GitLab object-storage smoke.
+
+**Wave 4** *(blocked on Wave 3 GitLab RGW validation)*
+
+- [x] `15-04-PLAN.md` — Remove disposable GitLab MinIO path after RGW validation.
+
+**Wave 5** *(blocked on object-storage cutover and GitLab readiness)*
+
+- [x] `15-05-PLAN.md` — Validate and fix Authentik OIDC `gitlab-admins` administrator group sync.
+
+### Phase 16: GitLab Runner BuildKit & Redacted SCM Closure
+
+**Goal**: Operator can prove the rebuilt GitLab/runner path builds images with BuildKit rootless, then close the GitLab/Forgejo migration safely with meaningful MR validation and redacted evidence.
+
+**Depends on**: Phase 15
+
+**Requirements**: CI-01, CI-02, CI-03, SCM-02, SCM-03, SCM-04
+
+**Success Criteria** (what must be TRUE):
+
+1. GitLab Runner can build and push an OCI image to Harbor with a pinned BuildKit rootless daemon in the baseline-PSS `gitlab` namespace and a restricted-PSS thin `buildctl` runner pod over mTLS `tcp://`, using masked `HARBOR_*` variables, without privileged pods, DinD, host Docker socket, runner namespace PSS relaxation, or weakened runner isolation. The buildkitd daemon retains the accepted `SETUID`/`SETGID` uidmap-helper exception required for rootlesskit; runner build pods do not gain capabilities.
+2. GitLab Runner manager CPU throttling is tuned without weakening namespace-scoped RBAC or restricted security posture.
+3. A migrated GitLab-hosted repository merge request passes repository-relevant local-runner validation before merge; no-op pipelines do not count.
+4. Every existing Forgejo-hosted private repository is migrated, exported, deleted, or explicitly de-scoped before Forgejo/runner decommission.
+5. SCM closure evidence is recorded in redacted form so internal Forgejo repository names do not enter public planning or GitOps artifacts.
+
+**Plans**: 5 plans
+Plans:
+**Wave 1**
+
+- [x] 16-01-PLAN.md — Complete Localhost seccomp profile rollout to remaining Talos nodes (CI-01)
+- [x] 16-04-PLAN.md — Forgejo inventory + per-repo disposition + migrate/export, redacted (SCM-03, SCM-04)
+
+**Wave 2** *(blocked on Wave 1 completion)*
+
+- [x] 16-02-PLAN.md — Persistent hardened buildkitd stack, mTLS runner client wiring, manager CPU tuning, delete CI-PATTERNS.md (CI-01, CI-03)
+- [x] 16-05-PLAN.md — Forgejo GitOps teardown + runtime residue cleanup (SCM-03)
+
+**Wave 3** *(blocked on Wave 2 completion)*
+
+- [x] 16-03-PLAN.md — glab proof repo + BuildKit→Harbor build proof + non-no-op MR validation (CI-01, CI-02, SCM-02)
+
+### Phase 17: kube-prometheus-stack Migration & Logging Repair
+
+**Goal**: kube-prometheus-stack becomes the production metrics/alerting path after memory/parity/rollback gates pass, while VictoriaLogs remains useful with repaired `_msg` fields.
+
+**Depends on**: Phase 16
+
+**Requirements**: OBS-01, OBS-02, OBS-03, OBS-04, OBS-05, LOG-01, LOG-02, LOG-03, MON-01, MON-02
+
+**Success Criteria** (what must be TRUE):
+
+1. Operator can bound Prometheus RSS/cardinality before cutover with accepted retention, retention size, scrape/eval intervals, sample limits, metric drops, disabled irrelevant rules/components, and explicit resource budgets.
+2. kube-prometheus-stack is the production metrics/alerting path after memory, parity, and rollback gates pass, with CRD ownership outside the chart and embedded Grafana disabled.
+3. Prometheus, Alertmanager, Grafana source links/routes, stale-pod alert/query logic, and a test alert are user-reachable and accurate after cutover.
+4. VictoriaMetrics remains available through the rollback window, then is removed from the primary metrics/alerting path or explicitly de-scoped, while VictoriaLogs remains unless separately replaced.
+5. Fluent Bit synthesizes a useful top-level `_msg` before VictoriaLogs ingestion, keeps stream fields bounded, and representative structured GitLab logs no longer show `_msg: missing _msg field`.
+
+**Plans**: 6 plans
+
+Plans:
+- [x] 17-01-PLAN.md — Historical metrics evidence, Prometheus sizing, monitoring namespace right-sizing, and source-link/query risk notes.
+- [x] 17-02-PLAN.md — Standalone kube-prometheus-stack app with external CRD ownership, disabled bundled Grafana, evidence-derived resources, routes, rules, and initial live target proof.
+- [x] 17-03-PLAN.md — Grafana datasource and dashboard migration with automated render proof.
+- [x] 17-04-PLAN.md — Alertmanager, silence, Flux notification, kromgo, Rook, source-link, and stale-query rewiring.
+- [x] 17-05-PLAN.md — Native VictoriaLogs collector `_msg` ingestion proof with bounded stream fields.
+- [x] 17-06-PLAN.md — Evidence-gated cutover, VictoriaMetrics history decision, and removal of VictoriaMetrics metrics/alerting from production GitOps.
+
+**UI hint**: yes
+
+## Progress
+
+| Milestone | Phases | Plans | Status | Completed |
+|-----------|--------|-------|--------|-----------|
+| v1.0 milestone | 8/8 | 31 summaries / 33 roadmap plans | Shipped with accepted deferrals | 2026-05-15 |
+| v1.1 Storage & Migration Foundations | 10/10 | 58/58 | Complete | 2026-05-30 |
+
+| Phase | Plans Complete | Status | Completed |
+|-------|----------------|--------|-----------|
+| 9. GitHub Validation & Storage Reclaim Inventory | 3/3 | Complete | 2026-05-15 |
+| 10. First-Node Reclaim & Constrained Rook-Ceph Bootstrap | 11/11 | Complete | 2026-05-21 |
+| 11. Initial Longhorn Migration Waves & Ceph Expansion | 7/7 | Complete | 2026-05-22 |
+| 12. Preserved Stateful Migration & Full Ceph Readiness | 7/7 | Complete   | 2026-05-24 |
+| 13. Longhorn Reference Removal & Decommission Gate | 4/4 | Complete | 2026-05-24 |
+| 14. CNPG Refactor, Pooler & Monitoring Boundaries | 8/8 | Complete    | 2026-05-25 |
+| 14.1 CNPG Rescue, GitOps Cleanup & Operational Recovery | 1/1 | Complete | 2026-05-27 |
+| 15. GitLab Rebuild on RGW & OIDC Admin Sync | 5/5 | Complete | 2026-05-30 |
+| 16. GitLab Runner BuildKit & Redacted SCM Closure | 5/5 | Complete | 2026-05-30 |
+| 17. kube-prometheus-stack Migration & Logging Repair | 6/6 | Complete | 2026-05-30 |
+
+---
+
+*Created: 2026-04-24*  
+*Last updated: 2026-05-27 after Phase 14.1 CNPG rescue cleanup completion*

--- a/.planning/v1.1-MILESTONE-AUDIT.md
+++ b/.planning/v1.1-MILESTONE-AUDIT.md
@@ -1,0 +1,57 @@
+---
+version: v1.1
+status: passed
+audited_at: 2026-05-30T21:40:00Z
+milestone: Storage & Migration Foundations
+---
+
+# v1.1 Milestone Audit
+
+## Status
+
+passed
+
+## Scope
+
+Milestone v1.1 covers phases 9-17: storage migration foundations, Longhorn decommission, OpenEBS/Ceph readiness, GitLab rebuild, runner/buildkit closure, and kube-prometheus-stack migration.
+
+## Requirements Coverage
+
+Result: PASS.
+
+The milestone delivered the planned storage and observability transitions:
+
+- Longhorn references and live resources removed.
+- Ceph/OpenEBS storage paths established for workloads.
+- GitLab and GitLab Runner rebuilt and validated on the new storage/CI path.
+- kube-prometheus-stack became the production metrics/alerting stack.
+- VictoriaLogs remains the log backend with native collector ingestion and `_msg` repair.
+- VictoriaMetrics metrics/alerting resources were removed from GitOps and the live cluster.
+- Longhorn-only Talos source extensions (`siderolabs/iscsi-tools`, `siderolabs/util-linux-tools`) were removed from `talos/talconfig.yaml`; `siderolabs/nfs-utils` remains intentionally because NFS workloads remain active.
+
+## Cross-Phase Integration
+
+Result: PASS.
+
+- Prometheus exporter coverage restored after VictoriaMetrics removal: `node-exporter` and `kube-state-metrics` targets are live via kube-prometheus-stack-managed workloads.
+- Alertmanager notification secrets were restored under kube-prometheus-stack after the VictoriaMetrics app was removed.
+- Tailscale egress for the Alertmanager webhook endpoint was added and verified with successful delivery logs.
+- VictoriaLogs missing `_msg` records were fixed with structured message-field fallbacks and a neutral default message.
+- Rook/Ceph, Grafana, Kromgo, silence-operator, and Flux Alertmanager Provider were rewired to Prometheus/Alertmanager endpoints.
+
+## Live Evidence
+
+- Flux relevant Kustomizations/HelmReleases reached Ready after follow-up fixes.
+- Prometheus metrics verified after exporter repair: node-exporter 3 targets, kube-state-metrics 1 target, `kube_node_info=3`, and `node_uname_info=3`.
+- VictoriaLogs query over fresh windows returned zero new `_msg:"missing _msg"` records after PR #1270.
+- Talos source check confirms no `siderolabs/iscsi-tools` or `siderolabs/util-linux-tools` remains in `talos/talconfig.yaml`.
+- `siderolabs/nfs-utils` remains on all three nodes for active NFS workload support.
+
+## Deferred / Accepted Items
+
+- Live Talos apply/reboot to actually change node system extensions remains operator-owned. This audit verifies source-of-truth cleanup, not live node reboot execution.
+- VictoriaMetrics CRDs may remain until separately cleaned; no VictoriaMetrics operator/CR/workload is required for production operation.
+
+## Verdict
+
+Milestone v1.1 achieved its definition of done. No closure phases are required before milestone completion.


### PR DESCRIPTION
## Summary
- archive v1.1 roadmap and requirements
- record v1.1 milestone audit
- collapse active roadmap/project state for the next milestone
- clear active requirements for a fresh next milestone cycle

## Validation
- milestone audit status: passed
- active requirements file deleted after archive copy
- v1.1 archives created under .planning/milestones/

Tag v1.1 will be created on the merged main commit after PR merge.