### PR TITLE
fix(authentik): add grant_types to linkwarden oauth2 provider

### DIFF
--- a/kubernetes/apps/default/authentik/app/blueprints/linkwarden.yaml
+++ b/kubernetes/apps/default/authentik/app/blueprints/linkwarden.yaml
@@ -25,6 +25,9 @@ entries:
       redirect_uris:
         - url: "https://linkwarden.melotic.dev/api/v1/auth/callback/authentik"
           matching_mode: strict
+      grant_types:
+        - authorization_code
+        - refresh_token
       property_mappings: *property_mappings
       signing_key: *signing_key
 


### PR DESCRIPTION
Linkwarden sign-in failed with next-auth invalid_request. Authentik rejected the authorize request with 'Invalid grant_type for provider' because the newly-created provider had an empty grant_types list — Authentik's grant_types field (migration 0032) defaults to empty for new providers, unlike older providers that were backfilled. Setting authorization_code + refresh_token (matching the existing policy-reporter blueprint) unblocks login.