### PR TITLE
fix(volsync): filter stale alerts against live ReplicationSource inventory

### DIFF
--- a/kubernetes/apps/volsync-system/volsync/app/prometheusrule.yaml
+++ b/kubernetes/apps/volsync-system/volsync/app/prometheusrule.yaml
@@ -40,7 +40,9 @@ spec:
 
         - alert: VolSyncSourceStaleWarning
           expr: |-
-            max by (obj_namespace, obj_name) (increase(volsync_sync_duration_seconds_count{role="source"}[18h])) < 1
+            (max by (obj_namespace, obj_name) (increase(volsync_sync_duration_seconds_count{role="source"}[18h])) < 1)
+              and on (obj_namespace, obj_name)
+            kube_customresource_volsync_replicationsource_info
           annotations:
             summary: >-
               {{ $labels.obj_namespace }}/{{ $labels.obj_name }} has no completed VolSync source sync in more than 18 hours
@@ -50,7 +52,9 @@ spec:
 
         - alert: VolSyncSourceStaleCritical
           expr: |-
-            max by (obj_namespace, obj_name) (increase(volsync_sync_duration_seconds_count{role="source"}[24h])) < 1
+            (max by (obj_namespace, obj_name) (increase(volsync_sync_duration_seconds_count{role="source"}[24h])) < 1)
+              and on (obj_namespace, obj_name)
+            kube_customresource_volsync_replicationsource_info
           annotations:
             summary: >-
               {{ $labels.obj_namespace }}/{{ $labels.obj_name }} has no completed VolSync source sync in more than 24 hours


### PR DESCRIPTION
The `VolSyncSourceStaleWarning` and `VolSyncSourceStaleCritical` alerts fire on stale metric series from deleted ReplicationSources (e.g. linkwarden). The PromQL `increase(...) < 1` matches stale series that no longer get new datapoints.

**Fix:** Join against `kube_customresource_volsync_replicationsource_info` so only ReplicationSources that actually exist in the cluster can trigger the staleness alerts. Ghost series from removed apps will no longer fire.