### PR TITLE
feat(monitoring): UniFi IDS to VictoriaLogs with log-based P2 alerting

### DIFF
--- a/kubernetes/apps/monitoring/fluent-bit/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/fluent-bit/app/helmrelease.yaml
@@ -76,7 +76,7 @@ spec:
         [PARSER]
             Name                 syslog-rfc3164-local
             Format               regex
-            Regex                ^\<(?<pri>[0-9]{1,5})\>(?<time>[A-Za-z]{3}\s+[0-9]{1,2}\s+[0-9]{2}:[0-9]{2}:[0-9]{2})\s+(?<host>[^ ]+)\s+(?<ident>[^\[:{ ]+)(?:\[(?<pid>[0-9]+)\])?[: ]*(?<message>.*)$
+            Regex                ^\<(?<pri>[0-9]{1,5})\>(?<time>[A-Za-z]{3}\s+[0-9]{1,2}\s+[0-9]{2}:[0-9]{2}:[0-9]{2})\s+(?<host>[^ ]+)\s+(?<message>.*)$
             Time_Key             time
             Time_Format          %b %d %H:%M:%S
             Time_System_Timezone On
@@ -86,7 +86,7 @@ spec:
             Match                syslog.*
             Host                 victoria-logs-server.monitoring.svc.cluster.local
             Port                 9428
-            URI                  /insert/jsonline?_stream_fields=host,ident&_msg_field=message,log&_time_field=date
+            URI                  /insert/jsonline?_stream_fields=host&_msg_field=message,log&_time_field=date
             Format               json_lines
             json_date_format     iso8601
             Compress             gzip

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/alertmanagerconfig.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/alertmanagerconfig.yaml
@@ -33,6 +33,12 @@ spec:
             value: ImagePullBackOff|ErrImagePull|InvalidImageName|CreateContainerConfigError
             matchType: =~
         continue: true
+      - receiver: pushover-escalation
+        matchers:
+          - name: tier
+            value: security
+            matchType: =
+        continue: true
       - receiver: webhook
         matchers:
           - name: severity

--- a/kubernetes/apps/monitoring/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kustomization.yaml
@@ -19,3 +19,4 @@ resources:
   - ./unpoller/ks.yaml
   - ./victoria-logs-collector/ks.yaml
   - ./victoria-logs/ks.yaml
+  - ./vmalert/ks.yaml

--- a/kubernetes/apps/monitoring/vmalert/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/vmalert/app/helmrelease.yaml
@@ -1,0 +1,68 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: vmalert
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: vmalert
+  interval: 1h
+  values:
+    fullnameOverride: vmalert
+    server:
+      image:
+        registry: docker.io
+      datasource:
+        url: http://victoria-logs-server.monitoring.svc.cluster.local:9428
+      notifier:
+        url: http://kube-prometheus-stack-alertmanager.monitoring.svc.cluster.local:9093
+      extraArgs:
+        rule.defaultRuleType: vlogs
+        external.url: https://victoria-logs.melotic.dev
+      extraVolumes:
+        - name: tmp
+          emptyDir: {}
+      extraVolumeMounts:
+        - name: tmp
+          mountPath: /tmp
+      podSecurityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop: ["ALL"]
+      resources:
+        requests:
+          cpu: 10m
+          memory: 64Mi
+        limits:
+          memory: 128Mi
+      config:
+        alerts:
+          groups:
+            - name: unifi-ids
+              type: vlogs
+              interval: 5m
+              rules:
+                - alert: UniFiIDSThreatBurst
+                  expr: '"UNIFIpolicyType=IDS/IPS" | stats count() as detections | filter detections:>10'
+                  for: 0m
+                  labels:
+                    severity: critical
+                    tier: security
+                  annotations:
+                    summary: >-
+                      UniFi IDS/IPS reported {{ $value }} threat detections in the
+                      last 5 minutes (active targeting at the WAN edge)
+    alertmanager:
+      enabled: false
+    serviceMonitor:
+      enabled: true

--- a/kubernetes/apps/monitoring/vmalert/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/vmalert/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/monitoring/vmalert/app/ocirepository.yaml
+++ b/kubernetes/apps/monitoring/vmalert/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: vmalert
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.42.1
+  url: oci://ghcr.io/victoriametrics/helm-charts/victoria-metrics-alert

--- a/kubernetes/apps/monitoring/vmalert/ks.yaml
+++ b/kubernetes/apps/monitoring/vmalert/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app vmalert
+  namespace: &namespace monitoring
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: victoria-logs
+    - name: kube-prometheus-stack
+  path: ./kubernetes/apps/monitoring/vmalert/app
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: false

--- a/kubernetes/apps/security/crowdsec/app/kustomization.yaml
+++ b/kubernetes/apps/security/crowdsec/app/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - ./ciliumnetworkpolicy.yaml
   - ./monitoring.yaml
   - ./grafanadashboard.yaml
+  - ./prometheusrule.yaml
 configMapGenerator:
   - name: crowdsec-config-local
     files:

--- a/kubernetes/apps/security/crowdsec/app/prometheusrule.yaml
+++ b/kubernetes/apps/security/crowdsec/app/prometheusrule.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: crowdsec-rules
+spec:
+  groups:
+    - name: crowdsec.rules
+      rules:
+        - alert: CrowdSecLAPIDown
+          expr: |-
+            up{job="crowdsec", namespace="security"} == 0
+          for: 5m
+          annotations:
+            summary: >-
+              CrowdSec LAPI is down: security decisions cannot be issued or
+              queried by bouncers
+          labels:
+            severity: critical
+            tier: security
+
+        - alert: CrowdSecCAPISyncFailing
+          expr: |-
+            increase(cs_papi_poll_errors_total{namespace="security"}[15m]) > 0
+          for: 15m
+          annotations:
+            summary: >-
+              CrowdSec central-API blocklist sync is failing: community threat
+              intelligence is going stale
+          labels:
+            severity: critical
+            tier: security


### PR DESCRIPTION
Makes UniFi IDS/IPS detections observable and alertable end to end.

- fluent-bit: minimal syslog forwarder (drops the brittle ident capture that failed on UniFi's format). Field extraction happens at query time in VictoriaLogs via LogsQL extract pipes (saved in the phase runbook).
- crowdsec: tier=security AlertmanagerConfig route to the Pushover P2 receiver, plus CrowdSec LAPI/CAPI PrometheusRules.
- vmalert: new instance using VictoriaLogs as datasource and the existing Alertmanager as notifier; a vlogs rule fires tier=security when UniFi IDS reports a burst (more than 10 detections in 5m), routed to P2.

Validated live: a real id-check test detection traversed UniFi CEF syslog to the fluent-bit LB (10.60.80.54) into VictoriaLogs; the extract query returns act=blocked, src, and the full ipsSignature. The vmalert stats_query expr was confirmed against live VictoriaLogs and the chart renders clean.

Tunable: the burst threshold (10 in 5m) is a conservative starting default.