### PR TITLE
fix(karakeep): raise crawler parser memory to handle large pages

### DIFF
--- a/kubernetes/apps/default/karakeep/app/helmrelease.yaml
+++ b/kubernetes/apps/default/karakeep/app/helmrelease.yaml
@@ -33,6 +33,7 @@ spec:
               tag: 0.32.0@sha256:64d6a9bbf2d37b5c808cf06b5d87f1f1c7846fdd3844724145a9741aeb06fd31
             env:
               BROWSER_WEB_URL: http://localhost:9222
+              CRAWLER_PARSER_MEM_LIMIT_MB: "1024"
               DATA_DIR: /data
               DB_WAL_MODE: "true"
               DISABLE_NEW_RELEASE_CHECK: "true"
@@ -71,7 +72,7 @@ spec:
                 cpu: 50m
                 memory: 512Mi
               limits:
-                memory: 1Gi
+                memory: 2Gi
           chrome:
             image:
               repository: docker.io/zenika/alpine-chrome


### PR DESCRIPTION
The crawl parse subprocess was OOM-killed at its default 512MB JS heap on content-heavy pages. Bump CRAWLER_PARSER_MEM_LIMIT_MB to 1024 and the web container memory limit to 2Gi so the transient parse subprocess fits alongside the main worker process.