### PR TITLE
fix(lidarr): reduce memory request to 256Mi

### DIFF
--- a/kubernetes/apps/default/lidarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/lidarr/app/helmrelease.yaml
@@ -62,7 +62,7 @@ spec:
             resources:
               requests:
                 cpu: 20m
-                memory: 320Mi
+                memory: 256Mi
               limits:
                 memory: 512Mi
     defaultPodOptions:


### PR DESCRIPTION
Align Lidarr memory request with other arr apps (Radarr, Sonarr, Prowlarr) which all use 256Mi.