### PR TITLE
fix(jellyfin): reserve trinity iGPU for plex

### DIFF
--- a/kubernetes/apps/default/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/default/jellyfin/app/helmrelease.yaml
@@ -56,14 +56,14 @@ spec:
       automountServiceAccountToken: false
       affinity:
         nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values: [k8s-trinity]
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
-              preference:
-                matchExpressions:
-                  - key: kubernetes.io/hostname
-                    operator: In
-                    values: [k8s-trinity]
-            - weight: 50
               preference:
                 matchExpressions:
                   - key: kubernetes.io/hostname


### PR DESCRIPTION
Plex and Jellyfin both preferred k8s-trinity and each request squat.ai/video:1, but trinity has one Intel QuickSync iGPU, so they contended and the descheduler plex-preferred-affinity profile bounced Plex in an eviction loop. Jellyfin now requires NotIn trinity and prefers the niobe/ghost AMD nodes, so the descheduler frees the iGPU and Plex settles on trinity. All three nodes expose squat.ai/video=1, so Jellyfin still transcodes on AMD.