### PR TITLE
fix(schemas): correct yaml-language-server schema comments for app-template HelmReleases

### DIFF
--- a/kubernetes/apps/default/echo/app/helmrelease.yaml
+++ b/kubernetes/apps/default/echo/app/helmrelease.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/kubernetes/apps/default/multi-scrobbler/app/ocirepository.yaml
+++ b/kubernetes/apps/default/multi-scrobbler/app/ocirepository.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:

--- a/kubernetes/apps/external-secrets/onepassword/app/helmrelease.yaml
+++ b/kubernetes/apps/external-secrets/onepassword/app/helmrelease.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:


### PR DESCRIPTION
Fixes incorrect/missing yaml-language-server schema directives:

- **echo, onepassword, cloudflare-tunnel HelmReleases**: replaced generic flux2-schemas URL with bjw-s app-template schema for proper IDE validation of chart values
- **multi-scrobbler OCIRepository**: added missing schema comment to match repo convention

Zero runtime impact — these are YAML comments for editor tooling only.