### PR TITLE
fix(gatus): make status.melotic.dev the canonical host

### DIFF
--- a/kubernetes/apps/default/authentik/app/blueprints/gatus.yaml
+++ b/kubernetes/apps/default/authentik/app/blueprints/gatus.yaml
@@ -15,7 +15,7 @@ entries:
       authorization_flow: *authorization_flow
       invalidation_flow: *invalidation_flow
       mode: forward_single
-      external_host: https://gatus.melotic.dev
+      external_host: https://status.melotic.dev
   - model: authentik_core.application
     identifiers:
       slug: gatus

--- a/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
@@ -94,7 +94,6 @@ spec:
         annotations:
           gatus.home-operations.com/enabled: "false"
         hostnames:
-          - "{{ .Release.Name }}.melotic.dev"
           - "status.melotic.dev"
         parentRefs:
           - name: envoy-internal


### PR DESCRIPTION
Swap the gatus HTTPRoute hostname and authentik proxy provider external_host from gatus.melotic.dev to status.melotic.dev. The forward-auth outpost only matches its provider's external_host, so the new status hostname 404'd at the auth check until the provider recognized it.