### PR TITLE
fix(security): restrict direct load balancer exposure

### DIFF
--- a/kubernetes/apps/default/ghidra-server/app/helmrelease.yaml
+++ b/kubernetes/apps/default/ghidra-server/app/helmrelease.yaml
@@ -74,6 +74,9 @@ spec:
         annotations:
           lbipam.cilium.io/ips: "${GHIDRA_SERVER_IP}"
         externalTrafficPolicy: Local
+        loadBalancerSourceRanges:
+          - 10.42.0.0/16
+          - 10.60.0.0/16
         ports:
           ghidra:
             port: *port

--- a/kubernetes/apps/default/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/default/jellyfin/app/helmrelease.yaml
@@ -81,6 +81,8 @@ spec:
         annotations:
           lbipam.cilium.io/ips: 10.60.80.8
         externalTrafficPolicy: Local
+        loadBalancerSourceRanges:
+          - 10.60.0.0/16
         ports:
           http:
             port: *port

--- a/kubernetes/apps/monitoring/fluent-bit/app/service.yaml
+++ b/kubernetes/apps/monitoring/fluent-bit/app/service.yaml
@@ -8,6 +8,9 @@ metadata:
     lbipam.cilium.io/ips: "10.60.80.54"
 spec:
   type: LoadBalancer
+  loadBalancerSourceRanges:
+    - 10.20.0.0/16
+    - 10.60.0.0/16
   selector:
     app.kubernetes.io/name: fluent-bit
     app.kubernetes.io/instance: fluent-bit


### PR DESCRIPTION
Add loadBalancerSourceRanges to Jellyfin, Ghidra server, and fluent-bit syslog LoadBalancer services to limit access to internal networks only.