### PR TITLE
feat(rook-ceph): migrate to v1.20 with ceph-csi-drivers chart

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
@@ -10,8 +10,6 @@ spec:
     name: rook-ceph
   interval: 1h
   values:
-    csi:
-      cephFSKernelMountOptions: ms_mode=prefer-crc
     image:
       repository: ghcr.io/rook/ceph
     monitoring:

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.19.6
+    tag: v1.20.0
   url: oci://ghcr.io/rook/rook-ceph

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.19.6
+    tag: v1.20.0
   url: oci://ghcr.io/rook/rook-ceph-cluster

--- a/kubernetes/apps/rook-ceph/rook-ceph/csi/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi/helmrelease.yaml
@@ -1,0 +1,118 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ceph-csi-drivers
+spec:
+  releaseName: ceph-csi-drivers
+  targetNamespace: rook-ceph
+  storageNamespace: rook-ceph
+  chart:
+    spec:
+      chart: ceph-csi-drivers
+      sourceRef:
+        kind: HelmRepository
+        name: ceph-csi-operator
+        namespace: rook-ceph
+      version: 1.0.1
+  interval: 1h
+  values:
+    operatorConfig:
+      name: ceph-csi-operator-config
+      namespace: rook-ceph
+      create: true
+      driverSpecDefaults:
+        clusterName: rook-ceph
+        imageSet:
+          name: rook-csi-operator-image-set-configmap
+        controllerPlugin:
+          hostNetwork: true
+          replicas: 2
+          deploymentStrategy:
+            type: Recreate
+          priorityClassName: system-cluster-critical
+        nodePlugin:
+          priorityClassName: system-node-critical
+    drivers:
+      rbd:
+        name: rook-ceph.rbd.csi.ceph.com
+        enabled: true
+        clusterName: rook-ceph
+        imageSet:
+          name: rook-csi-operator-image-set-configmap
+        snapshotPolicy: none
+        controllerPlugin:
+          hostNetwork: true
+          replicas: 2
+          priorityClassName: system-cluster-critical
+          resources:
+            attacher:
+              requests: { cpu: 100m, memory: 128Mi }
+              limits: { memory: 256Mi }
+            provisioner:
+              requests: { cpu: 100m, memory: 128Mi }
+              limits: { memory: 256Mi }
+            resizer:
+              requests: { cpu: 100m, memory: 128Mi }
+              limits: { memory: 256Mi }
+            snapshotter:
+              requests: { cpu: 100m, memory: 128Mi }
+              limits: { memory: 256Mi }
+            omapGenerator:
+              requests: { cpu: 250m, memory: 512Mi }
+              limits: { memory: 1Gi }
+            plugin:
+              requests: { memory: 512Mi }
+              limits: { memory: 1Gi }
+        nodePlugin:
+          priorityClassName: system-node-critical
+          resources:
+            plugin:
+              requests: { cpu: 250m, memory: 512Mi }
+              limits: { memory: 1Gi }
+            registrar:
+              requests: { cpu: 50m, memory: 128Mi }
+              limits: { memory: 256Mi }
+      cephfs:
+        name: rook-ceph.cephfs.csi.ceph.com
+        enabled: true
+        clusterName: rook-ceph
+        imageSet:
+          name: rook-csi-operator-image-set-configmap
+        snapshotPolicy: volumeGroupSnapshot
+        kernelMountOptions:
+          ms_mode: prefer-crc
+        controllerPlugin:
+          hostNetwork: true
+          replicas: 2
+          priorityClassName: system-cluster-critical
+          resources:
+            attacher:
+              requests: { cpu: 100m, memory: 128Mi }
+              limits: { memory: 256Mi }
+            provisioner:
+              requests: { cpu: 100m, memory: 128Mi }
+              limits: { memory: 256Mi }
+            resizer:
+              requests: { cpu: 100m, memory: 128Mi }
+              limits: { memory: 256Mi }
+            snapshotter:
+              requests: { cpu: 100m, memory: 128Mi }
+              limits: { memory: 256Mi }
+            plugin:
+              requests: { cpu: 250m, memory: 512Mi }
+              limits: { memory: 1Gi }
+        nodePlugin:
+          priorityClassName: system-node-critical
+          resources:
+            plugin:
+              requests: { cpu: 250m, memory: 512Mi }
+              limits: { memory: 1Gi }
+            registrar:
+              requests: { cpu: 50m, memory: 128Mi }
+              limits: { memory: 256Mi }
+      nvmeof:
+        enabled: false
+      nfs:
+        enabled: false

--- a/kubernetes/apps/rook-ceph/rook-ceph/csi/helmrepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi/helmrepository.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: ceph-csi-operator
+  namespace: rook-ceph
+spec:
+  interval: 1h
+  url: https://ceph.github.io/ceph-csi-operator

--- a/kubernetes/apps/rook-ceph/rook-ceph/csi/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
@@ -28,6 +28,34 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
+  name: &csi rook-ceph-csi
+  namespace: &namespace rook-ceph
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *csi
+  dependsOn:
+    - name: rook-ceph
+      namespace: rook-ceph
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: ceph-csi-drivers
+      namespace: *namespace
+  interval: 1h
+  path: ./kubernetes/apps/rook-ceph/rook-ceph/csi
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
   name: &cluster rook-ceph-cluster
   namespace: &namespace rook-ceph
 spec:
@@ -35,7 +63,7 @@ spec:
     labels:
       app.kubernetes.io/name: *cluster
   dependsOn:
-    - name: rook-ceph
+    - name: rook-ceph-csi
       namespace: rook-ceph
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2


### PR DESCRIPTION
## Summary
Migrates Rook-Ceph **v1.19.6 → v1.20.0**. The v1.20 breaking change: the `rook-ceph` operator chart no longer deploys CSI drivers — they are now configured by the separate **`ceph-csi-drivers`** Helm chart (creates the `Driver` + `OperatorConfig` CRs, reconciled by the `ceph-csi-operator` subchart). The two Renovate tag-bump PRs (#1309/#1310) are insufficient on their own.

## Changes
- Bump `rook-ceph` operator + cluster OCI charts → `v1.20.0`
- **New `csi/`**: HelmRelease `ceph-csi-drivers` (chart 1.0.1) + HelmRepository `ceph-csi-operator`
- Remove now-invalid `csi.cephFSKernelMountOptions` from operator values (moved to drivers chart)
- Flux ordering enforced via `dependsOn`: **`rook-ceph` → `rook-ceph-csi` → `rook-ceph-cluster`** (matches the official upgrade-doc chart order)

## Behavior preservation (verified by render + diff vs live CRs)
hostNetwork, replicas=2, Recreate strategy, priority classes, per-container resources, imageSet ref, cephfs `ms_mode=prefer-crc` + `volumeGroupSnapshot`, rbd snapshotPolicy=none. Driver names keep the `rook-ceph.` prefix so existing StorageClasses (`ceph-block`/`ceph-filesystem`) keep working. nvmeof/nfs disabled. The live CRs are pre-seeded with `meta.helm.sh/release-name: ceph-csi-drivers` so the chart adopts them.

## Merge-time verification (manual)
After merge, confirm the one-time CSI plugin rolling restart completes healthy:
```sh
kubectl -n rook-ceph rollout status deploy/rook-ceph.rbd.csi.ceph.com-ctrlplugin
kubectl -n rook-ceph rollout status ds/rook-ceph.rbd.csi.ceph.com-nodeplugin
kubectl -n rook-ceph rollout status deploy/rook-ceph.cephfs.csi.ceph.com-ctrlplugin
kubectl -n rook-ceph rollout status ds/rook-ceph.cephfs.csi.ceph.com-nodeplugin
```

> Note: ordering uses HelmRelease-Ready health gates (chart sequencing per the upgrade doc). The Ceph daemon upgrade does not hard-depend on CSI pod health; existing mounted volumes stay up during the CSI restart.

Conflicting Renovate PRs #1309/#1310 left open intentionally.