### PR TITLE
fix(rook-ceph): run CSI controller plugins on pod network (no hostNetwork)

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/csi/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi/helmrelease.yaml
@@ -27,7 +27,10 @@ spec:
         imageSet:
           name: rook-csi-operator-image-set-configmap
         controllerPlugin:
-          hostNetwork: true
+          # Provisioner runs on the pod network; Ceph is reachable there (no dedicated
+          # storage network). hostNetwork is only needed when the pod network cannot
+          # reach the Ceph cluster. Keeping it false avoids tripping disallow-host-namespaces.
+          hostNetwork: false
           replicas: 2
           deploymentStrategy:
             type: Recreate
@@ -43,7 +46,7 @@ spec:
           name: rook-csi-operator-image-set-configmap
         snapshotPolicy: none
         controllerPlugin:
-          hostNetwork: true
+          hostNetwork: false
           replicas: 2
           priorityClassName: system-cluster-critical
         nodePlugin:
@@ -58,7 +61,7 @@ spec:
         kernelMountOptions:
           ms_mode: prefer-crc
         controllerPlugin:
-          hostNetwork: true
+          hostNetwork: false
           replicas: 2
           priorityClassName: system-cluster-critical
         nodePlugin:


### PR DESCRIPTION
## Problem
The v1.20 CSI migration set `controllerPlugin.hostNetwork: true` for both rbd and cephfs drivers. This put the CSI **provisioner** (ctrlplugin) Deployments on the host network, adding 8 new `disallow-host-namespaces` Audit fails (Kyverno) that did not exist before.

## Why it's wrong
- ceph-csi-operator's `controllerPlugin.hostNetwork` **default is false** (`ptr.Deref(pluginSpec.HostNetwork, false)`; chart docs confirm default false).
- Per the operator's `docs/design/hostNetwork.md`, controller-plugin host networking is only needed for *dedicated storage network* setups where the pod network cannot reach the Ceph cluster.
- This cluster runs Ceph on the **pod network** (`cephcluster.spec.network` is empty), so the provisioner reaches the MONs fine on pod network.
- The **nodeplugins** still use host network (hardcoded by the operator — needed to mount devices on the node) and remain correctly excepted by the existing `host-namespace-infra` PolicyException.

## Fix
Set `controllerPlugin.hostNetwork: false` in driverSpecDefaults + both drivers. Restores `disallow-host-namespaces` to 0 residual fails and matches the operator default / upstream recommendation.

## Verification
- `kustomize build` passes.
- Post-merge: ctrlplugin pods restart onto pod network (Recreate, 2 replicas); CephCluster stays HEALTH_OK; PVC provisioning still works; host-ns census returns to 0.