### PR TITLE
feat(gatus): serve status page at status.melotic.dev

### DIFF
--- a/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
@@ -95,6 +95,7 @@ spec:
           gatus.home-operations.com/enabled: "false"
         hostnames:
           - "{{ .Release.Name }}.melotic.dev"
+          - "status.melotic.dev"
         parentRefs:
           - name: envoy-internal
             namespace: network


### PR DESCRIPTION
Adds status.melotic.dev as a second hostname on the Gatus HTTPRoute alongside gatus.melotic.dev. GitLab is already auto-monitored via the envoy-internal gateway annotation now that it routes through the gateway.