### PR TITLE
fix(kromgo): restore public badge route

### DIFF
--- a/kubernetes/apps/monitoring/kromgo/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kromgo/app/helmrelease.yaml
@@ -66,7 +66,7 @@ spec:
         hostnames:
           - "kromgo.melotic.dev"
         parentRefs:
-          - name: envoy-internal
+          - name: envoy-external
             namespace: network
             sectionName: https
         rules:


### PR DESCRIPTION
Restores the public Kromgo badge route.