### PR TITLE
fix(authentik): group dashboard apps, standardize icons, encode grant_types

### DIFF
--- a/kubernetes/apps/default/authentik/app/blueprints/alertmanager.yaml
+++ b/kubernetes/apps/default/authentik/app/blueprints/alertmanager.yaml
@@ -24,6 +24,7 @@ entries:
       slug: alertmanager
       provider: !Find [authentik_providers_proxy.proxyprovider, [name, alertmanager]]
       policy_engine_mode: any
+      group: Monitoring
       meta_icon: https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/alertmanager.svg
       meta_description: Alert routing and management
       open_in_new_tab: true

--- a/kubernetes/apps/default/authentik/app/blueprints/gatus.yaml
+++ b/kubernetes/apps/default/authentik/app/blueprints/gatus.yaml
@@ -24,6 +24,7 @@ entries:
       slug: gatus
       provider: !Find [authentik_providers_proxy.proxyprovider, [name, gatus]]
       policy_engine_mode: any
-      meta_icon: kubernetes/apps/default/authentik/app/blueprints/gatus.yaml
+      group: Monitoring
+      meta_icon: https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/gatus.svg
       meta_description: Uptime monitoring
       open_in_new_tab: true

--- a/kubernetes/apps/default/authentik/app/blueprints/ghidra-server.yaml
+++ b/kubernetes/apps/default/authentik/app/blueprints/ghidra-server.yaml
@@ -103,6 +103,7 @@ entries:
       slug: ghidra-ldap
       provider: !KeyOf ghidra-ldap-provider
       policy_engine_mode: any
+      group: Development
       meta_description: Ghidra Server LDAP access
       meta_publisher: Ghidra
 

--- a/kubernetes/apps/default/authentik/app/blueprints/gitlab.yaml
+++ b/kubernetes/apps/default/authentik/app/blueprints/gitlab.yaml
@@ -52,6 +52,9 @@ entries:
       redirect_uris:
         - url: "https://gitlab.melotic.dev/users/auth/openid_connect/callback"
           matching_mode: strict
+      grant_types:
+        - authorization_code
+        - refresh_token
       property_mappings: *groups_scope_mapping
       signing_key: *signing_key
 
@@ -64,7 +67,8 @@ entries:
       slug: gitlab
       provider: !Find [authentik_providers_oauth2.oauth2provider, [name, gitlab]]
       policy_engine_mode: any
-      meta_icon: https://about.gitlab.com/images/press/logo/svg/gitlab-icon-rgb.svg
+      group: Development
+      meta_icon: https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/gitlab.svg
       meta_description: Self-hosted GitLab (internal)
       meta_publisher: GitLab
       open_in_new_tab: true

--- a/kubernetes/apps/default/authentik/app/blueprints/grafana.yaml
+++ b/kubernetes/apps/default/authentik/app/blueprints/grafana.yaml
@@ -26,6 +26,9 @@ entries:
       redirect_uris:
         - url: "https://grafana.melotic.dev/login/generic_oauth"
           matching_mode: strict
+      grant_types:
+        - authorization_code
+        - refresh_token
       property_mappings: *property_mappings
       signing_key: *signing_key
 
@@ -38,7 +41,8 @@ entries:
       slug: grafana
       provider: !Find [authentik_providers_oauth2.oauth2provider, [name, grafana]]
       policy_engine_mode: any
-      meta_icon: https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/grafana.svg
+      group: Monitoring
+      meta_icon: https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/grafana.svg
       meta_description: Metrics and dashboards
       meta_publisher: Grafana Labs
       open_in_new_tab: true

--- a/kubernetes/apps/default/authentik/app/blueprints/harbor.yaml
+++ b/kubernetes/apps/default/authentik/app/blueprints/harbor.yaml
@@ -26,6 +26,9 @@ entries:
       redirect_uris:
         - url: "https://harbor.melotic.dev/c/oidc/callback"
           matching_mode: strict
+      grant_types:
+        - authorization_code
+        - refresh_token
       property_mappings: *property_mappings
       signing_key: *signing_key
 
@@ -38,7 +41,8 @@ entries:
       slug: harbor
       provider: !Find [authentik_providers_oauth2.oauth2provider, [name, harbor]]
       policy_engine_mode: any
-      meta_icon: https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/harbor.svg
+      group: Development
+      meta_icon: https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/harbor.svg
       meta_description: Container registry
       meta_publisher: Harbor
       open_in_new_tab: true

--- a/kubernetes/apps/default/authentik/app/blueprints/linkwarden.yaml
+++ b/kubernetes/apps/default/authentik/app/blueprints/linkwarden.yaml
@@ -39,7 +39,8 @@ entries:
       slug: linkwarden
       provider: !Find [authentik_providers_oauth2.oauth2provider, [name, linkwarden]]
       policy_engine_mode: any
-      meta_icon: https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/linkwarden.svg
+      group: Productivity
+      meta_icon: https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/linkwarden.svg
       meta_description: Bookmark manager
       meta_publisher: Linkwarden
       open_in_new_tab: true

--- a/kubernetes/apps/default/authentik/app/blueprints/paperless-ngx.yaml
+++ b/kubernetes/apps/default/authentik/app/blueprints/paperless-ngx.yaml
@@ -25,6 +25,9 @@ entries:
       redirect_uris:
         - url: "https://paperless.melotic.dev/accounts/oidc/authentik/login/callback/"
           matching_mode: strict
+      grant_types:
+        - authorization_code
+        - refresh_token
       property_mappings: *property_mappings
       signing_key: *signing_key
 
@@ -36,7 +39,8 @@ entries:
       slug: paperless
       provider: !Find [authentik_providers_oauth2.oauth2provider, [name, paperless-ngx]]
       policy_engine_mode: any
-      meta_icon: https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/paperless-ngx.svg
+      group: Productivity
+      meta_icon: https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/paperless-ngx.svg
       meta_description: Document management system
       meta_publisher: Paperless-ngx
       open_in_new_tab: true

--- a/kubernetes/apps/default/authentik/app/blueprints/policy-reporter.yaml
+++ b/kubernetes/apps/default/authentik/app/blueprints/policy-reporter.yaml
@@ -41,6 +41,7 @@ entries:
       slug: policy-reporter
       provider: !Find [authentik_providers_oauth2.oauth2provider, [name, policy-reporter]]
       policy_engine_mode: any
+      group: Monitoring
       meta_icon: https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/kyverno.svg
       meta_description: Kyverno policy reporting dashboard
       meta_publisher: Kyverno

--- a/kubernetes/apps/default/authentik/app/blueprints/slskd.yaml
+++ b/kubernetes/apps/default/authentik/app/blueprints/slskd.yaml
@@ -24,6 +24,7 @@ entries:
       slug: slskd
       provider: !Find [authentik_providers_proxy.proxyprovider, [name, slskd]]
       policy_engine_mode: any
-      meta_icon: https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/slskd.svg
+      group: Media
+      meta_icon: https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/slskd.svg
       meta_description: Soulseek client
       open_in_new_tab: true

--- a/kubernetes/apps/default/authentik/app/blueprints/victoria-logs.yaml
+++ b/kubernetes/apps/default/authentik/app/blueprints/victoria-logs.yaml
@@ -24,6 +24,7 @@ entries:
       slug: victoria-logs
       provider: !Find [authentik_providers_proxy.proxyprovider, [name, victoria-logs]]
       policy_engine_mode: any
-      meta_icon: https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/victoriametrics.svg
+      group: Monitoring
+      meta_icon: https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/victoriametrics.svg
       meta_description: Log management and storage
       open_in_new_tab: true


### PR DESCRIPTION
Groups the Authentik launcher apps (Development, Monitoring, Productivity, Media) since only Harbor was grouped before, and standardizes app icons to selfh.st where available (also fixes the gatus icon, which was a stray file path). Also encodes grant_types [authorization_code, refresh_token] on the gitlab/grafana/harbor/paperless OIDC providers so a from-scratch Authentik rebuild can't reset them to an empty list, which is the same gap that broke linkwarden sign-in in #1388.