### PR TITLE
fix(system-upgrade): bump tuppr chart 0.2.4 → 0.2.5

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/app/ocirepository.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.2.4
+    tag: 0.2.5
   url: oci://ghcr.io/home-operations/charts/tuppr


### PR DESCRIPTION
Patch bump for tuppr system-upgrade controller.