### PR TITLE
feat(cloudflare-access): Authentik OIDC provider and tofu-controller substrate

### DIFF
--- a/kubernetes/apps/default/authentik/app/blueprints/cloudflare-access.yaml
+++ b/kubernetes/apps/default/authentik/app/blueprints/cloudflare-access.yaml
@@ -1,0 +1,65 @@
+---
+# yaml-language-server: $schema=https://goauthentik.io/blueprints/schema.json
+version: 1
+metadata:
+  name: Cloudflare Access OIDC Provider and Application
+context:
+  authorization_flow: &authorization_flow !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+  invalidation_flow: &invalidation_flow !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+  signing_key: &signing_key !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+entries:
+  # Access group matched by the Cloudflare Access policy
+  - model: authentik_core.group
+    id: ztna-users
+    identifiers:
+      name: ztna-users
+    attrs:
+      name: ztna-users
+
+  # Groups scope mapping so group membership is emitted in the id_token
+  - model: authentik_providers_oauth2.scopemapping
+    id: scope-groups
+    identifiers:
+      name: "Cloudflare Access groups"
+    attrs:
+      name: "Cloudflare Access groups"
+      scope_name: groups
+      description: "User group membership"
+      expression: |
+        return {"groups": [group.name for group in request.user.groups.all()]}
+
+  # OAuth2/OIDC provider for Cloudflare Access
+  - model: authentik_providers_oauth2.oauth2provider
+    identifiers:
+      name: cloudflare-access
+    attrs:
+      name: cloudflare-access
+      authorization_flow: *authorization_flow
+      invalidation_flow: *invalidation_flow
+      client_type: confidential
+      client_id: !Env CLOUDFLARE_ACCESS_CLIENT_ID
+      client_secret: !Env CLOUDFLARE_ACCESS_CLIENT_SECRET
+      include_claims_in_id_token: true
+      redirect_uris:
+        - url: "https://melotic.cloudflareaccess.com/cdn-cgi/access/callback"
+          matching_mode: strict
+      grant_types:
+        - authorization_code
+        - refresh_token
+      sub_mode: hashed_user_id
+      property_mappings:
+        - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+        - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+        - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+        - !KeyOf scope-groups
+      signing_key: *signing_key
+
+  # Application slug drives the per-app JWKS URL at /application/o/cloudflare-access/jwks/
+  - model: authentik_core.application
+    identifiers:
+      slug: cloudflare-access
+    attrs:
+      name: Cloudflare Access
+      slug: cloudflare-access
+      provider: !Find [authentik_providers_oauth2.oauth2provider, [name, cloudflare-access]]
+      policy_engine_mode: any

--- a/kubernetes/apps/default/authentik/app/kustomization.yaml
+++ b/kubernetes/apps/default/authentik/app/kustomization.yaml
@@ -25,6 +25,7 @@ configMapGenerator:
       - flow-login.yaml=./blueprints/flow-login.yaml
       - brand.yaml=./blueprints/brand.yaml
       - reputation.yaml=./blueprints/reputation.yaml
+      - cloudflare-access.yaml=./blueprints/cloudflare-access.yaml
 generatorOptions:
   disableNameSuffixHash: true
   annotations:

--- a/kubernetes/apps/flux-system/tofu-controller/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/tofu-controller/app/helmrelease.yaml
@@ -29,6 +29,7 @@ spec:
         create: true
         allowedNamespaces:
           - flux-system
+          - network
     rbac:
       create: true
     podSecurityContext:

--- a/kubernetes/apps/network/cloudflare-access/app/externalsecret.yaml
+++ b/kubernetes/apps/network/cloudflare-access/app/externalsecret.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cloudflare-access-tfvars
+  namespace: network
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: cf-access-tfvars
+    template:
+      engineVersion: v2
+      data:
+        cloudflare_api_token: "{{ .CLOUDFLARE_ZT_TOKEN | trim }}"
+        account_id: "31bd6064f8c4bcc23fcb7eb49c171c98"
+        oidc_client_id: "{{ .cloudflare_access_client_id }}"
+        oidc_client_secret: "{{ .cloudflare_access_client_secret }}"
+        operator_email: "{{ .ztna_operator_email }}"
+  dataFrom:
+    - extract:
+        key: cloudflare
+    - extract:
+        key: authentik-oidc

--- a/kubernetes/apps/network/cloudflare-access/app/kustomization.yaml
+++ b/kubernetes/apps/network/cloudflare-access/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml

--- a/kubernetes/apps/network/cloudflare-access/ks.yaml
+++ b/kubernetes/apps/network/cloudflare-access/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app cloudflare-access
+  namespace: &namespace network
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/network/cloudflare-access/app
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: true

--- a/kubernetes/apps/network/kustomization.yaml
+++ b/kubernetes/apps/network/kustomization.yaml
@@ -9,6 +9,7 @@ components:
   - ../../components/psa/privileged
 resources:
   - ./certificates/ks.yaml
+  - ./cloudflare-access/ks.yaml
   - ./cloudflare-dns/ks.yaml
   - ./cloudflare-tunnel/ks.yaml
   - ./envoy-gateway/ks.yaml


### PR DESCRIPTION
Adds the Authentik OAuth2/OIDC provider+application blueprint (`cloudflare-access` slug, `ztna-users` group, groups scope mapping), allows the tf-runner in the `network` namespace, and scaffolds the `cloudflare-access` app whose ExternalSecret materializes the `cf-access-tfvars` Secret. Non-exposing groundwork; no routes change.

Requires the 1Password `authentik-oidc` item to carry `cloudflare_access_client_id`, `cloudflare_access_client_secret`, and `ztna_operator_email` before reconcile.