### PR TITLE
fix: right-size oversized workload memory limits cluster-wide

### DIFF
--- a/kubernetes/apps/default/aurral/app/helmrelease.yaml
+++ b/kubernetes/apps/default/aurral/app/helmrelease.yaml
@@ -51,7 +51,7 @@ spec:
                 cpu: 50m
                 memory: 256Mi
               limits:
-                memory: 2Gi
+                memory: 512Mi
     defaultPodOptions:
       automountServiceAccountToken: false
       securityContext:

--- a/kubernetes/apps/default/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/default/authentik/app/helmrelease.yaml
@@ -109,7 +109,7 @@ spec:
           cpu: 100m
           memory: 512Mi
         limits:
-          memory: 1Gi
+          memory: 768Mi
       envFrom:
         - secretRef:
             name: authentik-secret

--- a/kubernetes/apps/default/ghidra-server/app/helmrelease.yaml
+++ b/kubernetes/apps/default/ghidra-server/app/helmrelease.yaml
@@ -57,9 +57,9 @@ spec:
             resources:
               requests:
                 cpu: 50m
-                memory: 512Mi
+                memory: 384Mi
               limits:
-                memory: 2Gi
+                memory: 1Gi
     defaultPodOptions:
       automountServiceAccountToken: false
       securityContext:

--- a/kubernetes/apps/default/ghidra-server/app/helmrelease.yaml
+++ b/kubernetes/apps/default/ghidra-server/app/helmrelease.yaml
@@ -57,7 +57,7 @@ spec:
             resources:
               requests:
                 cpu: 50m
-                memory: 384Mi
+                memory: 512Mi
               limits:
                 memory: 1Gi
     defaultPodOptions:

--- a/kubernetes/apps/default/harbor/app/helmrelease.yaml
+++ b/kubernetes/apps/default/harbor/app/helmrelease.yaml
@@ -81,8 +81,8 @@ spec:
         repository: docker.io/goharbor/harbor-core
       resources:
         requests:
-          cpu: 25m
-          memory: 128Mi
+          cpu: 50m
+          memory: 256Mi
         limits:
           memory: 256Mi
       extraEnvVars:
@@ -98,8 +98,8 @@ spec:
           repository: docker.io/goharbor/registry-photon
         resources:
           requests:
-            cpu: 25m
-            memory: 128Mi
+            cpu: 50m
+            memory: 256Mi
           limits:
             memory: 256Mi
       controller:
@@ -107,8 +107,8 @@ spec:
           repository: docker.io/goharbor/harbor-registryctl
         resources:
           requests:
-            cpu: 25m
-            memory: 128Mi
+            cpu: 50m
+            memory: 256Mi
           limits:
             memory: 256Mi
     jobservice:
@@ -127,8 +127,8 @@ spec:
         repository: docker.io/goharbor/trivy-adapter-photon
       resources:
         requests:
-          cpu: 25m
-          memory: 192Mi
+          cpu: 50m
+          memory: 256Mi
         limits:
           cpu: null
           memory: 384Mi

--- a/kubernetes/apps/default/harbor/app/helmrelease.yaml
+++ b/kubernetes/apps/default/harbor/app/helmrelease.yaml
@@ -81,10 +81,10 @@ spec:
         repository: docker.io/goharbor/harbor-core
       resources:
         requests:
-          cpu: 50m
-          memory: 256Mi
+          cpu: 25m
+          memory: 128Mi
         limits:
-          memory: 512Mi
+          memory: 256Mi
       extraEnvVars:
         - name: CONFIG_OVERWRITE_JSON
           valueFrom:
@@ -98,19 +98,19 @@ spec:
           repository: docker.io/goharbor/registry-photon
         resources:
           requests:
-            cpu: 50m
-            memory: 256Mi
+            cpu: 25m
+            memory: 128Mi
           limits:
-            memory: 512Mi
+            memory: 256Mi
       controller:
         image:
           repository: docker.io/goharbor/harbor-registryctl
         resources:
           requests:
-            cpu: 50m
-            memory: 256Mi
+            cpu: 25m
+            memory: 128Mi
           limits:
-            memory: 512Mi
+            memory: 256Mi
     jobservice:
       priorityClassName: app-high
       image:
@@ -127,11 +127,11 @@ spec:
         repository: docker.io/goharbor/trivy-adapter-photon
       resources:
         requests:
-          cpu: 50m
-          memory: 256Mi
+          cpu: 25m
+          memory: 192Mi
         limits:
           cpu: null
-          memory: 512Mi
+          memory: 384Mi
     portal:
       priorityClassName: app-high
       image:

--- a/kubernetes/apps/default/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/default/jellyfin/app/helmrelease.yaml
@@ -50,7 +50,7 @@ spec:
                 memory: 512Mi
                 squat.ai/video: 1
               limits:
-                memory: 4Gi
+                memory: 2Gi
                 squat.ai/video: 1
     defaultPodOptions:
       automountServiceAccountToken: false

--- a/kubernetes/apps/default/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/default/plex/app/helmrelease.yaml
@@ -56,7 +56,7 @@ spec:
                 memory: 512Mi
                 squat.ai/video: 1
               limits:
-                memory: 2Gi
+                memory: 1Gi
                 squat.ai/video: 1
     defaultPodOptions:
       priorityClassName: app-high

--- a/kubernetes/apps/default/seerr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/seerr/app/helmrelease.yaml
@@ -90,7 +90,7 @@ spec:
                 cpu: 10m
                 memory: 256Mi
               limits:
-                memory: 2Gi
+                memory: 768Mi
     defaultPodOptions:
       automountServiceAccountToken: false
       securityContext:

--- a/kubernetes/apps/default/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/default/tautulli/app/helmrelease.yaml
@@ -46,7 +46,7 @@ spec:
             resources:
               requests:
                 cpu: 10m
-                memory: 192Mi
+                memory: 256Mi
               limits:
                 memory: 512Mi
     defaultPodOptions:

--- a/kubernetes/apps/default/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/default/tautulli/app/helmrelease.yaml
@@ -46,9 +46,9 @@ spec:
             resources:
               requests:
                 cpu: 10m
-                memory: 256Mi
+                memory: 192Mi
               limits:
-                memory: 1Gi
+                memory: 512Mi
     defaultPodOptions:
       automountServiceAccountToken: false
       securityContext:

--- a/kubernetes/apps/flux-system/flux-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/app/helmrelease.yaml
@@ -18,6 +18,12 @@ spec:
   values:
     serviceMonitor:
       create: true
+    resources:
+      requests:
+        cpu: 100m
+        memory: 64Mi
+      limits:
+        memory: 512Mi
     web:
       networkPolicy:
         create: false

--- a/kubernetes/apps/kube-system/multus/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/multus/app/helmrelease.yaml
@@ -20,4 +20,4 @@ spec:
         requests:
           cpu: 10m
         limits:
-          memory: 512Mi
+          memory: 256Mi

--- a/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
@@ -28,4 +28,4 @@ spec:
         cpu: 10m
         memory: 128Mi
       limits:
-        memory: 256Mi
+        memory: 128Mi

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -42,7 +42,7 @@ spec:
             cpu: 25m
             memory: 128Mi
           limits:
-            memory: 256Mi
+            memory: 128Mi
         storage:
           volumeClaimTemplate:
             spec:
@@ -90,7 +90,7 @@ spec:
           cpu: 50m
           memory: 128Mi
         limits:
-          memory: 256Mi
+          memory: 128Mi
       prometheusConfigReloader:
         resources:
           requests:

--- a/kubernetes/apps/monitoring/victoria-logs-collector/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/victoria-logs-collector/app/helmrelease.yaml
@@ -60,7 +60,7 @@ spec:
         cpu: 50m
         memory: 128Mi
       limits:
-        memory: 512Mi
+        memory: 256Mi
     podSecurityContext:
       enabled: true
       runAsNonRoot: false

--- a/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
                 cpu: 10m
                 memory: 128Mi
               limits:
-                memory: 256Mi
+                memory: 128Mi
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true

--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -24,7 +24,7 @@ spec:
               cpu: 100m
               memory: 512Mi
             limits:
-              memory: 2Gi
+              memory: 512Mi
       envoyService:
         externalTrafficPolicy: Local
   shutdown:
@@ -61,7 +61,7 @@ spec:
               cpu: 100m
               memory: 512Mi
             limits:
-              memory: 2Gi
+              memory: 512Mi
       envoyService:
         externalTrafficPolicy: Local
   shutdown:

--- a/kubernetes/apps/network/envoy-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/helmrelease.yaml
@@ -18,6 +18,13 @@ spec:
     deployment:
       replicas: 2
       priorityClassName: cluster-critical
+      envoyGateway:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            memory: 512Mi
     config:
       envoyGateway:
         provider:

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -16,6 +16,10 @@ spec:
       tag: v19.2.3-20250717@sha256:af0c5903e901e329adabe219dfc8d0c3efc1f05102a753902f33ee16c26b6cee
       allowUnsupported: false
     cephClusterSpec:
+      # Daemons already log to stdout (collected by victoria-logs); the file-based
+      # log collector + logrotate sidecars only duplicate that to disk.
+      logCollector:
+        enabled: false
       cephConfig:
         global:
           osd_pool_default_min_size: "2"
@@ -155,7 +159,7 @@ spec:
                 cpu: 100m
                 memory: 1Gi
               limits:
-                memory: 4Gi
+                memory: 2Gi
         storageClass:
           enabled: true
           name: ceph-filesystem


### PR DESCRIPTION
Cuts grossly oversized memory limits that pushed cluster limit-commitment to ~152% of allocatable; evidence is Prometheus 7d working-set max per workload, validated independently. Reduce-only, never below request, CPU limits left absent (Burstable preserved); biggest item is disabling the redundant rook-ceph file log-collector since daemons already log to stdout via victoria-logs. Commits are atomic per namespace so any one can be reverted alone.