### PR TITLE
feat(monitoring): backup alerts, inventory coverage, dashboard

### DIFF
--- a/kubernetes/apps/database/postgres/app/kustomization.yaml
+++ b/kubernetes/apps/database/postgres/app/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
   - ./monitoring/cluster-podmonitor.yaml
   - ./monitoring/pooler-podmonitor.yaml
   - ./pooler/pooler-rw.yaml
+  - ./prometheusrule-backup.yaml
   - ./roles/atuin.yaml
   - ./roles/authentik.yaml
   - ./roles/gitlab.yaml

--- a/kubernetes/apps/database/postgres/app/prometheusrule-backup.yaml
+++ b/kubernetes/apps/database/postgres/app/prometheusrule-backup.yaml
@@ -1,0 +1,79 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: postgres-backup
+spec:
+  groups:
+    - name: postgres.backup.rules
+      rules:
+        - alert: PostgresBackupStaleWarning
+          expr: |-
+            time() - max(barman_cloud_cloudnative_pg_io_last_available_backup_timestamp{namespace="database"}) > 129600
+          annotations:
+            summary: >-
+              CNPG backup has not completed successfully in more than 36 hours
+          for: 15m
+          labels:
+            severity: warning
+
+        - alert: PostgresBackupStaleCritical
+          expr: |-
+            time() - max(barman_cloud_cloudnative_pg_io_last_available_backup_timestamp{namespace="database"}) > 172800
+          annotations:
+            summary: >-
+              CNPG backup has not completed successfully in more than 48 hours
+          for: 15m
+          labels:
+            severity: critical
+
+        - alert: PostgresBackupFailed
+          expr: |-
+            max(barman_cloud_cloudnative_pg_io_last_failed_backup_timestamp{namespace="database"}) > max(barman_cloud_cloudnative_pg_io_last_available_backup_timestamp{namespace="database"})
+          annotations:
+            summary: >-
+              CNPG latest failed backup is newer than the latest available backup
+          for: 15m
+          labels:
+            severity: critical
+
+        - alert: PostgresBackupFreshnessUnobservable
+          expr: |-
+            absent(barman_cloud_cloudnative_pg_io_last_available_backup_timestamp{namespace="database"})
+          annotations:
+            summary: >-
+              CNPG backup freshness cannot be observed because Barman Cloud backup timestamp metrics are absent
+          for: 15m
+          labels:
+            severity: critical
+
+        - alert: PostgresWalArchiveFailures
+          expr: |-
+            increase(cnpg_pg_stat_archiver_failed_count{namespace="database"}[15m]) > 0
+          annotations:
+            summary: >-
+              CNPG WAL archiver recorded failures in the last 15 minutes
+          for: 5m
+          labels:
+            severity: critical
+
+        - alert: PostgresWalArchiveStale
+          expr: |-
+            cnpg_pg_stat_archiver_seconds_since_last_archival{namespace="database"} > 3600
+          annotations:
+            summary: >-
+              CNPG WAL archiver has not archived a WAL segment in more than 1 hour
+          for: 15m
+          labels:
+            severity: warning
+
+        - alert: PostgresWalLatestFailureNewerThanArchive
+          expr: |-
+            cnpg_pg_stat_archiver_last_failed_time{namespace="database"} - cnpg_pg_stat_archiver_last_archived_time{namespace="database"} > 1
+          annotations:
+            summary: >-
+              CNPG latest WAL archive failure is newer than the latest successful archive
+          for: 5m
+          labels:
+            severity: critical

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/grafanadashboard-backup-confidence.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/grafanadashboard-backup-confidence.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: backup-confidence
+spec:
+  allowCrossNamespaceImport: true
+  folder: General
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_PROMETHEUS
+  configMapRef:
+    name: backup-confidence-dashboard
+    key: backup-confidence.json

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -108,6 +108,31 @@ spec:
           memory: 128Mi
     kube-state-metrics:
       fullnameOverride: kube-state-metrics
+      rbac:
+        extraRules:
+          - apiGroups: ["volsync.backube"]
+            resources: ["replicationsources"]
+            verbs: ["list", "watch"]
+      customResourceState:
+        enabled: true
+        config:
+          kind: CustomResourceStateMetrics
+          spec:
+            resources:
+              - groupVersionKind:
+                  group: volsync.backube
+                  version: v1alpha1
+                  kind: ReplicationSource
+                metricNamePrefix: kube_customresource
+                labelsFromPath:
+                  obj_namespace: [metadata, namespace]
+                  obj_name: [metadata, name]
+                metrics:
+                  - name: volsync_replicationsource_info
+                    help: VolSync ReplicationSource inventory
+                    each:
+                      type: Info
+                      info: {}
       resources:
         requests:
           cpu: 10m

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
@@ -6,8 +6,15 @@ resources:
   - ./alertmanagerconfig.yaml
   - ./externalsecret-webhook.yaml
   - ./externalsecret.yaml
+  - ./grafanadashboard-backup-confidence.yaml
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
   - ./prometheusrule.yaml
   - ./tailscale-egress.yaml
+configMapGenerator:
+  - name: backup-confidence-dashboard
+    files:
+      - backup-confidence.json=./resources/backup-confidence.json
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/resources/backup-confidence.json
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/resources/backup-confidence.json
@@ -1,0 +1,420 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "panels": [],
+      "title": "Daily backup jobs",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 36 },
+              { "color": "red", "value": 48 }
+            ]
+          },
+          "unit": "h"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 1 },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "(time() - kube_cronjob_status_last_successful_time{namespace=\"default\", cronjob=\"nas-backup\"}) / 3600",
+          "legendFormat": "nas-backup",
+          "refId": "A"
+        }
+      ],
+      "title": "NAS backup age",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 36 },
+              { "color": "red", "value": 48 }
+            ]
+          },
+          "unit": "h"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 1 },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "(time() - kube_cronjob_status_last_successful_time{namespace=\"default\", cronjob=\"kopia-verify\"}) / 3600",
+          "legendFormat": "kopia-verify",
+          "refId": "A"
+        }
+      ],
+      "title": "Kopia verify age",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 36 },
+              { "color": "red", "value": 48 }
+            ]
+          },
+          "unit": "h"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 1 },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "(time() - kube_cronjob_status_last_successful_time{namespace=\"default\", cronjob=\"kopia-azure-sync\"}) / 3600",
+          "legendFormat": "kopia-azure-sync",
+          "refId": "A"
+        }
+      ],
+      "title": "Kopia Azure sync age",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 7 },
+      "id": 5,
+      "panels": [],
+      "title": "VolSync and Kopia repository maintenance",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 2 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 8 },
+      "id": 6,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(max by (obj_namespace, obj_name) (increase(volsync_sync_duration_seconds_count{role=\"source\"}[18h])) < bool 1)",
+          "legendFormat": "stale sources",
+          "refId": "A"
+        }
+      ],
+      "title": "VolSync sources stale over 18h",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 6 },
+              { "color": "red", "value": 8 }
+            ]
+          },
+          "unit": "h"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 8 },
+      "id": 7,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "(time() - max(kube_job_status_completion_time{namespace=\"volsync-system\", job_name=~\"kopia-maint-.*\"})) / 3600",
+          "legendFormat": "kopia-maintenance",
+          "refId": "A"
+        }
+      ],
+      "title": "Kopia maintenance age",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 2 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 8 },
+      "id": 8,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(volsync_volume_out_of_sync{role=\"source\"})",
+          "legendFormat": "out-of-sync sources",
+          "refId": "A"
+        }
+      ],
+      "title": "VolSync out-of-sync sources",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "id": 9,
+      "panels": [],
+      "title": "CNPG backup and WAL",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 36 },
+              { "color": "red", "value": 48 }
+            ]
+          },
+          "unit": "h"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 15 },
+      "id": 10,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "(time() - max(barman_cloud_cloudnative_pg_io_last_available_backup_timestamp{namespace=\"database\"})) / 3600",
+          "legendFormat": "cnpg-backup",
+          "refId": "A"
+        }
+      ],
+      "title": "CNPG backup age",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1800 },
+              { "color": "red", "value": 3600 }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 15 },
+      "id": 11,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "max(cnpg_pg_stat_archiver_seconds_since_last_archival{namespace=\"database\"})",
+          "legendFormat": "wal-archive-lag",
+          "refId": "A"
+        }
+      ],
+      "title": "CNPG WAL archival lag",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 15 },
+      "id": 12,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "max(barman_cloud_cloudnative_pg_io_last_failed_backup_timestamp{namespace=\"database\"}) > bool max(barman_cloud_cloudnative_pg_io_last_available_backup_timestamp{namespace=\"database\"})",
+          "legendFormat": "latest-failed-newer",
+          "refId": "A"
+        }
+      ],
+      "title": "CNPG latest backup failed",
+      "type": "stat"
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 39,
+  "tags": ["backup", "home-ops"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Backup Confidence",
+  "uid": "backup-confidence",
+  "version": 1,
+  "weekStart": ""
+}

--- a/kubernetes/apps/volsync-system/volsync/app/prometheusrule.yaml
+++ b/kubernetes/apps/volsync-system/volsync/app/prometheusrule.yaml
@@ -30,7 +30,7 @@ spec:
 
         - alert: VolSyncMissedInterval
           expr: |-
-            increase(volsync_missed_intervals_total{role="source"}[1h]) > 0
+            increase(volsync_missed_intervals_total{role="source"}[15h]) > 0
           annotations:
             summary: >-
               {{ $labels.obj_namespace }}/{{ $labels.obj_name }} missed a scheduled VolSync backup interval
@@ -48,17 +48,159 @@ spec:
           labels:
             severity: critical
 
-        - alert: KopiaAzureSyncFailed
+        - alert: VolSyncSourceStaleWarning
           expr: |-
-            kube_job_status_failed{namespace="default", job_name=~"kopia-azure-sync-.*"} > 0
+            max by (obj_namespace, obj_name) (increase(volsync_sync_duration_seconds_count{role="source"}[18h])) < 1
           annotations:
             summary: >-
-              Kopia Azure sync job {{ $labels.job_name }} failed
+              {{ $labels.obj_namespace }}/{{ $labels.obj_name }} has no completed VolSync source sync in more than 18 hours
+          for: 15m
+          labels:
+            severity: warning
+
+        - alert: VolSyncSourceStaleCritical
+          expr: |-
+            max by (obj_namespace, obj_name) (increase(volsync_sync_duration_seconds_count{role="source"}[24h])) < 1
+          annotations:
+            summary: >-
+              {{ $labels.obj_namespace }}/{{ $labels.obj_name }} has no completed VolSync source sync in more than 24 hours
+          for: 15m
+          labels:
+            severity: critical
+
+        - alert: VolSyncSourceFreshnessUnobservable
+          expr: |-
+            absent(volsync_sync_duration_seconds_count{role="source"})
+          annotations:
+            summary: >-
+              VolSync source freshness cannot be observed because sync duration metrics are absent
+          for: 15m
+          labels:
+            severity: critical
+
+        - alert: VolSyncSourceMissingFromInventory
+          expr: |-
+            kube_customresource_volsync_replicationsource_info
+              unless on (obj_namespace, obj_name)
+            count by (obj_namespace, obj_name) (volsync_sync_duration_seconds_count{role="source"})
+          annotations:
+            summary: >-
+              ReplicationSource {{ $labels.obj_namespace }}/{{ $labels.obj_name }} exists but has produced no VolSync sync metrics for over 13h (broken or never-synced backup source)
+          for: 13h
+          labels:
+            severity: critical
+
+        - alert: VolSyncInventoryUnobservable
+          expr: |-
+            absent(kube_customresource_volsync_replicationsource_info)
+          annotations:
+            summary: >-
+              VolSync ReplicationSource inventory metrics are absent; per-source backup coverage cannot be verified (kube-state-metrics custom resource state may be broken)
+          for: 15m
+          labels:
+            severity: critical
+
+        - alert: BackupCronJobFailed
+          expr: |-
+            kube_job_status_failed{namespace="default"} * on(namespace, job_name) group_left(owner_name) kube_job_owner{namespace="default", owner_kind="CronJob", owner_name=~"nas-backup|kopia-verify|kopia-azure-sync"} > 0
+          annotations:
+            summary: >-
+              Backup CronJob {{ $labels.owner_name }} job {{ $labels.job_name }} failed
           for: 10m
           labels:
             severity: critical
 
-        - alert: KopiaAzureSyncStale
+        - alert: BackupCronJobFreshnessUnobservable
+          expr: |-
+            kube_cronjob_info{namespace="default", cronjob=~"nas-backup|kopia-verify|kopia-azure-sync"} unless on(namespace, cronjob) kube_cronjob_status_last_successful_time{namespace="default", cronjob=~"nas-backup|kopia-verify|kopia-azure-sync"}
+          annotations:
+            summary: >-
+              Backup CronJob {{ $labels.cronjob }} freshness cannot be observed because last successful time is absent
+          for: 15m
+          labels:
+            severity: critical
+
+        - alert: NasBackupCronJobMissing
+          expr: |-
+            absent(kube_cronjob_info{namespace="default", cronjob="nas-backup"})
+          annotations:
+            summary: >-
+              Backup CronJob nas-backup is missing from kube-state-metrics
+          for: 15m
+          labels:
+            severity: critical
+
+        - alert: NasBackupStaleWarning
+          expr: |-
+            time() - kube_cronjob_status_last_successful_time{namespace="default", cronjob="nas-backup"} > 129600
+          annotations:
+            summary: >-
+              NAS backup has not completed successfully in more than 36 hours
+          for: 15m
+          labels:
+            severity: warning
+
+        - alert: NasBackupStaleCritical
+          expr: |-
+            time() - kube_cronjob_status_last_successful_time{namespace="default", cronjob="nas-backup"} > 172800
+          annotations:
+            summary: >-
+              NAS backup has not completed successfully in more than 48 hours
+          for: 15m
+          labels:
+            severity: critical
+
+        - alert: KopiaVerifyCronJobMissing
+          expr: |-
+            absent(kube_cronjob_info{namespace="default", cronjob="kopia-verify"})
+          annotations:
+            summary: >-
+              Backup CronJob kopia-verify is missing from kube-state-metrics
+          for: 15m
+          labels:
+            severity: critical
+
+        - alert: KopiaVerifyStaleWarning
+          expr: |-
+            time() - kube_cronjob_status_last_successful_time{namespace="default", cronjob="kopia-verify"} > 129600
+          annotations:
+            summary: >-
+              Kopia verify has not completed successfully in more than 36 hours
+          for: 15m
+          labels:
+            severity: warning
+
+        - alert: KopiaVerifyStaleCritical
+          expr: |-
+            time() - kube_cronjob_status_last_successful_time{namespace="default", cronjob="kopia-verify"} > 172800
+          annotations:
+            summary: >-
+              Kopia verify has not completed successfully in more than 48 hours
+          for: 15m
+          labels:
+            severity: critical
+
+        - alert: KopiaAzureSyncCronJobMissing
+          expr: |-
+            absent(kube_cronjob_info{namespace="default", cronjob="kopia-azure-sync"})
+          annotations:
+            summary: >-
+              Backup CronJob kopia-azure-sync is missing from kube-state-metrics
+          for: 15m
+          labels:
+            severity: critical
+
+        - alert: KopiaAzureSyncStaleWarning
+          expr: |-
+            time() - kube_cronjob_status_last_successful_time{namespace="default", cronjob="kopia-azure-sync"} > 129600
+          annotations:
+            summary: >-
+              Kopia Azure sync has not completed successfully in more than 36 hours
+          for: 15m
+          labels:
+            severity: warning
+
+        - alert: KopiaAzureSyncStaleCritical
           expr: |-
             time() - kube_cronjob_status_last_successful_time{namespace="default", cronjob="kopia-azure-sync"} > 172800
           annotations:
@@ -77,3 +219,33 @@ spec:
           for: 10m
           labels:
             severity: warning
+
+        - alert: KopiaMaintenanceStaleWarning
+          expr: |-
+            time() - max(kube_job_status_completion_time{namespace="volsync-system", job_name=~"kopia-maint-.*"}) > 21600
+          annotations:
+            summary: >-
+              Kopia maintenance has not completed successfully in more than 6 hours
+          for: 15m
+          labels:
+            severity: warning
+
+        - alert: KopiaMaintenanceStaleCritical
+          expr: |-
+            time() - max(kube_job_status_completion_time{namespace="volsync-system", job_name=~"kopia-maint-.*"}) > 28800
+          annotations:
+            summary: >-
+              Kopia maintenance has not completed successfully in more than 8 hours
+          for: 15m
+          labels:
+            severity: critical
+
+        - alert: KopiaMaintenanceFreshnessUnobservable
+          expr: |-
+            absent(kube_job_status_completion_time{namespace="volsync-system", job_name=~"kopia-maint-.*"})
+          annotations:
+            summary: >-
+              Kopia maintenance freshness cannot be observed because completion metrics are absent
+          for: 15m
+          labels:
+            severity: critical


### PR DESCRIPTION
Phase 18 (Backup Confidence) monitoring closure. Makes backup status impossible to silently report green/unknown.

## What
- **CNPG backup/WAL alerts** (`postgres/prometheusrule-backup.yaml`) — Barman Cloud plugin timestamps + `cnpg_pg_stat_archiver_*`; deliberately avoids the always-zero `cnpg_collector_*backup*` metrics.
- **VolSync/Kopia/NAS hardening** (`volsync/prometheusrule.yaml`) — failure + **missing/unobservable** guards for the `nas-backup`, `kopia-verify`, `kopia-azure-sync` CronJobs and Kopia maintenance, so a deleted/renamed job still alerts.
- **Inventory-based source coverage** — kube-state-metrics CustomResourceState exports `kube_customresource_volsync_replicationsource_info`; `VolSyncSourceMissingFromInventory` (per-source set-difference, steady-state, no decay) + `VolSyncInventoryUnobservable` absent() companion. Closes the "a ReplicationSource silently stops backing up" gap without a hardcoded source count.
- **Backup Confidence dashboard** — single pane across NAS/Kopia/VolSync/CNPG; `bool`-form stat panels so healthy = green, not "No data".

## Validation
- `yq`/`jq`/`kustomize build` pass for all touched dirs.
- All PromQL/dashboard exprs parsed against live Prometheus.
- KSM CustomResourceState wiring verified by `helm template` of the pinned kube-state-metrics 7.4.0 subchart (ConfigMap, `--custom-resource-state-config-file` arg, mount, and RBAC all render).
- Two rounds of code review; both findings fixed and re-confirmed.

## Post-merge check (only possible after reconcile)
Once Flux reconciles, confirm `kube_customresource_volsync_replicationsource_info` returns 18 series. Until it emits, `VolSyncInventoryUnobservable` fires **loud** (not silent), so the gate is safe.

> Note: the Azure storage audit and the harbor-registry/authentik-data NFS→Ceph backup-gap remediation are tracked separately (follow-up PR).