### PR TITLE
fix(monitoring): emit volsync_replicationsource_info series (KSM Info zero-series bug)

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -132,7 +132,10 @@ spec:
                     help: VolSync ReplicationSource inventory
                     each:
                       type: Info
-                      info: {}
+                      info:
+                        labelsFromPath:
+                          obj_namespace: [metadata, namespace]
+                          obj_name: [metadata, name]
       resources:
         requests:
           cpu: 10m


### PR DESCRIPTION
## Problem
The critical alert `VolSyncInventoryUnobservable` (`absent(kube_customresource_volsync_replicationsource_info)`) is firing. KSM v2.19.0 registers the metric family (HELP+TYPE) but emits **zero data series** despite 20 `ReplicationSource` CRs existing.

## Root cause (verified against KSM v2.19.0 source)
In `pkg/customresourcestate/registry_factory.go`, `compiledInfo.values()` only appends a series when the **info-block's own** `labelsFromPath` yields ≥1 label:
```go
addPathLabels(v, c.labelFromPath, value.Labels) // info-level labelsFromPath
if len(value.Labels) != 0 { result = append(result, value) }
```
The previous config put `labelsFromPath` at the **resource level** with `info: {}` empty. Resource-level labels are merged only *after* eachValues are produced (`DefaultLabels`), so an empty `info` block produces no eachValue → every series is dropped.

## Fix
Move `labelsFromPath` (obj_name/obj_namespace) into `each.info.labelsFromPath` so the Info gate is satisfied and one series is emitted per ReplicationSource. Kept resource-level labels too to future-proof additional metrics in this block.

## Verification
- `kustomize build` passes; rendered config confirmed.
- Root cause + no double-emission validated against source.
- Post-merge: confirm series appear on KSM `:8080/metrics` and alert clears in Alertmanager.