### PR TITLE
fix(container): pin busybox image in paperless-ngx initContainer

### DIFF
--- a/kubernetes/apps/default/paperless-ngx/app/helmrelease.yaml
+++ b/kubernetes/apps/default/paperless-ngx/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
           fix-run:
             image:
               repository: docker.io/library/busybox
-              tag: latest@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
+              tag: 1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
             command: ["sh", "-c", "chown 1000:1000 /run"]
             securityContext:
               runAsUser: 0


### PR DESCRIPTION
Pin busybox from `:latest` to `1.37.0` with digest for reproducibility and Renovate tracking.