### PR TITLE
feat(unifi-dns): harden external-dns webhook with read-only root filesystem

### DIFF
--- a/kubernetes/apps/network/unifi-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/unifi-dns/app/helmrelease.yaml
@@ -31,6 +31,11 @@ spec:
         image:
           repository: ghcr.io/kashalls/external-dns-unifi-webhook
           tag: v0.9.0@sha256:22f4106f44a0b9ac3c97cf29bbfef93026c1164492152dc797a1d6dc86ddfbb5
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
         env:
           - name: UNIFI_HOST
             value: https://10.60.0.1


### PR DESCRIPTION
The `external-dns` container already runs non-root with a read-only root filesystem (chart default), but the kashalls UniFi webhook sidecar had no container `securityContext`, so it lacked a read-only root filesystem — the only remaining `require-non-root-and-readonly-fs` violation in the `network` namespace.

## Change
Adds to `provider.webhook.securityContext`:
- `allowPrivilegeEscalation: false`
- `capabilities.drop: ["ALL"]`
- `readOnlyRootFilesystem: true`

The webhook continues to run non-root via the chart's pod-level `runAsNonRoot: true`.

## Verification
- `helm template` confirms the securityContext lands on the webhook container.
- After merge: confirm the `unifi-external-dns` pod stays Ready and the policy report flips fail → pass.