### PR TITLE
fix(rook-ceph): enable RBD volumeSnapshot policy for VolSync

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/csi/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi/helmrelease.yaml
@@ -44,7 +44,9 @@ spec:
         clusterName: rook-ceph
         imageSet:
           name: rook-csi-operator-image-set-configmap
-        snapshotPolicy: none
+        # VolSync creates individual VolumeSnapshots per PVC on ceph-block; this
+        # deploys the csi-snapshotter sidecar on the RBD controller plugin.
+        snapshotPolicy: volumeSnapshot
         controllerPlugin:
           hostNetwork: false
           replicas: 2


### PR DESCRIPTION
## Summary

Enable the RBD CSI driver `snapshotPolicy: volumeSnapshot` so ceph-block VolumeSnapshots can complete for VolSync backups.

## Root cause

The Rook v1.20 `ceph-csi-drivers` migration left the RBD driver with `snapshotPolicy: none`. That prevented the `csi-snapshotter` sidecar from being added to the RBD controller plugin, leaving all ceph-block VolumeSnapshots stuck with `ReadyToUse=false`.

## Symptoms

This caused stalled VolSync backups and fired `VolSyncVolumeOutOfSync` plus `VolSyncSourceStale` Warning/Critical alerts for ~19 default-namespace apps.

## Fix

Set the RBD driver `snapshotPolicy` to `volumeSnapshot`. This matches the intended snapshot support and aligns with CephFS already having snapshotter support via `volumeGroupSnapshot`.

## Verification checklist

- [ ] `csi-snapshotter` container appears on `rook-ceph.rbd.csi.ceph.com-ctrlplugin`.
- [ ] Stuck `volsync-*-src` VolumeSnapshots transition to `ReadyToUse=true`.
- [ ] VolSync alerts clear.
- [ ] CI `flux-local` validation passes.
