### PR TITLE
feat(crowdsec): in-cluster CrowdSec LAPI on CNPG, locked to Fedora endpoints

### DIFF
--- a/kubernetes/apps/database/postgres/app/databases/crowdsec.yaml
+++ b/kubernetes/apps/database/postgres/app/databases/crowdsec.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/postgresql.cnpg.io/database_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: crowdsec
+spec:
+  name: crowdsec
+  owner: crowdsec
+  cluster:
+    name: postgres-cluster
+  schemas:
+    - name: public
+      owner: crowdsec

--- a/kubernetes/apps/database/postgres/app/helmrelease.yaml
+++ b/kubernetes/apps/database/postgres/app/helmrelease.yaml
@@ -120,6 +120,11 @@ spec:
           login: true
           passwordSecret:
             name: postgres-user-atuin
+        - name: crowdsec
+          ensure: present
+          login: true
+          passwordSecret:
+            name: postgres-user-crowdsec
         - name: authentik
           ensure: present
           login: true

--- a/kubernetes/apps/database/postgres/app/kustomization.yaml
+++ b/kubernetes/apps/database/postgres/app/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./databases/app.yaml
   - ./databases/atuin.yaml
   - ./databases/authentik.yaml
+  - ./databases/crowdsec.yaml
   - ./databases/harbor.yaml
   - ./databases/gitlab.yaml
   - ./databases/lidarr.yaml
@@ -24,6 +25,7 @@ resources:
   - ./prometheusrule-backup.yaml
   - ./roles/atuin.yaml
   - ./roles/authentik.yaml
+  - ./roles/crowdsec.yaml
   - ./roles/gitlab.yaml
   - ./roles/harbor.yaml
   - ./roles/lidarr.yaml

--- a/kubernetes/apps/database/postgres/app/roles/crowdsec.yaml
+++ b/kubernetes/apps/database/postgres/app/roles/crowdsec.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: postgres-user-crowdsec
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: postgres-user-crowdsec
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      mergePolicy: Replace
+      type: kubernetes.io/basic-auth
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+      data:
+        user: crowdsec
+        username: crowdsec
+        password: "{{ .password }}"
+  dataFrom:
+    - extract:
+        key: crowdsec-postgres

--- a/kubernetes/apps/security/crowdsec/app/ciliumnetworkpolicy.yaml
+++ b/kubernetes/apps/security/crowdsec/app/ciliumnetworkpolicy.yaml
@@ -9,8 +9,6 @@ spec:
     matchLabels:
       app.kubernetes.io/name: crowdsec
   ingress:
-    # LAPI :8080 reachable ONLY from the off-cluster Fedora endpoint /32s (same set as
-    # config.yaml.local allowed_ranges). fromCIDR is required for off-cluster sources.
     - fromCIDR:
         - 10.20.0.147/32
         - 10.20.0.119/32
@@ -18,7 +16,6 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
-    # Prometheus scrapes :6060 (ServiceMonitor, Plan 26-03).
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
@@ -28,7 +25,6 @@ spec:
             - port: "6060"
               protocol: TCP
   egress:
-    # DNS
     - toEndpoints:
         - matchLabels:
             "k8s:io.kubernetes.pod.namespace": kube-system
@@ -40,7 +36,6 @@ spec:
           rules:
             dns:
               - matchPattern: "*"
-    # CNPG Postgres (database namespace) — the only other egress; CAPI is off (no internet).
     - toEndpoints:
         - matchLabels:
             "k8s:io.kubernetes.pod.namespace": database

--- a/kubernetes/apps/security/crowdsec/app/ciliumnetworkpolicy.yaml
+++ b/kubernetes/apps/security/crowdsec/app/ciliumnetworkpolicy.yaml
@@ -1,0 +1,50 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/CiliumProject/cilium/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: crowdsec
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: crowdsec
+  ingress:
+    # LAPI :8080 reachable ONLY from the off-cluster Fedora endpoint /32s (same set as
+    # config.yaml.local allowed_ranges). fromCIDR is required for off-cluster sources.
+    - fromCIDR:
+        - 10.20.0.147/32
+        - 10.20.0.119/32
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    # Prometheus scrapes :6060 (ServiceMonitor, Plan 26-03).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+            app.kubernetes.io/name: prometheus
+      toPorts:
+        - ports:
+            - port: "6060"
+              protocol: TCP
+  egress:
+    # DNS
+    - toEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": kube-system
+            "k8s:k8s-app": kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: ANY
+          rules:
+            dns:
+              - matchPattern: "*"
+    # CNPG Postgres (database namespace) — the only other egress; CAPI is off (no internet).
+    - toEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": database
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP

--- a/kubernetes/apps/security/crowdsec/app/config.yaml.local
+++ b/kubernetes/apps/security/crowdsec/app/config.yaml.local
@@ -1,0 +1,16 @@
+db_config:
+  type: pgx
+  host: postgres-cluster-rw.database.svc.cluster.local
+  port: 5432
+  user: crowdsec
+  password: $${POSTGRES_PASSWORD}
+  db_name: crowdsec
+  sslmode: require
+api:
+  server:
+    auto_registration:
+      enabled: true
+      token: $${CROWDSEC_REGISTRATION_TOKEN}
+      allowed_ranges:
+        - 10.20.0.147/32
+        - 10.20.0.119/32

--- a/kubernetes/apps/security/crowdsec/app/externalsecret.yaml
+++ b/kubernetes/apps/security/crowdsec/app/externalsecret.yaml
@@ -14,7 +14,7 @@ spec:
       engineVersion: v2
       data:
         CROWDSEC_REGISTRATION_TOKEN: "{{ .registration_token }}"
-        BOUNCER_KEY_fedora-nft: "{{ .bouncer_key_fedora_nft }}"
+        BOUNCER_KEY_fedora_nft: "{{ .bouncer_key_fedora_nft }}"
   dataFrom:
     - extract:
         key: crowdsec

--- a/kubernetes/apps/security/crowdsec/app/externalsecret.yaml
+++ b/kubernetes/apps/security/crowdsec/app/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: crowdsec
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: crowdsec
+    template:
+      engineVersion: v2
+      data:
+        CROWDSEC_REGISTRATION_TOKEN: "{{ .registration_token }}"
+        BOUNCER_KEY_fedora-nft: "{{ .bouncer_key_fedora_nft }}"
+  dataFrom:
+    - extract:
+        key: crowdsec

--- a/kubernetes/apps/security/crowdsec/app/grafanadashboard.yaml
+++ b/kubernetes/apps/security/crowdsec/app/grafanadashboard.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: crowdsec-overview
+spec:
+  allowCrossNamespaceImport: true
+  folder: General
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_PROMETHEUS
+  url: https://grafana.com/api/dashboards/19010/revisions/1/download
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: crowdsec-insights
+spec:
+  allowCrossNamespaceImport: true
+  folder: General
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_PROMETHEUS
+  url: https://grafana.com/api/dashboards/19011/revisions/1/download

--- a/kubernetes/apps/security/crowdsec/app/helmrelease.yaml
+++ b/kubernetes/apps/security/crowdsec/app/helmrelease.yaml
@@ -1,0 +1,106 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: crowdsec
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: crowdsec
+  interval: 1h
+  values:
+    controllers:
+      crowdsec:
+        strategy: Recreate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/crowdsecurity/crowdsec
+              tag: v1.7.8@sha256:2f527c9bb8b367120eb08b82890aa912ce96bfa1ada93dda0721700e4b4e0dde
+            env:
+              DISABLE_AGENT: "true"
+              DISABLE_ONLINE_API: "true"
+              CROWDSEC_BYPASS_DB_VOLUME_CHECK: "true"
+              CUSTOM_HOSTNAME: crowdsec-lapi
+              POSTGRES_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: crowdsec-postgres
+                    key: password
+            envFrom:
+              - secretRef:
+                  name: crowdsec
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8080
+                  initialDelaySeconds: 10
+                  periodSeconds: 15
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+              limits:
+                memory: 256Mi
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        type: LoadBalancer
+        annotations:
+          lbipam.cilium.io/ips: "10.60.80.20"
+        externalTrafficPolicy: Local
+        loadBalancerSourceRanges:
+          - 10.20.0.147/32
+          - 10.20.0.119/32
+        ports:
+          lapi:
+            port: 8080
+          metrics:
+            port: 6060
+    persistence:
+      etc-crowdsec:
+        type: emptyDir
+        globalMounts:
+          - path: /etc/crowdsec
+      data:
+        type: emptyDir
+        globalMounts:
+          - path: /var/lib/crowdsec/data
+      varlog:
+        type: emptyDir
+        globalMounts:
+          - path: /var/log
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+      config-local:
+        type: configMap
+        name: crowdsec-config-local
+        advancedMounts:
+          crowdsec:
+            app:
+              - path: /etc/crowdsec/config.yaml.local
+                subPath: config.yaml.local
+                readOnly: true

--- a/kubernetes/apps/security/crowdsec/app/kustomization.yaml
+++ b/kubernetes/apps/security/crowdsec/app/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./ciliumnetworkpolicy.yaml
+configMapGenerator:
+  - name: crowdsec-config-local
+    files:
+      - config.yaml.local
+    options:
+      disableNameSuffixHash: true

--- a/kubernetes/apps/security/crowdsec/app/kustomization.yaml
+++ b/kubernetes/apps/security/crowdsec/app/kustomization.yaml
@@ -7,6 +7,8 @@ resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
   - ./ciliumnetworkpolicy.yaml
+  - ./monitoring.yaml
+  - ./grafanadashboard.yaml
 configMapGenerator:
   - name: crowdsec-config-local
     files:

--- a/kubernetes/apps/security/crowdsec/app/monitoring.yaml
+++ b/kubernetes/apps/security/crowdsec/app/monitoring.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: crowdsec
+spec:
+  namespaceSelector:
+    matchNames:
+      - security
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: crowdsec
+  endpoints:
+    - port: metrics
+      path: /metrics
+      honorLabels: true

--- a/kubernetes/apps/security/crowdsec/app/ocirepository.yaml
+++ b/kubernetes/apps/security/crowdsec/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: crowdsec
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/security/crowdsec/ks.yaml
+++ b/kubernetes/apps/security/crowdsec/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app crowdsec
+  namespace: &namespace security
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/cnpg-database
+  dependsOn:
+    - name: postgres
+      namespace: database
+    - name: external-secrets
+      namespace: external-secrets
+  path: ./kubernetes/apps/security/crowdsec/app
+  postBuild:
+    substitute:
+      APP: crowdsec
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: false

--- a/kubernetes/apps/security/kustomization.yaml
+++ b/kubernetes/apps/security/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: security
+components:
+  - ../../components/common
+  - ../../components/psa/baseline
+resources:
+  - ./crowdsec/ks.yaml


### PR DESCRIPTION
Stands up the CrowdSec Local API in-cluster as the foundation for endpoint + network security monitoring.

## What
- **DB**: CNPG `crowdsec` role + database (owns `public` schema for DDL on PG17); `postgres-user-crowdsec` ExternalSecret from 1Password.
- **LAPI**: new `security` namespace; bjw-s app-template Deployment on the digest-pinned `docker.io/crowdsecurity/crowdsec:v1.7.8` image, LAPI-only (`DISABLE_AGENT`/`DISABLE_ONLINE_API`), backed by CNPG over `sslmode=require`. Hardened: non-root, read-only rootfs, drop ALL.
- **Exposure**: Cilium LoadBalancer `10.60.80.20` with `externalTrafficPolicy: Local`, locked to the Fedora endpoint `/32`s at both the `CiliumNetworkPolicy` (`fromCIDR`) and app (`allowed_ranges`) layers.
- **Secrets**: registration token + bouncer key via ESO/1Password; config overlay uses the `$${VAR}` Flux-escape.
- **Observability**: ServiceMonitor scraping `:6060` into Prometheus + the two official CrowdSec Grafana dashboards (19010, 19011).

## Notes
- Image is full-registry + digest-pinned to pass the Enforce Kyverno image policy.
- The pre-seeded bouncer registers as `fedora_nft` (env-var identifiers can't contain hyphens).
- Operator prerequisite (already done): 1Password items `crowdsec-postgres` + `crowdsec` in vault Zion.