### PR TITLE
fix(karakeep): enable meilisearch dumpless upgrade via env var

### DIFF
--- a/kubernetes/apps/default/karakeep/app/helmrelease.yaml
+++ b/kubernetes/apps/default/karakeep/app/helmrelease.yaml
@@ -100,10 +100,9 @@ spec:
             image:
               repository: docker.io/getmeili/meilisearch
               tag: v1.46.1@sha256:cbe0e500a5fc04397dfe0245cf143fee40658b26470daaf549f0a6927c5c08dc
-            args:
-              # Needed to migrate the existing v1.41 data to v1.46; remove after a successful migration only if operationally safe.
-              - --experimental-dumpless-upgrade
             env:
+              # Needed for the v1.41 -> v1.46 dumpless migration; remove after success only if operationally safe.
+              MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE: "true"
               HOME: /tmp
               MEILI_ENV: production
               MEILI_MASTER_KEY:


### PR DESCRIPTION
Enable MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE for v1.41→v1.46.1 in-place migration.