### PR TITLE
fix(rook-ceph): restore CSI service accounts

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/app/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.20.0
+    tag: v1.19.6
   url: oci://ghcr.io/rook/rook-ceph

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.20.0
+    tag: v1.19.6
   url: oci://ghcr.io/rook/rook-ceph-cluster


### PR DESCRIPTION
Reverts Rook charts to v1.19.6 to fix CSI driver registration broken by v1.20.0 defaults.