### PR TITLE
fix(rook-ceph): drop partial CSI resources blocks rejected by v1.20 Driver CRD

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/csi/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi/helmrelease.yaml
@@ -46,34 +46,8 @@ spec:
           hostNetwork: true
           replicas: 2
           priorityClassName: system-cluster-critical
-          resources:
-            attacher:
-              requests: { cpu: 100m, memory: 128Mi }
-              limits: { memory: 256Mi }
-            provisioner:
-              requests: { cpu: 100m, memory: 128Mi }
-              limits: { memory: 256Mi }
-            resizer:
-              requests: { cpu: 100m, memory: 128Mi }
-              limits: { memory: 256Mi }
-            snapshotter:
-              requests: { cpu: 100m, memory: 128Mi }
-              limits: { memory: 256Mi }
-            omapGenerator:
-              requests: { cpu: 250m, memory: 512Mi }
-              limits: { memory: 1Gi }
-            plugin:
-              requests: { memory: 512Mi }
-              limits: { memory: 1Gi }
         nodePlugin:
           priorityClassName: system-node-critical
-          resources:
-            plugin:
-              requests: { cpu: 250m, memory: 512Mi }
-              limits: { memory: 1Gi }
-            registrar:
-              requests: { cpu: 50m, memory: 128Mi }
-              limits: { memory: 256Mi }
       cephfs:
         name: rook-ceph.cephfs.csi.ceph.com
         enabled: true
@@ -87,31 +61,8 @@ spec:
           hostNetwork: true
           replicas: 2
           priorityClassName: system-cluster-critical
-          resources:
-            attacher:
-              requests: { cpu: 100m, memory: 128Mi }
-              limits: { memory: 256Mi }
-            provisioner:
-              requests: { cpu: 100m, memory: 128Mi }
-              limits: { memory: 256Mi }
-            resizer:
-              requests: { cpu: 100m, memory: 128Mi }
-              limits: { memory: 256Mi }
-            snapshotter:
-              requests: { cpu: 100m, memory: 128Mi }
-              limits: { memory: 256Mi }
-            plugin:
-              requests: { cpu: 250m, memory: 512Mi }
-              limits: { memory: 1Gi }
         nodePlugin:
           priorityClassName: system-node-critical
-          resources:
-            plugin:
-              requests: { cpu: 250m, memory: 512Mi }
-              limits: { memory: 1Gi }
-            registrar:
-              requests: { cpu: 50m, memory: 128Mi }
-              limits: { memory: 256Mi }
       nvmeof:
         enabled: false
       nfs:


### PR DESCRIPTION
Follow-up to #1311. The `ceph-csi-drivers` chart renders **every** resource sub-key and emits `null` for any not specified; the stricter v1.20 `Driver` CRD rejects `null` (must be object), so the Helm install failed server-side. Partial resource customization is impossible with this chart. Dropping the `resources` blocks lets the operator apply its defaults. Verified with `kubectl apply --server-side --dry-run=server` against the live CRD — both Driver CRs apply cleanly.