### PR TITLE
fix(karakeep): pin replicas=1 to stop silent scale-to-0 drift

### DIFF
--- a/kubernetes/apps/default/karakeep/app/helmrelease.yaml
+++ b/kubernetes/apps/default/karakeep/app/helmrelease.yaml
@@ -12,6 +12,10 @@ spec:
   values:
     controllers:
       karakeep:
+        # ponytail: pin replicas so an out-of-band `kubectl scale` can't silently
+        # drift this to 0 again (it did — 17d at 0/0 with a live route). Drift
+        # detection is off, so git must own the count.
+        replicas: 1
         strategy: Recreate
         annotations:
           reloader.stakater.com/auto: "true"


### PR DESCRIPTION
karakeep sat 0/0 for 17d with a live HTTPRoute (karakeep.melotic.dev) and
Service pointing at zero endpoints. HelmRelease was Ready/not-suspended and the
repo declared no replica count, so the chart default (1) should have applied —
but an out-of-band kubectl scale set the live Deployment to 0 and stuck across 4
generations. Drift detection is off, so nothing reset it.

Pin replicas=1 in git so the count is GitOps-owned and can't silently drift
again. No other change.
