### PR TITLE
fix(github-release): pin flux distribution to v2.9.0

### DIFF
--- a/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
@@ -21,8 +21,8 @@ spec:
   values:
     instance:
       distribution:
-        # renovate: datasource=github-releases depName=controlplaneio-fluxcd/distribution
-        version: 2.9.1
+        # renovate: datasource=github-releases depName=controlplaneio-fluxcd/distribution allowedVersions=/^v?2\.9\.0$/
+        version: 2.9.0
       cluster:
         networkPolicy: false
       components:


### PR DESCRIPTION
Pin Flux distribution to the last version accepted by flux-operator.