### PR TITLE
chore(reloader): update reloader chart to 2.2.12

### DIFF
--- a/kubernetes/apps/kube-system/reloader/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/reloader/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 2.2.11
+    tag: 2.2.12
   url: oci://ghcr.io/stakater/charts/reloader


### PR DESCRIPTION
## Summary

Bump the Stakater Reloader Helm chart from **2.2.11** → **2.2.12** (patch release).

### Changes
- `kubernetes/apps/kube-system/reloader/app/ocirepository.yaml`: tag 2.2.11 → 2.2.12

### Validation
- `kustomize build kubernetes/apps/kube-system/reloader/app` — passes, renders correct tag
- `flux-local test` could not run due to unrelated mise trust issue in CI-less env; kustomize build confirms manifests are valid

### Risk
- **Low**: patch-level chart bump for a utility (config-reload watcher). No value changes, no breaking API changes expected.