### PR TITLE
fix(gitlab): increase HelmRelease timeout to 15m

### DIFF
--- a/kubernetes/apps/gitlab/gitlab/app/helmrelease.yaml
+++ b/kubernetes/apps/gitlab/gitlab/app/helmrelease.yaml
@@ -16,6 +16,7 @@ metadata:
   name: gitlab
 spec:
   interval: 1h
+  timeout: 15m
   chart:
     spec:
       chart: gitlab
@@ -27,6 +28,11 @@ spec:
   install:
     remediation:
       retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   postRenderers:
     - kustomize:
         patches:


### PR DESCRIPTION
Resolve stalled HelmRelease by setting explicit 15m timeout for Helm upgrade operations.