### PR TITLE
feat(gatus): internal uptime probes and connectivity ICMP fix

### DIFF
--- a/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
@@ -17,22 +17,33 @@ spec:
           reloader.stakater.com/auto: "true"
         initContainers:
           gatus-sidecar:
-            image:
+            image: &sidecarImage
               repository: ghcr.io/home-operations/gatus-sidecar
               tag: 0.0.19@sha256:a62610509ddb9d04ac562d13e096cecb391aa6647ac97d66ae5ba4db869bc6b8
             args:
               - --auto-httproute
               - --enable-httproute
               - --enable-service
-            securityContext:
+            securityContext: &sidecarSecurityContext
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               capabilities: {drop: ["ALL"]}
-            resources:
+            resources: &sidecarResources
               requests:
                 cpu: 10m
               limits:
                 memory: 64Mi
+            restartPolicy: Always
+          gatus-sidecar-uptime:
+            image: *sidecarImage
+            args:
+              - --auto-httproute
+              - --gateway-name=envoy-internal
+              - --annotation-config=gatus.home-operations.com/uptime
+              - --prefix-httproute=uptime-
+              - --output=/config/gatus-uptime.yaml
+            securityContext: *sidecarSecurityContext
+            resources: *sidecarResources
             restartPolicy: Always
         containers:
           app:

--- a/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
@@ -71,7 +71,7 @@ spec:
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
-              capabilities: {add: ["NET_RAW"], drop: ["ALL"]}
+              capabilities: {drop: ["ALL"]}
             resources:
               requests:
                 cpu: 100m
@@ -85,7 +85,6 @@ spec:
               size: 5Gi
     defaultPodOptions:
       automountServiceAccountToken: true
-      hostUsers: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/kubernetes/apps/monitoring/gatus/app/prometheusrule.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/prometheusrule.yaml
@@ -27,3 +27,14 @@ spec:
               The {{ $labels.name }} endpoint has a public DNS record and is exposed
           labels:
             severity: critical
+
+        - alert: GatusInternalRouteDown
+          expr: |-
+            gatus_results_endpoint_success{group="internal-uptime"} == 0
+          for: 5m
+          annotations:
+            summary: >-
+              Internal route {{ $labels.name }} is failing through envoy-internal
+              (HTTP 5xx/unreachable — possible stale EDS or backend down)
+          labels:
+            severity: critical

--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -133,6 +133,13 @@ metadata:
       ui:
         hide-hostname: true
         hide-url: true
+    gatus.home-operations.com/uptime: |-
+      group: internal-uptime
+      interval: 1m
+      conditions:
+        - "[STATUS] < 500"
+      ui:
+        hide-hostname: true
 spec:
   gatewayClassName: envoy
   infrastructure:

--- a/kubernetes/apps/network/envoy-gateway/app/monitoring.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/monitoring.yaml
@@ -35,31 +35,3 @@ spec:
   selector:
     matchLabels:
       control-plane: envoy-gateway
----
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
-apiVersion: monitoring.coreos.com/v1
-kind: PrometheusRule
-metadata:
-  name: envoy-xds-health
-spec:
-  groups:
-    - name: envoy-xds
-      rules:
-        - alert: EnvoyXdsConnectionFailures
-          expr: |
-            increase(envoy_cluster_upstream_cx_connect_fail{envoy_cluster_name="xds_cluster"}[10m]) > 0
-          for: 5m
-          labels:
-            severity: warning
-          annotations:
-            summary: "Envoy proxy {{ $labels.pod }} has xDS connection failures"
-            description: "Pod {{ $labels.pod }} in namespace {{ $labels.namespace }} is failing to connect to the xDS control plane."
-        - alert: EnvoyXdsStreamReset
-          expr: |
-            increase(envoy_cluster_upstream_cx_destroy{envoy_cluster_name="xds_cluster"}[15m]) > 1
-          for: 5m
-          labels:
-            severity: critical
-          annotations:
-            summary: "Envoy proxy {{ $labels.pod }} xDS stream destroyed repeatedly"
-            description: "Pod {{ $labels.pod }} in namespace {{ $labels.namespace }} has had multiple xDS stream resets, indicating persistent control plane connectivity issues."


### PR DESCRIPTION
Adds a second gatus-sidecar that probes envoy-internal HTTPRoutes over HTTP, with a GatusInternalRouteDown alert that catches stale-EDS routing (Envoy serving a dead pod IP after a dropped endpoint update). Removes the noisy envoy-xds-health PrometheusRule, whose EnvoyXdsStreamReset alert fired on normal xDS churn and never caught that failure mode. Also fixes the silently-failing connectivity ICMP checks by removing the gatus-only hostUsers: false, whose user namespace had forced the netns ping_group_range to 65534 65534 and excluded gatus's gid 1000.