### PR TITLE
feat(authentik): add operators group that cascades app access

### DIFF
--- a/kubernetes/apps/default/authentik/app/blueprints/cloudflare-access.yaml
+++ b/kubernetes/apps/default/authentik/app/blueprints/cloudflare-access.yaml
@@ -26,7 +26,7 @@ entries:
       scope_name: groups
       description: "User group membership"
       expression: |
-        return {"groups": [group.name for group in request.user.groups.all()]}
+        return {"groups": [group.name for group in request.user.all_groups()]}
 
   # OAuth2/OIDC provider for Cloudflare Access
   - model: authentik_providers_oauth2.oauth2provider

--- a/kubernetes/apps/default/authentik/app/blueprints/gitlab.yaml
+++ b/kubernetes/apps/default/authentik/app/blueprints/gitlab.yaml
@@ -27,7 +27,7 @@ entries:
       scope_name: groups
       expression: |
         return {
-          "groups": [group.name for group in user.ak_groups.all()]
+          "groups": [group.name for group in user.all_groups()]
         }
 
   # GitLab administrators group

--- a/kubernetes/apps/default/authentik/app/blueprints/groups.yaml
+++ b/kubernetes/apps/default/authentik/app/blueprints/groups.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://goauthentik.io/blueprints/schema.json
+version: 1
+metadata:
+  name: Group hierarchy and access personas
+entries:
+  # The "operators" persona aggregates every access-gating group as a PARENT.
+  # Authentik resolves membership upward: User.all_groups() returns direct groups
+  # plus all ancestors, and Group.is_member() is true for a group or any of its
+  # parents. So a single membership in "operators" cascades into ztna-users,
+  # gitlab-admins and ghidra-users without adding the user to each one.
+  #
+  # The parent groups are declared in their own app blueprints (cloudflare-access,
+  # gitlab, ghidra-server); !Find resolves them at import time. On a cold bootstrap
+  # those blueprints must import first; Authentik retries failed blueprints, so the
+  # parentage self-heals on a later reconcile if it ever races.
+  - model: authentik_core.group
+    id: operators
+    identifiers:
+      name: operators
+    attrs:
+      name: operators
+      is_superuser: false
+      parents:
+        - !Find [authentik_core.group, [name, ztna-users]]
+        - !Find [authentik_core.group, [name, gitlab-admins]]
+        - !Find [authentik_core.group, [name, ghidra-users]]

--- a/kubernetes/apps/default/authentik/app/kustomization.yaml
+++ b/kubernetes/apps/default/authentik/app/kustomization.yaml
@@ -26,6 +26,7 @@ configMapGenerator:
       - brand.yaml=./blueprints/brand.yaml
       - reputation.yaml=./blueprints/reputation.yaml
       - cloudflare-access.yaml=./blueprints/cloudflare-access.yaml
+      - groups.yaml=./blueprints/groups.yaml
 generatorOptions:
   disableNameSuffixHash: true
   annotations:


### PR DESCRIPTION
## What

Introduce an `operators` group whose parents are the three access-gating groups: `ztna-users` (Cloudflare Access), `gitlab-admins` (GitLab), and `ghidra-users` (Ghidra). Authentik resolves membership upward, so a single membership in `operators` grants all three without per-group enrollment.

Also flip the Cloudflare Access and GitLab OIDC scope mappings from direct group enumeration to `all_groups()` so inherited (ancestor) group names are emitted in the `groups` claim. Ghidra already binds via `is_member`, which respects ancestry, so it needs no change.

## Files

- `blueprints/groups.yaml` (new): declares `operators` with `is_superuser: false` and `parents: [ztna-users, gitlab-admins, ghidra-users]` via `!Find`.
- `blueprints/cloudflare-access.yaml`: scope mapping `request.user.groups.all()` -> `request.user.all_groups()`.
- `blueprints/gitlab.yaml`: scope mapping `user.ak_groups.all()` -> `user.all_groups()`.
- `kustomization.yaml`: register `groups.yaml` in the blueprint configMapGenerator.

## Behavior change

The Cloudflare Access and GitLab OIDC `groups` claims now include inherited group names. Both consumers match on exact names (`ztna-users`, `gitlab-admins`), so emitting additional ancestor names is inert for them.

This change is inert on merge: with no member in `operators` yet, `all_groups()` equals the direct group set for every user, so nothing changes until the membership is added.

## Rollout (additive, no lockout)

No memberships are modified. After merge:
1. Add the operator account to `operators` in the Authentik UI.
2. Verify the cascade: searxng via Cloudflare Access, GitLab admin, and Ghidra all work through the single membership.
3. Optionally remove the now-redundant direct memberships.

## Validation

`flux-local test --enable-helm --all-namespaces` passed (162) in an isolated worktree.