### PR TITLE
chore(default): right-size resources

### DIFF
--- a/kubernetes/apps/default/aurral/app/helmrelease.yaml
+++ b/kubernetes/apps/default/aurral/app/helmrelease.yaml
@@ -48,7 +48,7 @@ spec:
               capabilities: {drop: ["ALL"]}
             resources:
               requests:
-                cpu: 50m
+                cpu: 10m
                 memory: 256Mi
               limits:
                 memory: 512Mi

--- a/kubernetes/apps/default/ghidra-server/app/helmrelease.yaml
+++ b/kubernetes/apps/default/ghidra-server/app/helmrelease.yaml
@@ -56,10 +56,10 @@ spec:
               capabilities: {drop: ["ALL"]}
             resources:
               requests:
-                cpu: 50m
-                memory: 512Mi
+                cpu: 10m
+                memory: 384Mi
               limits:
-                memory: 1Gi
+                memory: 512Mi
     defaultPodOptions:
       automountServiceAccountToken: false
       securityContext:

--- a/kubernetes/apps/default/harbor/app/helmrelease.yaml
+++ b/kubernetes/apps/default/harbor/app/helmrelease.yaml
@@ -81,7 +81,7 @@ spec:
         repository: docker.io/goharbor/harbor-core
       resources:
         requests:
-          cpu: 50m
+          cpu: 10m
           memory: 256Mi
         limits:
           memory: 256Mi
@@ -98,7 +98,7 @@ spec:
           repository: docker.io/goharbor/registry-photon
         resources:
           requests:
-            cpu: 50m
+            cpu: 10m
             memory: 256Mi
           limits:
             memory: 256Mi
@@ -107,7 +107,7 @@ spec:
           repository: docker.io/goharbor/harbor-registryctl
         resources:
           requests:
-            cpu: 50m
+            cpu: 10m
             memory: 256Mi
           limits:
             memory: 256Mi
@@ -117,7 +117,7 @@ spec:
         repository: docker.io/goharbor/harbor-jobservice
       resources:
         requests:
-          cpu: 30m
+          cpu: 10m
           memory: 128Mi
         limits:
           memory: 256Mi
@@ -127,7 +127,7 @@ spec:
         repository: docker.io/goharbor/trivy-adapter-photon
       resources:
         requests:
-          cpu: 50m
+          cpu: 10m
           memory: 256Mi
         limits:
           cpu: null

--- a/kubernetes/apps/default/paperless-ngx/app/helmrelease.yaml
+++ b/kubernetes/apps/default/paperless-ngx/app/helmrelease.yaml
@@ -97,7 +97,7 @@ spec:
               capabilities: {drop: ["ALL"]}
             resources:
               requests:
-                cpu: 100m
+                cpu: 10m
                 memory: 512Mi
               limits:
                 memory: 2Gi

--- a/kubernetes/apps/default/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/default/plex/app/helmrelease.yaml
@@ -56,7 +56,7 @@ spec:
                 memory: 512Mi
                 squat.ai/video: 1
               limits:
-                memory: 2Gi
+                memory: 4Gi
                 squat.ai/video: 1
     defaultPodOptions:
       priorityClassName: app-high

--- a/kubernetes/apps/default/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/prowlarr/app/helmrelease.yaml
@@ -61,7 +61,7 @@ spec:
               capabilities: {drop: ["ALL"]}
             resources:
               requests:
-                cpu: 20m
+                cpu: 10m
                 memory: 256Mi
               limits:
                 memory: 512Mi

--- a/kubernetes/apps/default/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/default/tautulli/app/helmrelease.yaml
@@ -46,9 +46,9 @@ spec:
             resources:
               requests:
                 cpu: 10m
-                memory: 256Mi
+                memory: 224Mi
               limits:
-                memory: 512Mi
+                memory: 384Mi
     defaultPodOptions:
       automountServiceAccountToken: false
       securityContext:


### PR DESCRIPTION
Right-sizes default-namespace resources from a fresh 12-day usage baseline. Trims stale CPU requests on harbor, paperless-ngx, aurral, prowlarr, ghidra-server, and tautulli (most reserved 30–100m while using ≤10m), and raises Plex's memory limit 2Gi→4Gi after kernel OOM dumps showed the transcoder hitting ~1.9 GiB and overflowing the 2Gi cgroup — request stays 512Mi, so it's a ceiling-only change. Only `resources:` blocks change; rollback unit is this PR.
