### PR TITLE
fix(linkwarden): enable meilisearch dumpless upgrade

### DIFF
--- a/kubernetes/apps/default/linkwarden/app/helmrelease.yaml
+++ b/kubernetes/apps/default/linkwarden/app/helmrelease.yaml
@@ -67,6 +67,9 @@ spec:
             env:
               MEILI_NO_ANALYTICS: "true"
               TMPDIR: /tmp
+              # In-place DB migration on engine upgrade (e.g. Renovate bumps).
+              # Supported for DB >=v1.12 -> engine >=v1.13.
+              MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE: "true"
               MEILI_MASTER_KEY:
                 secretKeyRef:
                   name: linkwarden-secret


### PR DESCRIPTION
The meilisearch sidecar was CrashLooping (exit 1) because its on-disk DB is v1.12.8 while the Renovate-bumped engine is v1.46.1, which refuses to open an older database. Setting MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE=true migrates the DB in place on startup (supported for DB >=v1.12 to engine >=v1.13) and auto-handles future version bumps. The linkwarden app container itself was already healthy on :3000.