### PR TITLE
chore(tuppr): update chart to 0.2.6

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/app/ocirepository.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.2.5
+    tag: 0.2.6
   url: oci://ghcr.io/home-operations/charts/tuppr


### PR DESCRIPTION
Bump tuppr chart 0.2.5 → 0.2.6 (bug fix: default placement to hard, degrade to preferred on single-node).