### PR TITLE
chore(helm): update gitlab chart

### DIFF
--- a/kubernetes/apps/gitlab/gitlab/app/helmrelease.yaml
+++ b/kubernetes/apps/gitlab/gitlab/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
   chart:
     spec:
       chart: gitlab
-      version: 10.0.2
+      version: 10.1.0
       sourceRef:
         kind: HelmRepository
         name: gitlab


### PR DESCRIPTION
Updates the GitLab Helm chart to 10.1.0.

Validation:
- flux-local test --enable-helm --all-namespaces --path kubernetes/flux/cluster -v --sources flux-system
- flux-local build all --enable-helm --skip-invalid-kustomization-paths --output-file /tmp/home-ops-rendered.yaml kubernetes/flux/cluster
- kubeconform -strict -summary -ignore-missing-schemas ... /tmp/home-ops-rendered.yaml
- yamlfmt -lint kubernetes/apps/gitlab/gitlab/app/helmrelease.yaml