### PR TITLE
feat(excalidraw): self-host on the internal gateway

### DIFF
--- a/kubernetes/apps/default/excalidraw/app/helmrelease.yaml
+++ b/kubernetes/apps/default/excalidraw/app/helmrelease.yaml
@@ -1,0 +1,84 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: excalidraw
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: excalidraw
+  install:
+    remediation:
+      retries: -1
+  values:
+    controllers:
+      excalidraw:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        strategy: RollingUpdate
+        containers:
+          app:
+            image:
+              repository: docker.io/excalidraw/excalidraw
+              tag: latest@sha256:f7ee194addd607bf831d2af0f0a34463dd4225e426cf35199ef0b12a803398e9
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: &port 8080
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 128Mi
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        annotations:
+          gatus.home-operations.com/endpoint: |-
+            conditions: ["[STATUS] == 200"]
+        hostnames: ["{{ .Release.Name }}.melotic.dev"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+    persistence:
+      config:
+        type: configMap
+        name: excalidraw-config
+        globalMounts:
+          - path: /etc/nginx/nginx.conf
+            subPath: nginx.conf
+            readOnly: true
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/default/excalidraw/app/kustomization.yaml
+++ b/kubernetes/apps/default/excalidraw/app/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+configMapGenerator:
+  - name: excalidraw-config
+    files:
+      - nginx.conf=./resources/nginx.conf
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/default/excalidraw/app/ocirepository.yaml
+++ b/kubernetes/apps/default/excalidraw/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: excalidraw
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/excalidraw/app/resources/nginx.conf
+++ b/kubernetes/apps/default/excalidraw/app/resources/nginx.conf
@@ -1,0 +1,35 @@
+pid /tmp/nginx.pid;
+worker_processes auto;
+events {
+  worker_connections 1024;
+}
+http {
+  include /etc/nginx/mime.types;
+  default_type application/octet-stream;
+  client_body_temp_path /tmp/client_temp;
+  proxy_temp_path /tmp/proxy_temp;
+  fastcgi_temp_path /tmp/fastcgi_temp;
+  uwsgi_temp_path /tmp/uwsgi_temp;
+  scgi_temp_path /tmp/scgi_temp;
+  sendfile on;
+  tcp_nopush on;
+  keepalive_timeout 65;
+  gzip on;
+  gzip_vary on;
+  gzip_types text/plain text/css application/javascript application/json image/svg+xml application/wasm font/woff2;
+  server {
+    listen 8080;
+    listen [::]:8080;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+    location = /healthz {
+      access_log off;
+      add_header Content-Type text/plain;
+      return 200 "ok\n";
+    }
+    location / {
+      try_files $uri $uri/ /index.html;
+    }
+  }
+}

--- a/kubernetes/apps/default/excalidraw/ks.yaml
+++ b/kubernetes/apps/default/excalidraw/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app excalidraw
+  namespace: &namespace default
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/default/excalidraw/app
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: false

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - ./authentik/ks.yaml
   - ./beets/ks.yaml
   - ./echo/ks.yaml
+  - ./excalidraw/ks.yaml
   - ./ghidra-server/ks.yaml
   - ./harbor/ks.yaml
   - ./home-assistant/ks.yaml


### PR DESCRIPTION
excalidraw.melotic.dev on the internal gateway. Static client, no state (localStorage only), no collab in the self-hosted image.

Stock image runs nginx as root on :80, so it can't meet the non-root + read-only-rootfs policy. Swapped in an nginx.conf that listens on :8080 with temp/pid under /tmp, so it runs as 65534 read-only with caps dropped.