### PR TITLE
feat(karakeep): lock auth to OIDC-only

### DIFF
--- a/kubernetes/apps/default/karakeep/app/helmrelease.yaml
+++ b/kubernetes/apps/default/karakeep/app/helmrelease.yaml
@@ -32,15 +32,17 @@ spec:
               repository: ghcr.io/karakeep-app/karakeep
               tag: 0.32.0@sha256:64d6a9bbf2d37b5c808cf06b5d87f1f1c7846fdd3844724145a9741aeb06fd31
             env:
+              BROWSER_WEB_URL: http://localhost:9222
               DATA_DIR: /data
+              DB_WAL_MODE: "true"
+              DISABLE_NEW_RELEASE_CHECK: "true"
+              DISABLE_PASSWORD_AUTH: "true"
               HOME: /tmp
               MEILI_ADDR: http://localhost:7700
-              BROWSER_WEB_URL: http://localhost:9222
               NEXTAUTH_URL: https://karakeep.melotic.dev
-              DISABLE_NEW_RELEASE_CHECK: "true"
-              DB_WAL_MODE: "true"
-              OAUTH_WELLKNOWN_URL: https://sso.melotic.dev/application/o/karakeep/.well-known/openid-configuration
+              OAUTH_AUTO_REDIRECT: "true"
               OAUTH_PROVIDER_NAME: authentik
+              OAUTH_WELLKNOWN_URL: https://sso.melotic.dev/application/o/karakeep/.well-known/openid-configuration
             envFrom:
               - secretRef:
                   name: karakeep-secret
@@ -98,13 +100,13 @@ spec:
               repository: docker.io/getmeili/meilisearch
               tag: v1.41.0@sha256:860fa4baed04ae1c235de870edab0c8006227546dea1bbb6411fbfc5e27cf1db
             env:
-              MEILI_NO_ANALYTICS: "true"
-              MEILI_ENV: production
               HOME: /tmp
+              MEILI_ENV: production
               MEILI_MASTER_KEY:
                 secretKeyRef:
                   name: karakeep-secret
                   key: MEILI_MASTER_KEY
+              MEILI_NO_ANALYTICS: "true"
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true


### PR DESCRIPTION
Now that the authentik admin user is bootstrapped, set DISABLE_PASSWORD_AUTH and OAUTH_AUTO_REDIRECT so /login redirects straight to authentik and local password login is disabled. Also alphabetized the web and meilisearch env blocks.