### PR TITLE
feat(victoria-logs-collector): collect kube-apiserver audit logs

### DIFF
--- a/kubernetes/apps/monitoring/victoria-logs-collector/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/victoria-logs-collector/app/helmrelease.yaml
@@ -15,9 +15,14 @@ spec:
       registry: docker.io
       tag: v1.50.0@sha256:89693ad27a728bb6971e533eb7b121ad00cf38efdbdda2ec4bf056a348f5ca82
     extraArgs:
-      tmpDataPath: /tmp
+      tmpDataPath: /var/lib/vl-collector
+      fileCollector.timeField: requestReceivedTimestamp
+      fileCollector.msgField: requestURI
     remoteWrite:
       - url: http://victoria-logs-server.monitoring.svc.cluster.local:9428
+    fileCollector:
+      - glob: /var/log/audit/kube/kube-apiserver.log
+        extraFields: '{"log_type":"kube-audit"}'
     collector:
       msgField:
         - message
@@ -52,7 +57,9 @@ spec:
       includeNodeAnnotations: false
     persistence:
       volume:
-        emptyDir: {}
+        hostPath:
+          path: /var/lib/vl-collector
+          type: DirectoryOrCreate
     podMonitor:
       enabled: true
     resources:
@@ -77,3 +84,4 @@ spec:
       runAsGroup: 0
       capabilities:
         drop: ["ALL"]
+        add: ["DAC_READ_SEARCH"]


### PR DESCRIPTION
Ships the kube-apiserver audit log (Talos Metadata policy) from each control-plane node into VictoriaLogs, reusing the existing collector's `/var/log` host mount via the chart's native `fileCollector`. No new component.

Details:
- The audit JSON has no `message`/`time` field, so `_msg`/`_time` are mapped to `requestURI`/`requestReceivedTimestamp`; entries land under `log_type=kube-audit`. Field extraction stays at query time in LogsQL.
- The files are written 0600 by uid 65534, so the agent gets `DAC_READ_SEARCH` (read only); all other capabilities stay dropped.
- Collector checkpoints move from emptyDir to a node hostPath. With emptyDir the read offset is lost on every pod restart and vlagent re-reads each file from the start; I measured ~30% duplicate re-ingestion of a node's logs after a single restart, which would corrupt the audit record. hostPath keeps the offset across restarts (verified live with DirectoryOrCreate).

Detection rules over the new source are a deliberate follow-up once baseline volume exists.