### PR TITLE
fix(karakeep): enable meilisearch dumpless upgrade

### DIFF
--- a/kubernetes/apps/default/karakeep/app/helmrelease.yaml
+++ b/kubernetes/apps/default/karakeep/app/helmrelease.yaml
@@ -100,6 +100,9 @@ spec:
             image:
               repository: docker.io/getmeili/meilisearch
               tag: v1.46.1@sha256:cbe0e500a5fc04397dfe0245cf143fee40658b26470daaf549f0a6927c5c08dc
+            args:
+              # Needed to migrate the existing v1.41 data to v1.46; remove after a successful migration only if operationally safe.
+              - --experimental-dumpless-upgrade
             env:
               HOME: /tmp
               MEILI_ENV: production


### PR DESCRIPTION
Enables Meilisearch dumpless upgrade so Karakeep can migrate its existing index data.