### PR TITLE
fix(cert-manager): make CertManagerCertExpirySoon renewal-aware

### DIFF
--- a/kubernetes/apps/cert-manager/cert-manager/app/prometheusrule.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/prometheusrule.yaml
@@ -24,13 +24,13 @@ spec:
         - alert: CertManagerCertExpirySoon
           annotations:
             description:
-              The domain that this cert covers will be unavailable after {{ $value
-              | humanizeDuration }}. Clients using endpoints that this cert protects will
-              start to fail in {{ $value | humanizeDuration }}.
+              The cert is either overdue for renewal and under 21 days from expiry,
+              or under 3 days from expiry regardless of renewal state. Clients using
+              endpoints that this cert protects will start to fail in {{ $value |
+              humanizeDuration }}.
             runbook_url: https://github.com/imusmanmalik/cert-manager-mixin/blob/main/RUNBOOK.md#certmanagercertexpirysoon
             summary:
-              The cert `{{ $labels.name }}` is {{ $value | humanizeDuration }} from
-              expiry and overdue for renewal.
+              The cert `{{ $labels.name }}` expires in {{ $value | humanizeDuration }}.
           # Fire only when a cert is near expiry AND its renewal is actually overdue
           # (renewal timestamp already passed), so certs with a shorter renewBefore
           # than the 21d window (e.g. the barman-cloud self-signed certs, renewBefore

--- a/kubernetes/apps/cert-manager/cert-manager/app/prometheusrule.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/prometheusrule.yaml
@@ -30,11 +30,32 @@ spec:
             runbook_url: https://github.com/imusmanmalik/cert-manager-mixin/blob/main/RUNBOOK.md#certmanagercertexpirysoon
             summary:
               The cert `{{ $labels.name }}` is {{ $value | humanizeDuration }} from
-              expiry, it should have renewed over a week ago.
+              expiry and overdue for renewal.
+          # Fire only when a cert is near expiry AND its renewal is actually overdue
+          # (renewal timestamp already passed), so certs with a shorter renewBefore
+          # than the 21d window (e.g. the barman-cloud self-signed certs, renewBefore
+          # 360h) don't false-positive while waiting for their scheduled renewal.
+          # A hard <3d expiry backstop still fires regardless of the renewal metric.
           expr: |
-            avg by (exported_namespace, namespace, name) (
-              certmanager_certificate_expiration_timestamp_seconds - time()
-            ) < (21 * 24 * 3600) # 21 days in seconds
+            (
+              (
+                avg by (exported_namespace, namespace, name) (
+                  certmanager_certificate_expiration_timestamp_seconds - time()
+                ) < (21 * 24 * 3600)
+              )
+              and on (exported_namespace, namespace, name)
+              (
+                avg by (exported_namespace, namespace, name) (
+                  certmanager_certificate_renewal_timestamp_seconds - time()
+                ) < 0
+              )
+            )
+            or
+            (
+              avg by (exported_namespace, namespace, name) (
+                certmanager_certificate_expiration_timestamp_seconds - time()
+              ) < (3 * 24 * 3600)
+            )
           for: 1h
           labels:
             severity: critical


### PR DESCRIPTION
## Problem
`CertManagerCertExpirySoon` (cert-manager-mixin) fires whenever a cert is within **21 days** of expiry. The barman-cloud self-signed mTLS certs (`barman-cloud-client`/`barman-cloud-server`, used by the CNPG barman plugin) have `renewBefore: 360h` (15d), so cert-manager intentionally renews them at 15 days before expiry. The fixed 21d window trips ~6 days **before** the scheduled renewal, producing a recurring **false-positive critical** every 90-day cycle even though the certs are healthy (currently 18d from expiry, renewing in ~3d).

The rule's own summary said *"it should have renewed over a week ago"* — but the expression never checked the renewal timestamp.

## Fix
Gate the 21d-expiry condition on the renewal actually being overdue (`certmanager_certificate_renewal_timestamp_seconds - time() < 0`), which respects each cert's own `renewBefore` policy. A hard unconditional `<3d` expiry backstop is kept so a genuinely-expiring cert still alerts even if the renewal metric is missing/stale.

## Verification
- New expr validated against live Prometheus: parses OK, **0 series fire** now (the 2 barman false-positives clear); old expr fired 2.
- All 6 certs export both expiration and renewal metrics.
- Genuine renewal failures still fire (renewal overdue + nearing expiry), plus the <3d backstop.
- CI flux-local will validate.