### PR TITLE
refactor(cloudflare-access): make the ztna-users allow policy reusable

### DIFF
--- a/kubernetes/apps/network/cloudflare-access/app/terraform/main.tf
+++ b/kubernetes/apps/network/cloudflare-access/app/terraform/main.tf
@@ -53,17 +53,19 @@ resource "cloudflare_zero_trust_access_application" "searxng" {
   ]
   auto_redirect_to_identity = false
   policies = [{
-    id         = cloudflare_zero_trust_access_policy.searxng_allow.id
+    id         = cloudflare_zero_trust_access_policy.ztna_users.id
     precedence = 1
   }]
 }
 
-# Allow policy: the primary rule matches the ztna-users group from the Authentik
-# OIDC id_token; the secondary rule allows the operator email as the One-time PIN
-# break-glass path (One-time PIN identities carry no groups claim).
-resource "cloudflare_zero_trust_access_policy" "searxng_allow" {
+# Shared, reusable allow policy for the ZTNA front door. Attach it to any Access
+# application that should be gated on Authentik group membership: the primary
+# rule matches the ztna-users group from the Authentik OIDC id_token, and the
+# operator-email rule is a One-time PIN break-glass path (One-time PIN identities
+# carry no groups claim) available to every app that references this policy.
+resource "cloudflare_zero_trust_access_policy" "ztna_users" {
   account_id = var.account_id
-  name       = "searxng-ztna-users"
+  name       = "allow-ztna-users"
   decision   = "allow"
   include = [
     {
@@ -79,6 +81,13 @@ resource "cloudflare_zero_trust_access_policy" "searxng_allow" {
       }
     },
   ]
+}
+
+# The policy was renamed from searxng_allow; preserve its identity so the rename
+# is an in-place update instead of a destroy and recreate.
+moved {
+  from = cloudflare_zero_trust_access_policy.searxng_allow
+  to   = cloudflare_zero_trust_access_policy.ztna_users
 }
 
 output "authentik_idp_id" {


### PR DESCRIPTION
## What

Decouple the Cloudflare Access allow policy from searxng so it can be reused across every app behind the ZTNA front door.

- Rename the policy `searxng-ztna-users` -> `allow-ztna-users`
- Rename the Terraform address `searxng_allow` -> `ztna_users`
- Add a `moved` block so the existing policy is renamed in place (no destroy/recreate)
- Point the searxng Access application at the renamed policy

## Why

The policy is an account-level reusable resource that only enforces `groups contains ztna-users` (with the operator-email One-time PIN break-glass). Naming it after a single app was misleading and would lead to one near-identical policy per app. Now any future Access app just appends the same policy id to its `policies` list.

## Behavior

No change to enforcement: the same group rule and operator break-glass apply. searxng is not yet public, so the rename has no exposure impact.