### PR TITLE
fix(monitoring): restore victoria logs collector memory

### DIFF
--- a/kubernetes/apps/monitoring/victoria-logs-collector/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/victoria-logs-collector/app/helmrelease.yaml
@@ -61,7 +61,7 @@ spec:
         cpu: 50m
         memory: 128Mi
       limits:
-        memory: 256Mi
+        memory: 512Mi
     podSecurityContext:
       enabled: true
       runAsNonRoot: false

--- a/kubernetes/apps/monitoring/victoria-logs-collector/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/victoria-logs-collector/app/helmrelease.yaml
@@ -9,7 +9,6 @@ spec:
     kind: OCIRepository
     name: victoria-logs-collector
   interval: 1h
-  timeout: 10m
   values:
     fullnameOverride: victoria-logs-collector
     image:


### PR DESCRIPTION
Restore the collector memory limit to the previous working value.