### PR TITLE
feat(gitlab): route SSH through envoy-internal TCPRoute

### DIFF
--- a/kubernetes/apps/gitlab/gitlab/app/helmrelease.yaml
+++ b/kubernetes/apps/gitlab/gitlab/app/helmrelease.yaml
@@ -75,7 +75,7 @@ spec:
         externalIP: ""
         gitlab:
           name: gitlab.melotic.dev
-        ssh: ssh.gitlab.melotic.dev
+        ssh: gitlab.melotic.dev
       ingress:
         configureCertmanager: false
         provider: none
@@ -284,11 +284,10 @@ spec:
             memory: 512Mi
       gitlab-shell:
         gatewayRoute:
-          enabled: false
+          enabled: true
+          sectionName: gitlab-ssh
         service:
-          type: LoadBalancer
-          annotations:
-            external-dns.alpha.kubernetes.io/hostname: ssh.gitlab.melotic.dev
+          type: ClusterIP
           internalPort: 2222
         resources:
           requests:

--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -161,6 +161,17 @@ spec:
         certificateRefs:
           - kind: Secret
             name: melotic-dev-tls
+    - name: gitlab-ssh
+      protocol: TCP
+      port: 22
+      allowedRoutes:
+        kinds:
+          - kind: TCPRoute
+        namespaces:
+          from: Selector
+          selector:
+            matchLabels:
+              kubernetes.io/metadata.name: gitlab
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.envoyproxy.io/backendtrafficpolicy_v1alpha1.json
 apiVersion: gateway.envoyproxy.io/v1alpha1


### PR DESCRIPTION
Routes GitLab git-over-SSH through the envoy-internal Gateway via a TCP:22 listener and the chart's gitlab-shell TCPRoute, so it stops consuming a dedicated LoadBalancer IP. The SSH host collapses to gitlab.melotic.dev and gitlab-shell becomes a ClusterIP service.