### PR TITLE
feat(searxng): route through the cloudflare access front door

### DIFF
--- a/kubernetes/apps/default/searxng/app/helmrelease.yaml
+++ b/kubernetes/apps/default/searxng/app/helmrelease.yaml
@@ -66,7 +66,7 @@ spec:
       app:
         hostnames: ["{{ .Release.Name }}.melotic.dev"]
         parentRefs:
-          - name: envoy-internal
+          - name: envoy-external
             namespace: network
             sectionName: https
         rules:


### PR DESCRIPTION
## What

Move the searxng route from `envoy-internal` to `envoy-external` (single parentRef, namespace `network`, sectionName `https`). This is the only change.

## Effect

`searxng.melotic.dev` becomes publicly reachable through the Cloudflare Tunnel and is gated by the existing Cloudflare Access application + `allow-ztna-users` policy:

- Unauthenticated requests get a 302 to the Access login at the Cloudflare edge and never reach the origin.
- Authenticated members of the `ztna-users` Authentik group pass through; the operator email is a One-time PIN break-glass.
- LAN / Tailscale clients keep reaching the origin directly at the internal gateway (no Cloudflare hairpin) by design.

The Access app and policy are already live (`Ready=True`), and the OIDC groups claim was verified, so enforcement is active the moment the proxied DNS record appears.

## Post-merge verification

- Off-LAN `curl -sI https://searxng.melotic.dev` returns a 302 to `*.cloudflareaccess.com` (never a 200 origin response).
- Browser login as a `ztna-users` member loads searxng; OTP break-glass is selectable and works for the operator email.
- `dig +short searxng.melotic.dev` returns Cloudflare-proxied (orange-cloud) addresses; no WAN port-forward to the internal gateway.