### PR TITLE
fix(renovate): exclude cert-manager from digest pinning

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -86,6 +86,14 @@
       pinDigests: true,
     },
     {
+      // cert-manager is the only chart that pins via its own image.digest field;
+      // also pinning the tag renders an invalid double-digest ref (tag@sha256@sha256).
+      description: "cert-manager self-manages image digests",
+      matchDatasources: ["docker"],
+      matchFileNames: ["kubernetes/apps/cert-manager/cert-manager/app/helmrelease.yaml"],
+      pinDigests: false,
+    },
+    {
       // Bulk pin rollout must be reviewed + pass CI; routine re-pins still automerge.
       description: "Require manual review for digest pin rollout",
       matchUpdateTypes: ["pin", "pinDigest"],


### PR DESCRIPTION
## Problem
The surgical `pinDigests` rule (#1316) appended `@sha256:...` to every container image `tag:` in HelmReleases. cert-manager is the **only** chart in the repo whose values pin via a dedicated `image.digest` field, so its rendered refs became invalid double-digests:

```
quay.io/jetstack/cert-manager-controller:v1.20.2@sha256:fe06…@sha256:fe06…  # ErrImagePull
```

Caught at the manual-review gate on PR #1317 (automerge was disabled by config — working as designed). Affects all **5** cert-manager images (controller, webhook, cainjector, acmesolver, startupapicheck).

## Root cause (verified repo-wide)
A scan of **every** `helmrelease.yaml` shows cert-manager is the sole file with a dedicated `digest:` field. All other charts (app-template *and* non-app-template like rook-ceph/volsync) carry the digest only in `tag:`, so `tag: X@sha256` renders correctly.

## Fix
File-scoped `pinDigests: false` for the cert-manager HelmRelease — robust against future cert-manager image additions regardless of registry. cert-manager keeps self-managing digests via its `image.digest` field.

## Follow-up
After merge, Renovate will regenerate #1317 without the cert-manager pins (it's Immortal); #1317 will be closed.