### PR TITLE
fix(tofu-controller): allow cross-namespace source references

### DIFF
--- a/kubernetes/apps/flux-system/tofu-controller/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/tofu-controller/app/helmrelease.yaml
@@ -16,6 +16,9 @@ spec:
     remediation:
       strategy: rollback
   values:
+    # Required so a Terraform CR in an app namespace (network) can reference the
+    # shared GitRepository in flux-system.
+    allowCrossNamespaceRefs: true
     awsPackage:
       install: false
     image:


### PR DESCRIPTION
The cloudflare-access Terraform reconciler runs in the `network` namespace but references the shared `flux-system` GitRepository. tofu-controller blocks cross-namespace source refs by default, so the reconciler stalled with AccessDenied. This enables `allowCrossNamespaceRefs` (the documented pattern for a shared source with Terraform CRs in app namespaces).