### PR TITLE
feat(kopia-azure): bound the Azure mirror with a weekly guarded prune

### DIFF
--- a/kubernetes/apps/default/kopia-azure-sync/app/cronjob-prune.yaml
+++ b/kubernetes/apps/default/kopia-azure-sync/app/cronjob-prune.yaml
@@ -1,0 +1,103 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/batch/cronjob_v1.json
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: kopia-azure-prune
+spec:
+  schedule: "30 9 * * 0"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 28800
+      backoffLimit: 0
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          automountServiceAccountToken: false
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 977
+            runAsGroup: 988
+            fsGroup: 988
+          containers:
+            - name: kopia
+              image: docker.io/kopia/kopia:0.23.0
+              env:
+                - name: USER
+                  value: kopia
+                - name: KOPIA_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: kopia-azure-sync-secret
+                      key: KOPIA_PASSWORD
+                - name: AZURE_STORAGE_ACCOUNT
+                  valueFrom:
+                    secretKeyRef:
+                      name: kopia-azure-sync-secret
+                      key: AZURE_STORAGE_ACCOUNT
+                - name: AZURE_SAS_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: kopia-azure-sync-secret
+                      key: AZURE_SAS_TOKEN
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -eu
+
+                  echo "Connecting to kopia repository..."
+                  kopia repository connect filesystem \
+                    --path=/repository \
+                    --password="$KOPIA_PASSWORD"
+                  echo "Pruning Azure mirror to match repository (sync-to --delete)..."
+                  kopia repository sync-to azure \
+                    --container=nas-backup \
+                    --prefix=k8s/volsync \
+                    --storage-account="$AZURE_STORAGE_ACCOUNT" \
+                    --sas-token="$AZURE_SAS_TOKEN" \
+                    --parallel=2 \
+                    --delete \
+                    --must-exist
+                  echo "Azure prune complete."
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              volumeMounts:
+                - name: repository
+                  mountPath: /repository
+                  readOnly: true
+                - name: tmp
+                  mountPath: /tmp
+                - name: kopia-cache
+                  mountPath: /app/cache
+                - name: kopia-config
+                  mountPath: /app/config
+                - name: kopia-logs
+                  mountPath: /app/logs
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 256Mi
+                limits:
+                  memory: 512Mi
+          volumes:
+            - name: repository
+              nfs:
+                server: construct.melotic.dev
+                path: /var/nfs/shared/k8s/volsync
+                readOnly: true
+            - name: tmp
+              emptyDir: {}
+            - name: kopia-cache
+              emptyDir: {}
+            - name: kopia-config
+              emptyDir: {}
+            - name: kopia-logs
+              emptyDir: {}

--- a/kubernetes/apps/default/kopia-azure-sync/app/kustomization.yaml
+++ b/kubernetes/apps/default/kopia-azure-sync/app/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./cronjob.yaml
+  - ./cronjob-prune.yaml


### PR DESCRIPTION
## What

Adds a weekly `kopia-azure-prune` CronJob (Sun 09:30) that runs the **same** `kopia repository sync-to azure` as the daily job but with `--delete` instead of `--no-delete`, so the offsite Azure mirror tracks the repository instead of growing without bound.

The daily `kopia-azure-sync` stays `--no-delete` (additive, near-daily RPO). The weekly job is the only thing that prunes.

## Why it's safe (ransomware-resistant, declarative — no bash guards)

The prune's `--delete` is backed by Azure-side declarative safety on `sthomeopsbackup`:

- **Blob soft-delete = 30 days** with versioning **OFF** → true "days-since-deletion" recovery; every `--delete` (or overwrite) is recoverable for 30 days, and storage is bounded (auto-purge at 30d).
- **Restricted SAS** rotated in 1Password: permissions `racwld` — **no `y` (permanent-delete), no `x` (delete-version)**.
- **`allowPermanentDelete = false`** on the account → even with the key, soft-deleted blobs can't be purged early.

A leaked SAS or bad sync can therefore only soft-delete, which self-heals for 30 days. Empirically validated (delete/undelete/overwrite-snapshot all recoverable; new SAS daily sync green: `7295 in sync, 54.9 GB`).

## Diff

`cronjob-prune.yaml` is a verbatim clone of `cronjob.yaml` differing only by: name, schedule, `--no-delete`→`--delete`, and log strings. Reuses the existing `kopia-azure-sync-secret` and read-only NAS mount.