### PR TITLE
fix(bootstrap): make log fatal abort instead of falling through

### DIFF
--- a/scripts/bootstrap-apps.sh
+++ b/scripts/bootstrap-apps.sh
@@ -91,11 +91,11 @@ function apply_crds() {
     local -r helmfile_file="${ROOT_DIR}/bootstrap/helmfile.d/00-crds.yaml"
 
     if [[ ! -f "${helmfile_file}" ]]; then
-        log fatal "File does not exist" "file" "${helmfile_file}"
+        log fatal "File does not exist" "file=${helmfile_file}"
     fi
 
     if ! crds=$(helmfile --file "${helmfile_file}" template --quiet) || [[ -z "${crds}" ]]; then
-        log fatal "Failed to render CRDs from Helmfile" "file" "${helmfile_file}"
+        log fatal "Failed to render CRDs from Helmfile" "file=${helmfile_file}"
     fi
 
     if echo "${crds}" | kubectl diff --filename - &>/dev/null; then
@@ -104,7 +104,7 @@ function apply_crds() {
     fi
 
     if ! echo "${crds}" | kubectl apply --server-side --filename - &>/dev/null; then
-        log fatal "Failed to apply crds from Helmfile" "file" "${helmfile_file}"
+        log fatal "Failed to apply crds from Helmfile" "file=${helmfile_file}"
     fi
 
     log info "CRDs applied successfully"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -12,6 +12,7 @@ function log() {
         [info]=2
         [warn]=3
         [error]=4
+        [fatal]=5
     )
 
     # Get the current log level's priority
@@ -32,6 +33,7 @@ function log() {
         [info]="\033[1m\033[38;5;87m"   # Cyan
         [warn]="\033[1m\033[38;5;192m"  # Yellow
         [error]="\033[1m\033[38;5;198m" # Red
+        [fatal]="\033[1m\033[38;5;160m" # Bright red
     )
 
     # Fallback to "info" if the color for the given level is not defined
@@ -53,7 +55,7 @@ function log() {
 
     # Determine output stream based on log level
     local output_stream="/dev/stdout"
-    if [[ "$level" == "error" ]]; then
+    if [[ "$level" == "error" || "$level" == "fatal" ]]; then
         output_stream="/dev/stderr"
     fi
 
@@ -61,8 +63,8 @@ function log() {
     printf "%s %b%s%b %s %b\n" "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
         "${color}" "${level^^}" "\033[0m" "${msg}" "${data}" >"${output_stream}"
 
-    # Exit if the log level is error
-    if [[ "$level" == "error" ]]; then
+    # Exit if the log level is error or fatal
+    if [[ "$level" == "error" || "$level" == "fatal" ]]; then
         exit 1
     fi
 }


### PR DESCRIPTION
The log() helper only treated 'error' as fatal, so the three 'log fatal' calls in bootstrap-apps.sh logged at info priority and kept going — a failed CRD render/apply would continue into the Helm sync stage against a cluster missing CRDs. This adds a real 'fatal' level (stderr, exit 1) and normalizes the call sites to key=value args.