### PR TITLE
fix(monitoring): extend victoria logs collector timeout

### DIFF
--- a/kubernetes/apps/monitoring/victoria-logs-collector/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/victoria-logs-collector/app/helmrelease.yaml
@@ -9,6 +9,7 @@ spec:
     kind: OCIRepository
     name: victoria-logs-collector
   interval: 1h
+  timeout: 10m
   values:
     fullnameOverride: victoria-logs-collector
     image:


### PR DESCRIPTION
Extends the victoria-logs-collector HelmRelease timeout to 10 minutes so rollbacks/upgrades have enough time for the DaemonSet to settle.