### PR TITLE
fix(harbor): resolve HelmRelease rollback state

### DIFF
--- a/kubernetes/apps/default/harbor/app/helmrelease.yaml
+++ b/kubernetes/apps/default/harbor/app/helmrelease.yaml
@@ -20,10 +20,14 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: harbor
-      version: 1.19.1
+      version: 1.19.0
   install:
     remediation:
       retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
   values:
     updateStrategy:
       type: Recreate


### PR DESCRIPTION
Pin chart to 1.19.0 and add upgrade remediation to clear stuck rollback.