### PR TITLE
fix(gitlab): pin webservice/sidekiq replicas to resolve runner CrashLoopBackOff

### DIFF
--- a/kubernetes/apps/gitlab/gitlab/app/helmrelease.yaml
+++ b/kubernetes/apps/gitlab/gitlab/app/helmrelease.yaml
@@ -40,6 +40,9 @@ spec:
           # the sensitive setup script against the same /srv/gitlab as puma.
           # Must redeclare preStop so the strategic merge does not drop the
           # chart's hardcoded graceful-shutdown hook.
+          # The chart omits spec.replicas (HPA-managed), so a broken HPA
+          # leaves the deployment at whatever replica count it had (0). Pin
+          # replicas: 1 directly so every Flux reconciliation resets it.
           - target:
               kind: Deployment
               name: gitlab-webservice-default
@@ -49,6 +52,7 @@ spec:
               metadata:
                 name: gitlab-webservice-default
               spec:
+                replicas: 1
                 template:
                   spec:
                     containers:
@@ -66,6 +70,16 @@ spec:
                                 - /bin/bash
                                 - -c
                                 - pkill -SIGINT -o ruby
+          - target:
+              kind: Deployment
+              name: gitlab-sidekiq-all-in-1-v2
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: gitlab-sidekiq-all-in-1-v2
+              spec:
+                replicas: 1
   values:
     global:
       edition: ee
@@ -211,8 +225,12 @@ spec:
           enabled: false
         service:
           type: ClusterIP
+        # Pin HPA to exactly 1 replica (homelab doesn't need auto-scaling).
+        # Previously the HPA left spec.replicas at 0 (broken metrics),
+        # which took down the GitLab API and caused downstream runner
+        # CrashLoopBackOff (503 on /api/v4/runners/verify).
         minReplicas: 1
-        maxReplicas: 2
+        maxReplicas: 1
         resources:
           requests:
             cpu: 500m


### PR DESCRIPTION
## Problem

`gitlab-runner-84bdd6bfdb-r4qfs` has been in CrashLoopBackOff (94+ restarts, ~4.5 days) because GitLab API returns **503 Service Unavailable** on `/api/v4/runners/verify`.

Root cause: `gitlab-webservice-default` and `gitlab-sidekiq-all-in-1-v2` deployments are stuck at `spec.replicas: 0`. The GitLab chart intentionally omits `spec.replicas` from Deployment templates (relying on the HPA to manage scaling), so when the HPA fails to act (broken/missing metrics), replicas remain at whatever stale value was last set.

## Fix

1. **PostRenderer patches** inject `spec.replicas: 1` into webservice and sidekiq Deployments so every Flux reconciliation guarantees at least 1 running pod.
2. **Pin HPA** `minReplicas=maxReplicas=1` for webservice (homelab doesn't benefit from autoscaling) to prevent the HPA from conflicting with the pinned replica count.

## Expected Result

On next Flux reconciliation:
- Webservice/sidekiq pods start → GitLab API responds 200
- Runner successfully verifies token → exits CrashLoopBackOff
- CI capacity restored

## Evidence

```
$ kubectl logs gitlab-runner-84bdd6bfdb-r4qfs -n gitlab-runner --tail=10
ERROR: Verifying runner... failed  status=503 Service Unavailable
PANIC: Failed to verify the runner.

$ kubectl get deploy -n gitlab
gitlab-webservice-default    0/0
gitlab-sidekiq-all-in-1-v2   0/0
```