### PR TITLE
fix(authentik): fail open when client IP is absent from GeoLite2 City DB

### DIFF
--- a/kubernetes/apps/default/authentik/app/blueprints/flow-login.yaml
+++ b/kubernetes/apps/default/authentik/app/blueprints/flow-login.yaml
@@ -166,6 +166,15 @@ entries:
             return False
 
         result = ak_call_policy("melotic-geoip-restriction")
+        if not result.passing:
+            # A public IP absent from the bundled free GeoLite2-City DB
+            # (VPN / iCloud Private Relay / datacenter / CGNAT egress, which the
+            # full MaxMind DB covers but the free tier does not) makes the GeoIP
+            # policy raise GeoIPNotFoundException -> non-passing. Treat "not
+            # found" as geo-unknown and fail open; password, enforced MFA and
+            # Turnstile still gate the login. Resolvable non-US IPs stay denied.
+            if any("not found" in str(message).lower() for message in (result.messages or [])):
+                return True
         return result.passing
 
   # Tombstone: remove the old direct GeoIP binding (replaced by wrapper)


### PR DESCRIPTION
## What

The login flow's GeoIP wrapper (`melotic-geoip-private-bypass`) now treats a **GeoIP lookup miss as geo-unknown and fails open**, instead of letting it cascade into a 404.

## Why

Off-LAN logins were failing with a hard 404 at `/application/o/authorize/`. Root cause traced via `authentik-server` logs:

```
GeoIPNotFoundException: client IP address not found in City database  (client_ip 95.173.221.173)
-> melotic-geoip-restriction non-passing
-> FlowNonApplicableException
-> 404
```

That IP **does** geolocate to Denver, US in MaxMind's full database, but the bundled **free GeoLite2-City** tier lacks it. The gap affects VPN, iCloud Private Relay, datacenter and CGNAT egress ranges — all common for legitimate remote users.

## Behavior change

- IP **not found** in the City DB -> fail **open** (geo-unknown).
- IP **resolves to a non-US country** -> still **denied** (message is a country-denial, not "not found").
- Private/RFC1918/loopback/CGNAT/ULA -> still bypassed as before.

This loosens one layer for unknown-geo IPs, but the login still requires **password + enforced MFA (TOTP/WebAuthn/static) + Turnstile**, and **Cloudflare Access keeps its own country policy at the edge**. Net posture for the ZTNA front door is unchanged in practice.

## Validation

- `flux-local test` 162 passed.
- Applies via the Authentik blueprint watcher after Flux reconcile.