### PR TITLE
fix(envoy-gateway): retune noisy xDS alerts on real health signals

### DIFF
--- a/kubernetes/apps/network/envoy-gateway/app/monitoring.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/monitoring.yaml
@@ -54,12 +54,24 @@ spec:
           annotations:
             summary: "Envoy proxy {{ $labels.pod }} has xDS connection failures"
             description: "Pod {{ $labels.pod }} in namespace {{ $labels.namespace }} is failing to connect to the xDS control plane."
-        - alert: EnvoyXdsStreamReset
+        - alert: EnvoyXdsDisconnected
           expr: |
-            increase(envoy_cluster_upstream_cx_destroy{envoy_cluster_name="xds_cluster"}[15m]) > 1
+            envoy_control_plane_connected_state{namespace="network"} == 0
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Envoy proxy {{ $labels.pod }} disconnected from xDS control plane"
+            description: "Pod {{ $labels.pod }} in namespace {{ $labels.namespace }} has not been connected to the envoy-gateway xDS control plane for 10m and cannot receive configuration updates."
+        - alert: EnvoyXdsConfigRejected
+          expr: |
+            (sum(increase(envoy_cluster_manager_cds_update_rejected[1h])) or vector(0))
+              + (sum(increase(envoy_listener_manager_lds_update_rejected[1h])) or vector(0))
+              + (sum(increase(envoy_http_rds_update_rejected[1h])) or vector(0))
+              + (sum(increase(envoy_sds_update_rejected[1h])) or vector(0)) > 0
           for: 5m
           labels:
             severity: critical
           annotations:
-            summary: "Envoy proxy {{ $labels.pod }} xDS stream destroyed repeatedly"
-            description: "Pod {{ $labels.pod }} in namespace {{ $labels.namespace }} has had multiple xDS stream resets, indicating persistent control plane connectivity issues."
+            summary: "Envoy proxies rejected an xDS config update"
+            description: "One or more Envoy proxies rejected a CDS/LDS/RDS/SDS update from the envoy-gateway control plane, indicating it is pushing invalid configuration."


### PR DESCRIPTION
EnvoyXdsStreamReset fired sporadically because increase(envoy_cluster_upstream_cx_destroy{xds_cluster}[15m]) > 1 triggers on routine xDS stream recycling on Flux config pushes (crossed threshold 191 times in 7d while connected_state never dropped and cx_connect_fail stayed 0). It is replaced with EnvoyXdsDisconnected (warning, on the canonical envoy_control_plane_connected_state == 0 gauge) and EnvoyXdsConfigRejected (critical, on summed CDS/LDS/RDS/SDS update_rejected). The envoy-gateway chart ships no alerts of its own, so these stay hand-rolled.