### PR TITLE
fix(talos): reduce kube audit noise

### DIFF
--- a/kubernetes/apps/default/kai-rbac/app/kustomization.yaml
+++ b/kubernetes/apps/default/kai-rbac/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./rbac.yaml

--- a/kubernetes/apps/default/kai-rbac/app/rbac.yaml
+++ b/kubernetes/apps/default/kai-rbac/app/rbac.yaml
@@ -1,0 +1,104 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/rbac.authorization.k8s.io/clusterrole_v1.json
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kai-homelab-read
+rules:
+  - apiGroups: [""]
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - namespaces
+      - nodes
+      - persistentvolumeclaims
+      - persistentvolumes
+      - pods
+      - pods/log
+      - services
+      - serviceaccounts
+    verbs: [get, list, watch]
+  - apiGroups: [apps]
+    resources:
+      - daemonsets
+      - deployments
+      - replicasets
+      - statefulsets
+    verbs: [get, list, watch]
+  - apiGroups: [autoscaling]
+    resources: [horizontalpodautoscalers]
+    verbs: [get, list, watch]
+  - apiGroups: [batch]
+    resources:
+      - cronjobs
+      - jobs
+    verbs: [get, list, watch]
+  - apiGroups: [discovery.k8s.io]
+    resources: [endpointslices]
+    verbs: [get, list, watch]
+  - apiGroups: [external-secrets.io]
+    resources:
+      - clusterexternalsecrets
+      - clustersecretstores
+      - externalsecrets
+      - secretstores
+    verbs: [get, list, watch]
+  - apiGroups: [gateway.envoyproxy.io]
+    resources:
+      - backendtrafficpolicies
+      - clienttrafficpolicies
+      - envoyproxies
+      - securitypolicies
+    verbs: [get, list, watch]
+  - apiGroups: [helm.toolkit.fluxcd.io]
+    resources: [helmreleases]
+    verbs: [get, list, watch]
+  - apiGroups: [kustomize.toolkit.fluxcd.io]
+    resources: [kustomizations]
+    verbs: [get, list, watch]
+  - apiGroups: [source.toolkit.fluxcd.io]
+    resources:
+      - buckets
+      - gitrepositories
+      - helmcharts
+      - helmrepositories
+      - ocirepositories
+    verbs: [get, list, watch]
+  - apiGroups: [metrics.k8s.io]
+    resources:
+      - nodes
+      - pods
+    verbs: [get, list, watch]
+  - apiGroups: [monitoring.coreos.com]
+    resources:
+      - alertmanagerconfigs
+      - podmonitors
+      - probes
+      - prometheusrules
+      - servicemonitors
+    verbs: [get, list, watch]
+  - apiGroups: [reports.kyverno.io]
+    resources:
+      - clusterephemeralreports
+      - ephemeralreports
+    verbs: [get, list, watch]
+  - apiGroups: [wgpolicyk8s.io]
+    resources:
+      - clusterpolicyreports
+      - policyreports
+    verbs: [get, list, watch]
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/rbac.authorization.k8s.io/clusterrolebinding_v1.json
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kai-homelab-read
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kai-homelab-read
+subjects:
+  - kind: ServiceAccount
+    name: kai
+    namespace: default

--- a/kubernetes/apps/default/kai-rbac/ks.yaml
+++ b/kubernetes/apps/default/kai-rbac/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app kai-rbac
+spec:
+  targetNamespace: default
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/default/kai-rbac/app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  timeout: 5m
+  wait: true

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - ./harbor/ks.yaml
   - ./home-assistant/ks.yaml
   - ./jellyfin/ks.yaml
+  - ./kai-rbac/ks.yaml
   - ./karakeep/ks.yaml
   - ./kopia-azure-sync/ks.yaml
   - ./kopia-verify/ks.yaml

--- a/talos/patches/controller/cluster.yaml
+++ b/talos/patches/controller/cluster.yaml
@@ -5,6 +5,67 @@ cluster:
     extraArgs:
       # https://kubernetes.io/docs/tasks/extend-kubernetes/configure-aggregation-layer/
       enable-aggregator-routing: true
+    auditPolicy:
+      apiVersion: audit.k8s.io/v1
+      kind: Policy
+      # RequestReceived doubles volume for most short requests while adding little
+      # investigation value. Keep completion/watch records and security-sensitive
+      # resources below.
+      omitStages:
+        - RequestReceived
+      rules:
+        # Drop high-volume health/discovery probes from kube components.
+        - level: None
+          nonResourceURLs:
+            - /healthz*
+            - /livez*
+            - /readyz*
+            - /version
+            - /openapi*
+        # Leader-election leases are hot-loop background control-plane noise.
+        - level: None
+          verbs: [get, update, patch, watch]
+          resources:
+            - group: coordination.k8s.io
+              resources: [leases]
+        # Kyverno cleanup checks its own permissions constantly; audit the
+        # resulting report changes, not the repetitive self-SARs.
+        - level: None
+          users:
+            - system:serviceaccount:kyverno:kyverno-cleanup-controller
+          verbs: [create]
+          resources:
+            - group: authorization.k8s.io
+              resources: [selfsubjectaccessreviews]
+        # Keep secret access visible; reads are security-sensitive too.
+        - level: Metadata
+          resources:
+            - group: ""
+              resources: [secrets]
+        # Keep security-sensitive configuration changes at Metadata.
+        - level: Metadata
+          verbs: [create, update, patch, delete, deletecollection]
+          resources:
+            - group: ""
+              resources: [configmaps, serviceaccounts]
+            - group: rbac.authorization.k8s.io
+              resources: [roles, rolebindings, clusterroles, clusterrolebindings]
+            - group: admissionregistration.k8s.io
+              resources: [mutatingwebhookconfigurations, validatingwebhookconfigurations]
+            - group: certificates.k8s.io
+              resources: [certificatesigningrequests]
+            - group: gateway.envoyproxy.io
+              resources: [securitypolicies]
+            - group: external-secrets.io
+              resources: [externalsecrets, secretstores, clusterexternalsecrets, clustersecretstores]
+        # Preserve an investigation trail for pod/exec/log/proxy access.
+        - level: Metadata
+          resources:
+            - group: ""
+              resources: [pods/exec, pods/attach, pods/portforward, pods/proxy, pods/log]
+        # Everything else stays visible at metadata level, but without the
+        # RequestReceived duplicate stage above.
+        - level: Metadata
   controllerManager:
     extraArgs:
       bind-address: 0.0.0.0


### PR DESCRIPTION
Audit was collecting enough routine control-plane noise to hurt the nodes. This trims the spam, keeps the security-sensitive events, and adds read-only Kai RBAC for safer triage.