### PR TITLE
feat(kyverno): scrape policy-reporter into VM/Grafana + rook-ceph PolicyException

### DIFF
--- a/kubernetes/apps/kyverno/policies/app/exceptions/rook-ceph-storage.yaml
+++ b/kubernetes/apps/kyverno/policies/app/exceptions/rook-ceph-storage.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/kyverno/main/.schemas/v2/policyexception.json
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: rook-ceph-storage-rootfs
+  namespace: kyverno
+  annotations:
+    policies.kyverno.io/reason: >-
+      Ceph daemons (osd/mon/mgr/mds/rgw/operator/crashcollector/exporter/tools) and CSI
+      plugins require root and a writable root filesystem to manage block devices and mounts.
+    policies.kyverno.io/intent: accepted-risk
+    home-ops.melotic.dev/review-trigger: >-
+      Re-evaluate if Rook-Ceph upstream ships a rootless/read-only-rootfs profile.
+spec:
+  background: true # MUST be true so background-scan PolicyReports flip fail→skip
+  exceptions:
+    - policyName: require-non-root-and-readonly-fs
+      ruleNames:
+        - check-runAsNonRoot
+        - check-readOnlyRootFilesystem
+        - autogen-check-runAsNonRoot
+        - autogen-check-readOnlyRootFilesystem
+        - autogen-cronjob-check-runAsNonRoot
+        - autogen-cronjob-check-readOnlyRootFilesystem
+    - policyName: verify-image-signature-cosign
+      ruleNames:
+        - verify-trusted-registries
+        - autogen-verify-trusted-registries
+        - autogen-cronjob-verify-trusted-registries
+  match:
+    any:
+      - resources:
+          namespaces: [rook-ceph]
+          kinds: [Pod, Deployment, StatefulSet, DaemonSet, Job, CronJob, ReplicaSet]

--- a/kubernetes/apps/kyverno/policies/app/kustomization.yaml
+++ b/kubernetes/apps/kyverno/policies/app/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - ./06-verify-image-signature-cosign.yaml
   - ./07-disallow-untrusted-images.yaml
   - ./08-require-image-registry-allowlist.yaml
+  - ./exceptions/rook-ceph-storage.yaml

--- a/kubernetes/apps/kyverno/policy-reporter/app/helmrelease.yaml
+++ b/kubernetes/apps/kyverno/policy-reporter/app/helmrelease.yaml
@@ -50,6 +50,19 @@ spec:
       kyverno:
         enabled: true
 
+    metrics:
+      enabled: true
+      mode: detailed
+
+    monitoring:
+      enabled: true
+      grafana:
+        grafanaDashboard:
+          enabled: true
+          folder: kyverno
+          matchLabels:
+            dashboards: grafana
+
     podSecurityContext:
       runAsNonRoot: true
       runAsUser: 1234


### PR DESCRIPTION
## What

Two related Kyverno changes:

**1. Surface the policy-reporter census into the monitoring stack**

Enables the already-deployed policy-reporter chart's native monitoring outputs via HelmRelease values:

- `metrics.enabled: true` + `mode: detailed` — exposes `policy_report_result{policy,rule,status,namespace,kind,name}`
- `monitoring.enabled: true` — ships the chart's `ServiceMonitor`, so the VM operator scrapes it
- `monitoring.grafana.grafanaDashboard.enabled: true` (folder `kyverno`, `matchLabels.dashboards: grafana`) — the Grafana Operator imports the 3 bundled dashboards (Overview / PolicyReport / ClusterPolicyReport)

Result: the live PolicyReport pass/fail/skip census is durable, queryable in VictoriaMetrics, and dashboarded in Grafana — instead of only being visible in the policy-reporter UI.

**2. Add a typed PolicyException for rook-ceph**

`rook-ceph-storage-rootfs` (`kyverno.io/v2`, namespace `kyverno`) excepts `require-non-root-and-readonly-fs` and `verify-image-signature-cosign` for the `rook-ceph` namespace. Ceph daemons + CSI plugins legitimately need root and a writable rootfs to manage block devices/mounts.

- Full base + `autogen-*` + `autogen-cronjob-*` rule enumeration (base-only names don't clear controller-owned Pod results)
- `reason` / `intent: accepted-risk` / `review-trigger` annotations for auditability
- No ClusterPolicy `exclude:` widening — typed exception only

## Why

This is the first, narrowly-scoped exception. It clears the ~319 rook-ceph rootfs/cosign violations and confirms a PolicyException in the `kyverno` namespace is honored for resources in other namespaces before any broader exception rollout.

## Verify after merge

Once Flux reconciles and Kyverno's background scan runs, the rook-ceph rootfs/cosign results should move from `fail` to `skip`:

```sh
KUBECONFIG=./kubeconfig kubectl get policyreport -A -o json \
  | jq -r '.items[] | select(.metadata.namespace=="rook-ceph") | .results[] | select(.result=="fail") | .policy' \
  | sort | uniq -c
```

The rootfs/cosign policies should disappear from the rook-ceph fail list; overall `skip` rises ~319 and `fail` drops correspondingly.