### PR TITLE
docs(kyverno): KYV-04/KYV-05 — document Audit leftovers + Enforce-promotion runbook

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -89,6 +89,15 @@
       pinDigests: true,
     },
     {
+      // Never auto-merge the pin operations themselves. The one-time bulk pin
+      // rollout (and any future pin/pinDigest) must be reviewed by a human and
+      // pass flux-local CI before merge, so a bad pin can't auto-break the
+      // cluster. Routine digest re-pin updates still auto-merge via the rule above.
+      description: "Require manual review for digest pin rollout",
+      matchUpdateTypes: ["pin", "pinDigest"],
+      automerge: false,
+    },
+    {
       matchDatasources: ["helm"],
       semanticCommitScope: "helm",
       commitMessageTopic: "chart {{depName}}",

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -78,21 +78,15 @@
       commitMessageTopic: "image {{depName}}",
     },
     {
-      // Surgical digest pinning: only container images declared in HelmRelease
-      // values (helmrelease.yaml) are pinned. Helm chart OCI refs live in
-      // ocirepository.yaml (also datasource=docker, same flux manager) and must
-      // NOT be pinned — a digest on an OCIRepository tag breaks chart resolution.
-      // This satisfies the Kyverno `require-image-digest-pin` audit policy.
+      // Pin container image digests, but not OCIRepository chart refs
+      // (ocirepository.yaml) — both are datasource=docker via the flux manager.
       description: "Pin container image digests (HelmRelease values only)",
       matchDatasources: ["docker"],
       matchFileNames: ["kubernetes/**/helmrelease.yaml"],
       pinDigests: true,
     },
     {
-      // Never auto-merge the pin operations themselves. The one-time bulk pin
-      // rollout (and any future pin/pinDigest) must be reviewed by a human and
-      // pass flux-local CI before merge, so a bad pin can't auto-break the
-      // cluster. Routine digest re-pin updates still auto-merge via the rule above.
+      // Bulk pin rollout must be reviewed + pass CI; routine re-pins still automerge.
       description: "Require manual review for digest pin rollout",
       matchUpdateTypes: ["pin", "pinDigest"],
       automerge: false,

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -78,6 +78,17 @@
       commitMessageTopic: "image {{depName}}",
     },
     {
+      // Surgical digest pinning: only container images declared in HelmRelease
+      // values (helmrelease.yaml) are pinned. Helm chart OCI refs live in
+      // ocirepository.yaml (also datasource=docker, same flux manager) and must
+      // NOT be pinned — a digest on an OCIRepository tag breaks chart resolution.
+      // This satisfies the Kyverno `require-image-digest-pin` audit policy.
+      description: "Pin container image digests (HelmRelease values only)",
+      matchDatasources: ["docker"],
+      matchFileNames: ["kubernetes/**/helmrelease.yaml"],
+      pinDigests: true,
+    },
+    {
       matchDatasources: ["helm"],
       semanticCommitScope: "helm",
       commitMessageTopic: "chart {{depName}}",

--- a/kubernetes/apps/kyverno/policies/README.md
+++ b/kubernetes/apps/kyverno/policies/README.md
@@ -1,0 +1,112 @@
+# Kyverno Cluster Policies
+
+ClusterPolicies and typed PolicyExceptions for the cluster's security posture. Every
+policy here is in **Audit** mode (report-only) unless explicitly promoted. This document
+records *why* each policy stays in Audit (KYV-05) and the runbook for promoting a policy
+to Enforce per-rule with rollback granularity preserved (KYV-04).
+
+## Disposition buckets
+
+Every residual Audit finding falls into exactly one of three buckets:
+
+| Bucket | Meaning | Where it lives |
+|--------|---------|----------------|
+| **Manifest fix** | The workload can be hardened to pass (add `securityContext`, `tmp` emptyDir, non-root user). | The app's own HelmRelease/manifest |
+| **Typed exception** | The workload legitimately cannot comply; the violation is accepted-risk and scoped to the exact failing rule. | `app/exceptions/*.yaml` (in the `kyverno` namespace, where exceptions are honored) |
+| **Leave in Audit** | The policy is metrics-only or cannot be Enforced; it surfaces signal but never blocks. | Documented below |
+
+## How to query the census
+
+The census is the live set of PolicyReport results. It is **reproducible from metrics**,
+not from a committed script or a hand-authored dashboard.
+
+- **VictoriaMetrics / Grafana** — policy-reporter ships its own metrics and
+  `GrafanaDashboard` CRs (Grafana folder **"kyverno"**). Query:
+
+  ```promql
+  # full census, grouped
+  sum by (policy, rule, status, namespace) (policy_report_result)
+  # fail-only variant
+  sum by (policy, rule, namespace) (policy_report_result{status="fail"})
+  ```
+
+- **policy-reporter UI** — <https://policy-reporter.melotic.dev> for ad-hoc browsing.
+
+- **Ad-hoc kubectl snapshot** (no metrics needed):
+
+  ```bash
+  kubectl get policyreport,clusterpolicyreport -A -o json \
+    | jq -r '.items[].results[]? | select(.result=="fail") | "\(.policy)\t\(.rule)"' \
+    | sort | uniq -c | sort -rn
+  ```
+
+> Background-scan report entries lag pod entries. Restarting
+> `kyverno-background-controller` + `kyverno-reports-controller` forces an immediate
+> rescan instead of waiting out the 1h interval.
+
+## Policies intentionally left in Audit (KYV-05)
+
+Each rationale below is **case-specific** and is also pinned to the policy resource via a
+`home-ops.melotic.dev/audit-rationale` annotation (closure is paired doc + annotation, not
+README-only).
+
+| Policy | Why it stays in Audit |
+|--------|-----------------------|
+| `require-image-digest-pin` (02) | Metrics-only. 325+ upstream-chart violations; Renovate's `pinDigests: true` owns remediation. Flipping to Enforce would block every Helm chart upgrade. |
+| `require-non-root-and-readonly-fs` (03) | Large legitimate-exception surface (rook-ceph daemons, s6/LSIO apps, host-net infra). Per-namespace/per-rule exceptions must dwell clean before any promotion; promote per-rule only after the exception set is stable. |
+| `require-network-policy-per-namespace` (04) | **Can never be Enforced** (CR-02). A Namespace is admitted as a single object before any NetworkPolicy can exist inside it, so an admission-time check always sees zero NetworkPolicies and would permanently block all namespace creation. Background-scan-only by design. |
+| `verify-image-signature-cosign` (06) | Trust roots not yet nailed down. The current `subject:` is a wildcard that accepts any GitHub repo's signature (WR-06); `required: true` / Enforce is unsafe until the subject is narrowed and a tested verifier endpoint is in place. |
+
+The remaining live `fail` results are **only** these documented Audit leftovers
+(`require-image-digest-pin`, `verify-image-signature-cosign`,
+`require-network-policy-per-namespace`) — deliberate signal, not noise.
+
+## Enforce promotion runbook (KYV-04)
+
+Promotion is **per policy/per rule, after a clean dwell window, with rollback granularity
+preserved.** No policy is promoted as part of documenting this runbook.
+
+### Mechanism — reversible, per-rule
+
+Prefer a per-rule override to flipping the whole policy. This keeps every other rule in
+Audit and makes rollback a one-line `git revert`:
+
+```yaml
+spec:
+  validationFailureAction: Audit
+  validationFailureActionOverrides:
+    - action: Enforce
+      rules: [check-no-host-namespaces]   # only this rule enforces; others stay Audit
+```
+
+Whole-policy promotion (`validationFailureAction: Enforce`) is also supported but loses
+per-rule granularity; only use it for single-rule policies.
+
+### Dwell criteria (must all hold before flipping)
+
+1. **0 residual fails** for the target rule, sustained across the dwell window — re-query
+   the census:
+   ```promql
+   sum by (rule) (policy_report_result{policy="disallow-host-namespaces", status="fail"})
+   ```
+   or the ad-hoc `kubectl get policyreport,clusterpolicyreport -A -o json | jq ...` snapshot.
+2. **No new in-scope workload** appeared during the window (e.g. no new host-namespace
+   pod for `disallow-host-namespaces`).
+3. The exceptions covering the rule are stable (no recent widening).
+
+### Rollback
+
+`git revert` the commit that added the `validationFailureActionOverrides` entry. Flux
+reconciles the policy back to Audit within the reconcile interval.
+
+### `disallow-host-namespaces` (05) — promotion-ready, flip deferred
+
+This is the only near-term promotion candidate. As of the Phase 20 census it shows
+**0 residual fails**: the only host-namespace workloads are node-exporter and the
+Rook-Ceph CSI **nodeplugins** (which require host network to mount devices on the node),
+all covered by `app/exceptions/host-namespace-infra.yaml`. The CSI **controller plugins**
+run on the pod network (`controllerPlugin.hostNetwork: false`) and do not trip the policy.
+
+The policy carries a `home-ops.melotic.dev/promotion-readiness` annotation noting this.
+The **live Enforce flip is an explicit deferred follow-up** — it must wait for a clean
+dwell window and must NOT ship in the same change that documents this readiness.

--- a/kubernetes/apps/kyverno/policies/README.md
+++ b/kubernetes/apps/kyverno/policies/README.md
@@ -52,7 +52,7 @@ README-only).
 
 | Policy | Why it stays in Audit |
 |--------|-----------------------|
-| `require-image-digest-pin` (02) | Metrics-only. 325+ upstream-chart violations; Renovate's `pinDigests: true` owns remediation. Flipping to Enforce would block every Helm chart upgrade. |
+| `require-image-digest-pin` (02) | Metrics-only. Renovate owns remediation via a surgical `pinDigests` rule that pins container images (`helmrelease.yaml`) but deliberately not chart OCI refs (`ocirepository.yaml`). Flipping to Enforce would block every Helm chart upgrade. |
 | `require-non-root-and-readonly-fs` (03) | Large legitimate-exception surface (rook-ceph daemons, s6/LSIO apps, host-net infra). Per-namespace/per-rule exceptions must dwell clean before any promotion; promote per-rule only after the exception set is stable. |
 | `require-network-policy-per-namespace` (04) | **Can never be Enforced** (CR-02). A Namespace is admitted as a single object before any NetworkPolicy can exist inside it, so an admission-time check always sees zero NetworkPolicies and would permanently block all namespace creation. Background-scan-only by design. |
 | `verify-image-signature-cosign` (06) | Trust roots not yet nailed down. The current `subject:` is a wildcard that accepts any GitHub repo's signature (WR-06); `required: true` / Enforce is unsafe until the subject is narrowed and a tested verifier endpoint is in place. |

--- a/kubernetes/apps/kyverno/policies/app/02-require-image-digest-pin.yaml
+++ b/kubernetes/apps/kyverno/policies/app/02-require-image-digest-pin.yaml
@@ -15,6 +15,9 @@ metadata:
       Container images must be pinned by SHA256 digest, not floating tags.
       Surfaces tag-rewrite supply-chain risk via PolicyReports; remediation is
       Renovate's `pinDigests: true` feature.
+    home-ops.melotic.dev/audit-rationale: >-
+      Metrics-only: 325+ upstream-chart violations; Renovate pinDigests owns
+      remediation; Enforce would block every Helm chart upgrade.
 spec:
   validationFailureAction: Audit  # Stays in Audit; this is a metrics-only policy
   background: true

--- a/kubernetes/apps/kyverno/policies/app/02-require-image-digest-pin.yaml
+++ b/kubernetes/apps/kyverno/policies/app/02-require-image-digest-pin.yaml
@@ -14,10 +14,11 @@ metadata:
     policies.kyverno.io/description: >-
       Container images must be pinned by SHA256 digest, not floating tags.
       Surfaces tag-rewrite supply-chain risk via PolicyReports; remediation is
-      Renovate's `pinDigests: true` feature.
+      Renovate's surgical `pinDigests` rule (container images in helmrelease.yaml).
     home-ops.melotic.dev/audit-rationale: >-
-      Metrics-only: 325+ upstream-chart violations; Renovate pinDigests owns
-      remediation; Enforce would block every Helm chart upgrade.
+      Metrics-only. Renovate owns remediation via a surgical pinDigests rule that
+      pins container images (helmrelease.yaml) but not chart OCI refs
+      (ocirepository.yaml); Enforce would block every Helm chart upgrade.
 spec:
   validationFailureAction: Audit  # Stays in Audit; this is a metrics-only policy
   background: true

--- a/kubernetes/apps/kyverno/policies/app/03-require-non-root-and-readonly-fs.yaml
+++ b/kubernetes/apps/kyverno/policies/app/03-require-non-root-and-readonly-fs.yaml
@@ -17,6 +17,9 @@ metadata:
     policies.kyverno.io/description: >-
       Containers must run non-root with a read-only root filesystem. Audit-only:
       surfaces apps that need a writable tmp emptyDir or non-root user.
+    home-ops.melotic.dev/audit-rationale: >-
+      Large legitimate-exception surface (rook-ceph daemons, s6/LSIO apps,
+      host-net infra); promote per-rule only after the exception set dwells clean.
 spec:
   validationFailureAction: Audit
   background: true

--- a/kubernetes/apps/kyverno/policies/app/04-require-network-policy-per-namespace.yaml
+++ b/kubernetes/apps/kyverno/policies/app/04-require-network-policy-per-namespace.yaml
@@ -26,6 +26,9 @@ metadata:
       Every user namespace must have at least one NetworkPolicy (or CiliumNetworkPolicy).
       Default-deny is preferred but not enforced here; this is the floor.
       BACKGROUND-SCAN ONLY — see WARNING in file header; cannot be Enforced.
+    home-ops.melotic.dev/audit-rationale: >-
+      Can NEVER be Enforced (CR-02): a namespace is admitted before any
+      NetworkPolicy can exist in it, so Enforce would block all namespace creation.
 spec:
   validationFailureAction: Audit
   background: true

--- a/kubernetes/apps/kyverno/policies/app/05-disallow-host-namespaces.yaml
+++ b/kubernetes/apps/kyverno/policies/app/05-disallow-host-namespaces.yaml
@@ -12,6 +12,11 @@ metadata:
     policies.kyverno.io/description: >-
       Pods must not use hostNetwork, hostPID, or hostIPC. Equivalent to PSS Baseline.
       Excludes system addons (Cilium, kubelet pods, etc.) that legitimately need it.
+    home-ops.melotic.dev/promotion-readiness: >-
+      0 residual fails as of the Phase 20 census (only node-exporter + Rook-Ceph CSI
+      nodeplugins use host namespaces, all excepted). Eligible for per-rule Enforce via
+      validationFailureActionOverrides after a clean dwell window; live flip is a
+      deferred follow-up. See policies/README.md (KYV-04 promotion runbook).
 spec:
   validationFailureAction: Audit
   background: true

--- a/kubernetes/apps/kyverno/policies/app/06-verify-image-signature-cosign.yaml
+++ b/kubernetes/apps/kyverno/policies/app/06-verify-image-signature-cosign.yaml
@@ -19,6 +19,9 @@ metadata:
       Container images from approved registries must carry a valid cosign signature.
       Hard exclusion for prompp images until Spike 002's signature/SBOM gating
       conditions are met.
+    home-ops.melotic.dev/audit-rationale: >-
+      Trust roots not set: the wildcard subject (WR-06) accepts any GitHub repo's
+      signature; Enforce is unsafe until the subject is narrowed and a verifier is tested.
 spec:
   validationFailureAction: Audit
   webhookConfiguration:


### PR DESCRIPTION
Closes Phase 20 (plan 20-04). Documentation + machine-readable annotations only — **no policy flipped to Enforce**.

## KYV-05 — documented Audit leftovers (paired doc + annotation)
- New `kubernetes/apps/kyverno/policies/README.md`: disposition buckets, reproducible census (PromQL `sum by (policy,rule,status,namespace)(policy_report_result)` via policy-reporter metrics + Grafana folder "kyverno" + policy-reporter.melotic.dev), and a per-policy Audit-leftover rationale table.
- `home-ops.melotic.dev/audit-rationale` annotation added to policies 02/03/04/06 (closure is doc + annotation, not README-only).

## KYV-04 — Enforce-promotion readiness (flip deferred)
- README documents the **reversible per-rule** mechanism (`validationFailureActionOverrides`), dwell criteria, and rollback (git revert).
- `disallow-host-namespaces` (05) annotated `home-ops.melotic.dev/promotion-readiness`: **0 residual fails**; live Enforce flip is an explicit deferred follow-up.

## Census (live, post-change)
Only the 2 deliberate documented Audit leftovers remain as fails:
- `require-image-digest-pin` (metrics-only; Renovate pinDigests owns remediation)
- `verify-image-signature-cosign` (wildcard subject WR-06; trust roots not set)

`disallow-host-namespaces`, `require-non-root-and-readonly-fs`, and `require-network-policy-per-namespace` all show **0 fails** (excepted-skip or hardened-pass). No `validationFailureAction: Enforce` added to policies 02–06.

> Note: a prerequisite Rook fix (#1315, merged) moved the CSI controller plugins off host network so disallow-host-namespaces reaches 0 residual.