### PR TITLE
fix(authentik): extend Helm release timeout

### DIFF
--- a/kubernetes/apps/default/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/default/authentik/app/helmrelease.yaml
@@ -9,6 +9,7 @@ spec:
     kind: OCIRepository
     name: authentik
   interval: 1h
+  timeout: 15m
   values:
     authentik:
       email:


### PR DESCRIPTION
Extends the authentik HelmRelease timeout to allow upgrades to complete.