### PR TITLE
fix(authentik): reduce GeoIP update cadence

### DIFF
--- a/kubernetes/apps/default/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/default/authentik/app/helmrelease.yaml
@@ -29,7 +29,9 @@ spec:
         - authentik-blueprints
     geoip:
       enabled: true
-      updateInterval: 8
+      # MaxMind GeoLite2 databases update weekly; 24h avoids hitting daily download limits
+      # (both server and worker pods run independent geoipupdate sidecars)
+      updateInterval: 24
       existingSecret:
         accountId: MAXMIND_ACCOUNT_ID
         licenseKey: MAXMIND_LICENSE_KEY


### PR DESCRIPTION
## Context

MaxMind notified (2026-06-06 14:16 UTC) that account 1270959 hit the daily GeoIP database download limit. The authentik HelmRelease runs geoipupdate sidecars on both server and worker pods at an 8-hour interval; combined with pod restarts, this exceeds the daily cap.

## Change

Increase `geoip.updateInterval` from 8h to 24h. GeoLite2 databases only update weekly, so a 24h cadence is more than sufficient and stays well within MaxMind's limits.

## Validation

```
$ flux-local test --enable-helm --all-namespaces --path kubernetes/flux/cluster --sources flux-system
collected 155 items — 155 passed in 58.68s
```
