### PR TITLE
fix(monitoring): harden gatus and fluent-bit to satisfy non-root/read-only-rootfs policy

### DIFF
--- a/kubernetes/apps/monitoring/fluent-bit/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/fluent-bit/app/helmrelease.yaml
@@ -31,6 +31,25 @@ spec:
         port: 5140
         containerPort: 5140
         protocol: UDP
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+      fsGroupChangePolicy: OnRootMismatch
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      runAsUser: 1000
+      capabilities:
+        drop: ["ALL"]
+    extraVolumes:
+      - name: tmp
+        emptyDir: {}
+    extraVolumeMounts:
+      - name: tmp
+        mountPath: /tmp
     config:
       service: |-
         [SERVICE]

--- a/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
@@ -24,6 +24,10 @@ spec:
               - --auto-httproute
               - --enable-httproute
               - --enable-service
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
             resources:
               requests:
                 cpu: 10m
@@ -71,6 +75,12 @@ spec:
     defaultPodOptions:
       automountServiceAccountToken: true
       hostUsers: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
     service:
       app:
         ports:


### PR DESCRIPTION
## What

Harden two monitoring workloads at the source so they satisfy the cluster's
`require-non-root-and-readonly-fs` policy — flipping their findings from **fail → pass**
(genuine fixes, not policy exceptions).

### gatus
- Add the canonical container `securityContext` (drop `ALL`, no privilege escalation,
  read-only rootfs) to the `gatus-sidecar` init container, which previously had none.
- Add a pod-level non-root `securityContext` (`runAsNonRoot` + `runAsUser`/`runAsGroup`/
  `fsGroup` 1000).
- The sidecar only writes its generated config to `/config`, a PVC mounted writable in
  both containers, so a read-only rootfs is safe. `NET_RAW` on the app container is
  preserved for ICMP monitoring.

### fluent-bit
- Set `podSecurityContext` (non-root, uid/gid/fsGroup 1000) and the container
  `securityContext` (drop `ALL`, no privilege escalation, read-only rootfs), plus a
  writable `/tmp` emptyDir.
- This deployment only ingests syslog over UDP/5140 (an unprivileged port) and ships to
  victoria-logs over HTTP with in-memory buffering, so it needs neither root nor a
  writable rootfs.

## Why

These two were the workloads that genuinely tolerate the control. Other audited
candidates (harbor, smartctl-exporter, victoria-logs-collector, paperless-ngx) legitimately
require root and/or a writable rootfs (raw disk access, host-log reads, root init
container) and will be handled separately with scoped policy exceptions instead.

## Verification

- YAML parses; `kustomize build` renders both apps cleanly.
- After merge + reconcile: both workloads stay Ready and their
  `require-non-root-and-readonly-fs` findings move fail → pass.
