### PR TITLE
fix(security): harden public debug routes

### DIFF
--- a/kubernetes/apps/default/echo/app/helmrelease.yaml
+++ b/kubernetes/apps/default/echo/app/helmrelease.yaml
@@ -75,7 +75,7 @@ spec:
             conditions: ["[STATUS] == 200"]
         hostnames: ["{{ .Release.Name }}.melotic.dev"]
         parentRefs:
-          - name: envoy-external
+          - name: envoy-internal
             namespace: network
             sectionName: https
         rules:

--- a/kubernetes/apps/monitoring/kromgo/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kromgo/app/helmrelease.yaml
@@ -66,8 +66,9 @@ spec:
         hostnames:
           - "kromgo.melotic.dev"
         parentRefs:
-          - name: envoy-external
+          - name: envoy-internal
             namespace: network
+            sectionName: https
         rules:
           - backendRefs:
               - identifier: app


### PR DESCRIPTION
Move Kromgo and echo routes to envoy-internal to prevent public exposure of cluster metrics and request metadata.