### PR TITLE
fix(kyverno): set policyExceptions namespace so exceptions are honored

### DIFF
--- a/kubernetes/apps/kyverno/kyverno/app/helmrelease.yaml
+++ b/kubernetes/apps/kyverno/kyverno/app/helmrelease.yaml
@@ -95,3 +95,4 @@ spec:
     features:
       policyExceptions:
         enabled: true
+        namespace: kyverno


### PR DESCRIPTION
## What

Adds `features.policyExceptions.namespace: kyverno` to the Kyverno HelmRelease.

## Why

The chart had `policyExceptions.enabled: true` but no `namespace`, so Kyverno rendered `--exceptionNamespace=` (empty). With that flag empty, the exception selector fails to initialize and **no PolicyException is honored at all**. Verified live on the cluster — the background controller logs:

```
ERR engine.go:68 > the flag --exceptionNamespace cannot be empty
   enablePolicyException=true  exceptionNamespace=
```

This was caught while piloting the first PolicyException (rook-ceph): the exception was correctly formed and accepted, but rook-ceph `require-non-root-and-readonly-fs` / cosign results stayed `fail` instead of flipping to `skip`. An identical exception placed directly in the `rook-ceph` namespace was also ignored — confirming the cause is the empty flag, not exception placement.

## Choice of value

`kyverno` (not `*`): all repo exceptions are applied into the `kyverno` namespace via the `policies` kustomization (`targetNamespace: kyverno`), which only Flux can write to. Restricting to a single, Flux-controlled namespace prevents a namespace owner from self-excepting policies.

## Verify after merge

After Flux reconciles and the Kyverno controllers restart, the previously-merged rook-ceph PolicyException should take effect:

```sh
KUBECONFIG=./kubeconfig kubectl get policyreport -A -o json \
  | jq -r '.items[] | select(.metadata.namespace=="rook-ceph") | .results[] | select(.result=="fail") | .policy' \
  | sort | uniq -c
```

`require-non-root-and-readonly-fs` and `verify-image-signature-cosign` should drop out of the rook-ceph fail list (≈198 results flip fail→skip).