### PR TITLE
feat(kyverno): normalize bare images in gitlab-runner namespace

### DIFF
--- a/kubernetes/apps/kyverno/policies/app/09-prepend-default-registry.yaml
+++ b/kubernetes/apps/kyverno/policies/app/09-prepend-default-registry.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/kyverno/main/.schemas/v1/clusterpolicy.json
+# Mutate runs before validate, so allowlist 08 sees the prepended image.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: prepend-default-registry
+  annotations:
+    policies.kyverno.io/title: Prepend Default Registry
+    policies.kyverno.io/category: Supply Chain
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      CI jobs run bare DockerHub images like rust:1.96 that allowlist 08 rejects
+      (no registry prefix), so the job never starts. This prepends docker.io/ so it
+      passes; no-op when the image already has one. Scoped to gitlab-runner.
+spec:
+  background: false
+  rules:
+    - name: normalize-bare-images
+      match:
+        any:
+          - resources:
+              kinds: [Pod]
+              namespaces: [gitlab-runner]
+      mutate:
+        foreach:
+          - list: "request.object.spec.containers"
+            patchStrategicMerge:
+              spec:
+                containers:
+                  - name: "{{ element.name }}"
+                    image: "{{ image_normalize(element.image) }}"
+          - list: "request.object.spec.initContainers || `[]`"
+            patchStrategicMerge:
+              spec:
+                initContainers:
+                  - name: "{{ element.name }}"
+                    image: "{{ image_normalize(element.image) }}"

--- a/kubernetes/apps/kyverno/policies/app/kustomization.yaml
+++ b/kubernetes/apps/kyverno/policies/app/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - ./06-verify-image-signature-cosign.yaml
   - ./07-disallow-untrusted-images.yaml
   - ./08-require-image-registry-allowlist.yaml
+  - ./09-prepend-default-registry.yaml
   - ./exceptions/host-namespace-infra.yaml
   - ./exceptions/rook-ceph-storage.yaml
   - ./exceptions/unsigned-image-signatures.yaml

--- a/kubernetes/apps/kyverno/policies/tests/09-prepend-default-registry/fixtures/build-pod-mutated.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/09-prepend-default-registry/fixtures/build-pod-mutated.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runner-build-pod
+  namespace: gitlab-runner
+spec:
+  containers:
+    - command:
+        - sh
+        - -c
+        - sleep 1
+      image: docker.io/rust:1.96
+      name: build
+    - command:
+        - sh
+        - -c
+        - sleep 1
+      image: docker.io/alpine:3.19
+      name: helper
+    - command:
+        - sh
+        - -c
+        - sleep 1
+      image: docker.io/docker:27-dind
+      name: svc-0
+    - command:
+        - sh
+        - -c
+        - sleep 1
+      image: docker.io/library/busybox:1.37.0
+      name: already-prefixed
+  initContainers:
+    - command:
+        - sh
+        - -c
+        - "true"
+      image: registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:ubuntu-x86_64-v19.1.1
+      name: init-permissions

--- a/kubernetes/apps/kyverno/policies/tests/09-prepend-default-registry/fixtures/build-pod.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/09-prepend-default-registry/fixtures/build-pod.yaml
@@ -1,0 +1,26 @@
+---
+# A runner build pod: bare images (build/helper/service) plus a helper initContainer
+# that already has a registry.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runner-build-pod
+  namespace: gitlab-runner
+spec:
+  initContainers:
+    - name: init-permissions
+      image: registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:ubuntu-x86_64-v19.1.1
+      command: ["sh", "-c", "true"]
+  containers:
+    - name: build
+      image: rust:1.96
+      command: ["sh", "-c", "sleep 1"]
+    - name: helper
+      image: alpine:3.19
+      command: ["sh", "-c", "sleep 1"]
+    - name: svc-0
+      image: docker:27-dind
+      command: ["sh", "-c", "sleep 1"]
+    - name: already-prefixed
+      image: docker.io/library/busybox:1.37.0
+      command: ["sh", "-c", "sleep 1"]

--- a/kubernetes/apps/kyverno/policies/tests/09-prepend-default-registry/kyverno-test.yaml
+++ b/kubernetes/apps/kyverno/policies/tests/09-prepend-default-registry/kyverno-test.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: prepend-default-registry-test
+policies:
+  - ../../app/09-prepend-default-registry.yaml
+resources:
+  - fixtures/build-pod.yaml
+results:
+  - policy: prepend-default-registry
+    rule: normalize-bare-images
+    resources: [runner-build-pod]
+    kind: Pod
+    patchedResources: fixtures/build-pod-mutated.yaml
+    result: pass


### PR DESCRIPTION
Bare Docker Hub images in GitLab CI (image: rust:1.96) get written into the build pod as-is, and the registry allowlist (08) blocks the bare name, so every job fails to start.

Mutate policy scoped to the gitlab-runner namespace that prepends docker.io/ before the allowlist runs. Already-prefixed images are left alone.