### PR TITLE
fix(monitoring): restore kromgo public route and syslog ingestion

### DIFF
--- a/kubernetes/apps/monitoring/fluent-bit/app/service.yaml
+++ b/kubernetes/apps/monitoring/fluent-bit/app/service.yaml
@@ -8,9 +8,6 @@ metadata:
     lbipam.cilium.io/ips: "10.60.80.54"
 spec:
   type: LoadBalancer
-  loadBalancerSourceRanges:
-    - 10.20.0.0/16
-    - 10.60.0.0/16
   selector:
     app.kubernetes.io/name: fluent-bit
     app.kubernetes.io/instance: fluent-bit

--- a/kubernetes/apps/monitoring/kromgo/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kromgo/app/helmrelease.yaml
@@ -66,7 +66,7 @@ spec:
         hostnames:
           - "kromgo.melotic.dev"
         parentRefs:
-          - name: envoy-internal
+          - name: envoy-external
             namespace: network
             sectionName: https
         rules:


### PR DESCRIPTION
## Summary

Reverts two regressions introduced by recent hardening PRs:

### Kromgo public badges (Workboard: 39023956-5826-4023-889b-ea8ce7ea02cf)
PR #1497 moved Kromgo's HTTPRoute from `envoy-external` to `envoy-internal`, breaking public badge endpoints. This restores the parentRef to `envoy-external` so badges are publicly accessible again.

### Fluent-bit syslog ingestion (Workboard: eca016fe-a99b-4358-a4a3-650ee3e72287)
PR #1498 added `loadBalancerSourceRanges` to the syslog LoadBalancer service, restricting to `10.20.0.0/16` and `10.60.0.0/16`. These CIDRs were not validated against actual UniFi/network gear source addresses and may block log ingestion. This removes the restriction to restore syslog availability.

## Validation

```
flux-local test --enable-helm --all-namespaces --path kubernetes/flux/cluster -v --sources flux-system
159 passed in 59.17s
```

## Changes
- `kubernetes/apps/monitoring/kromgo/app/helmrelease.yaml`: `envoy-internal` → `envoy-external`
- `kubernetes/apps/monitoring/fluent-bit/app/service.yaml`: remove `loadBalancerSourceRanges`