### PR TITLE
fix: restore plex memory limit and trim gitaly cpu request

### DIFF
--- a/kubernetes/apps/default/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/default/plex/app/helmrelease.yaml
@@ -56,7 +56,7 @@ spec:
                 memory: 512Mi
                 squat.ai/video: 1
               limits:
-                memory: 1Gi
+                memory: 2Gi
                 squat.ai/video: 1
     defaultPodOptions:
       priorityClassName: app-high

--- a/kubernetes/apps/gitlab/gitlab/app/helmrelease.yaml
+++ b/kubernetes/apps/gitlab/gitlab/app/helmrelease.yaml
@@ -284,7 +284,7 @@ spec:
           accessMode: ReadWriteOnce
         resources:
           requests:
-            cpu: 250m
+            cpu: 100m
             memory: 512Mi
           limits:
             memory: 1Gi


### PR DESCRIPTION
Plex was OOMKilling (exit137, 7 restarts) after #1357 cut its limit 2Gi→1Gi; transcode buffers spike between Prometheus scrapes so working_set undercounts the true peak, so its 2Gi limit is restored. Also trimmed gitaly's 250m CPU request (KRR p95 over 10d is ~20m) to a still-generous 100m, the cluster's only notably-high CPU request — memory and all other workloads left untouched.