### PR TITLE
refactor(gatus): collapse internal probes into a single uptime check

### DIFF
--- a/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
@@ -17,33 +17,22 @@ spec:
           reloader.stakater.com/auto: "true"
         initContainers:
           gatus-sidecar:
-            image: &sidecarImage
+            image:
               repository: ghcr.io/home-operations/gatus-sidecar
               tag: 0.0.19@sha256:a62610509ddb9d04ac562d13e096cecb391aa6647ac97d66ae5ba4db869bc6b8
             args:
               - --auto-httproute
               - --enable-httproute
               - --enable-service
-            securityContext: &sidecarSecurityContext
+            securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               capabilities: {drop: ["ALL"]}
-            resources: &sidecarResources
+            resources:
               requests:
                 cpu: 10m
               limits:
                 memory: 64Mi
-            restartPolicy: Always
-          gatus-sidecar-uptime:
-            image: *sidecarImage
-            args:
-              - --auto-httproute
-              - --gateway-name=envoy-internal
-              - --annotation-config=gatus.home-operations.com/uptime
-              - --prefix-httproute=uptime-
-              - --output=/config/gatus-uptime.yaml
-            securityContext: *sidecarSecurityContext
-            resources: *sidecarResources
             restartPolicy: Always
         containers:
           app:

--- a/kubernetes/apps/monitoring/gatus/app/prometheusrule.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/prometheusrule.yaml
@@ -18,19 +18,9 @@ spec:
           labels:
             severity: critical
 
-        - alert: GatusEndpointExposed
-          expr: |-
-            gatus_results_endpoint_success{group="internal"} == 0
-          for: 5m
-          annotations:
-            summary: >-
-              The {{ $labels.name }} endpoint has a public DNS record and is exposed
-          labels:
-            severity: critical
-
         - alert: GatusInternalRouteDown
           expr: |-
-            gatus_results_endpoint_success{group="internal-uptime"} == 0
+            gatus_results_endpoint_success{group="internal"} == 0
           for: 5m
           annotations:
             summary: >-

--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -129,12 +129,6 @@ metadata:
     external-dns.alpha.kubernetes.io/target: &hostname internal.melotic.dev
     gatus.home-operations.com/endpoint: |-
       group: internal
-      guarded: true
-      ui:
-        hide-hostname: true
-        hide-url: true
-    gatus.home-operations.com/uptime: |-
-      group: internal-uptime
       interval: 1m
       conditions:
         - "[STATUS] < 500"


### PR DESCRIPTION
Internal services were each showing two Gatus cards (a guarded DNS-exposure check and an HTTP uptime probe), cluttering the dashboard. This drops the second sidecar and the exposure guard so each internal service has a single HTTP uptime card, and repoints GatusInternalRouteDown to group="internal".