### PR TITLE
feat(default): deploy Firefly III (SimpleFIN + MCP + webhook)

### DIFF
--- a/kubernetes/apps/database/postgres/app/databases/firefly.yaml
+++ b/kubernetes/apps/database/postgres/app/databases/firefly.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: firefly
+spec:
+  name: firefly
+  owner: firefly
+  cluster:
+    name: postgres-cluster
+  schemas:
+    - name: public
+      owner: firefly

--- a/kubernetes/apps/database/postgres/app/helmrelease.yaml
+++ b/kubernetes/apps/database/postgres/app/helmrelease.yaml
@@ -130,6 +130,11 @@ spec:
           login: true
           passwordSecret:
             name: postgres-user-crowdsec
+        - name: firefly
+          ensure: present
+          login: true
+          passwordSecret:
+            name: postgres-user-firefly
         - name: authentik
           ensure: present
           login: true

--- a/kubernetes/apps/database/postgres/app/kustomization.yaml
+++ b/kubernetes/apps/database/postgres/app/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ./databases/atuin.yaml
   - ./databases/authentik.yaml
   - ./databases/crowdsec.yaml
+  - ./databases/firefly.yaml
   - ./databases/harbor.yaml
   - ./databases/gitlab.yaml
   - ./databases/lidarr.yaml
@@ -27,6 +28,7 @@ resources:
   - ./roles/atuin.yaml
   - ./roles/authentik.yaml
   - ./roles/crowdsec.yaml
+  - ./roles/firefly.yaml
   - ./roles/gitlab.yaml
   - ./roles/harbor.yaml
   - ./roles/lidarr.yaml

--- a/kubernetes/apps/database/postgres/app/roles/firefly.yaml
+++ b/kubernetes/apps/database/postgres/app/roles/firefly.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: postgres-user-firefly
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: postgres-user-firefly
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      mergePolicy: Replace
+      type: kubernetes.io/basic-auth
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+      data:
+        user: firefly
+        username: firefly
+        password: "{{ .password }}"
+  dataFrom:
+    - extract:
+        key: firefly-postgres

--- a/kubernetes/apps/default/firefly/app/externalsecret.yaml
+++ b/kubernetes/apps/default/firefly/app/externalsecret.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: firefly
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: firefly-secret
+    template:
+      engineVersion: v2
+      data:
+        # --- Firefly III core ---
+        APP_KEY: "{{ .APP_KEY }}"
+        STATIC_CRON_TOKEN: "{{ .STATIC_CRON_TOKEN }}"
+        # --- Data Importer + MCP server auth to Firefly (operator fills after first login) ---
+        FIREFLY_III_ACCESS_TOKEN: "{{ .FIREFLY_PAT }}"
+        FIREFLY_III_PAT: "{{ .FIREFLY_PAT }}"
+        # --- SimpleFIN (operator pastes setup token) ---
+        SIMPLEFIN_TOKEN: "{{ .SIMPLEFIN_TOKEN }}"
+        # --- MCP server bearer + webhook secret ---
+        MCP_BEARER_TOKEN: "{{ .MCP_BEARER_TOKEN }}"
+        WEBHOOK_SECRET: "{{ .WEBHOOK_SECRET }}"
+  dataFrom:
+    - extract:
+        key: firefly

--- a/kubernetes/apps/default/firefly/app/helmrelease.yaml
+++ b/kubernetes/apps/default/firefly/app/helmrelease.yaml
@@ -1,0 +1,232 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: firefly
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: firefly
+  interval: 1h
+  values:
+    controllers:
+      firefly:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          # ---------------------------------------------------------------
+          # Firefly III core (web UI + REST API + webhook emitter)
+          # ---------------------------------------------------------------
+          app:
+            image:
+              repository: fireflyiii/core
+              tag: version-6.6.6@sha256:ae69fdd95cdef9038cd7a460a5aec731f14813973e4f096511d5a4ea9ff0e972
+            env:
+              TZ: America/Chicago
+              APP_ENV: production
+              APP_URL: "https://firefly.melotic.dev"
+              SITE_OWNER: justinmp215@gmail.com
+              DEFAULT_LANGUAGE: en_US
+              TRUSTED_PROXIES: "**"
+              LOG_CHANNEL: stack
+              APP_LOG_LEVEL: notice
+              DB_CONNECTION: pgsql
+              DB_HOST: postgres-cluster-rw.database.svc.cluster.local
+              DB_PORT: "5432"
+              DB_DATABASE: firefly
+              DB_USERNAME:
+                secretKeyRef:
+                  name: &pgsecret firefly-postgres
+                  key: username
+              DB_PASSWORD:
+                secretKeyRef:
+                  name: *pgsecret
+                  key: password
+              APP_KEY:
+                secretKeyRef:
+                  name: &secret firefly-secret
+                  key: APP_KEY
+              STATIC_CRON_TOKEN:
+                secretKeyRef:
+                  name: *secret
+                  key: STATIC_CRON_TOKEN
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8080
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 6
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: {drop: ["ALL"]}
+            resources:
+              requests:
+                cpu: 25m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+          # ---------------------------------------------------------------
+          # Data Importer (SimpleFIN -> Firefly, headless autoimport)
+          # ---------------------------------------------------------------
+          importer:
+            image:
+              repository: fireflyiii/data-importer
+              tag: version-2.3.3@sha256:376b52a3abc92ea459b9b77c7be594e5abf9c845e80eccbbe6bda0af67859c31
+            env:
+              TZ: America/Chicago
+              APP_URL: "https://firefly-import.melotic.dev"
+              APP_ENV: production
+              LOG_CHANNEL: stack
+              TRUSTED_PROXIES: "**"
+              EXPECT_SECURE_URL: "true"
+              # Talk to core over localhost within the same pod
+              FIREFLY_III_URL: "http://localhost:8080"
+              VANITY_URL: "https://firefly.melotic.dev"
+              FIREFLY_III_ACCESS_TOKEN:
+                secretKeyRef:
+                  name: *secret
+                  key: FIREFLY_III_ACCESS_TOKEN
+              # SimpleFIN bank feed (operator pastes token into 1Password)
+              SIMPLEFIN_TOKEN:
+                secretKeyRef:
+                  name: *secret
+                  key: SIMPLEFIN_TOKEN
+              # Headless sync: allow POST /autoimport with this secret
+              CAN_POST_AUTOIMPORT: "true"
+              AUTO_IMPORT_SECRET:
+                secretKeyRef:
+                  name: *secret
+                  key: WEBHOOK_SECRET
+              IMPORT_DIR_ALLOWLIST: /import
+            probes:
+              liveness: &iprobes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 8081
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 6
+              readiness: *iprobes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: {drop: ["ALL"]}
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+          # ---------------------------------------------------------------
+          # MCP server (@firefly-iii-mcp/server) - ALL tools (preset: full)
+          # No include/exclude filter: SimpleFIN is read-only upstream, so
+          # no MCP tool can move real money; worst case is a recoverable
+          # local-ledger edit that re-syncs from the bank feed.
+          # ---------------------------------------------------------------
+          mcp:
+            image:
+              repository: node
+              tag: 22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2
+            command:
+              - npx
+              - -y
+              - "@firefly-iii-mcp/server@1.4.0"
+            env:
+              PORT: "3000"
+              FIREFLY_III_BASE_URL: "http://localhost:8080"
+              FIREFLY_III_PRESET: full
+              FIREFLY_III_PAT:
+                secretKeyRef:
+                  name: *secret
+                  key: FIREFLY_III_PAT
+            probes:
+              liveness: &mprobes
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 3000
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 6
+              readiness: *mprobes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: {drop: ["ALL"]}
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        controller: firefly
+        ports:
+          http:
+            port: 8080
+      mcp:
+        controller: firefly
+        ports:
+          http:
+            port: 3000
+      importer:
+        controller: firefly
+        ports:
+          http:
+            port: 8081
+    route:
+      app:
+        hostnames:
+          - "firefly.melotic.dev"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: 8080
+      importer:
+        hostnames:
+          - "firefly-import.melotic.dev"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: importer
+                port: 8081
+    persistence:
+      upload:
+        type: emptyDir
+      import:
+        type: emptyDir
+        advancedMounts:
+          firefly:
+            importer:
+              - path: /import

--- a/kubernetes/apps/default/firefly/app/helmrelease.yaml
+++ b/kubernetes/apps/default/firefly/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           # ---------------------------------------------------------------
           app:
             image:
-              repository: fireflyiii/core
+              repository: docker.io/fireflyiii/core
               tag: version-6.6.6@sha256:ae69fdd95cdef9038cd7a460a5aec731f14813973e4f096511d5a4ea9ff0e972
             env:
               TZ: America/Chicago
@@ -79,7 +79,7 @@ spec:
           # ---------------------------------------------------------------
           importer:
             image:
-              repository: fireflyiii/data-importer
+              repository: docker.io/fireflyiii/data-importer
               tag: version-2.3.3@sha256:376b52a3abc92ea459b9b77c7be594e5abf9c845e80eccbbe6bda0af67859c31
             env:
               TZ: America/Chicago
@@ -138,7 +138,7 @@ spec:
           # ---------------------------------------------------------------
           mcp:
             image:
-              repository: node
+              repository: docker.io/library/node
               tag: 22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2
             command:
               - npx

--- a/kubernetes/apps/default/firefly/app/kustomization.yaml
+++ b/kubernetes/apps/default/firefly/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./externalsecret.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/default/firefly/app/ocirepository.yaml
+++ b/kubernetes/apps/default/firefly/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: firefly
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/firefly/ks.yaml
+++ b/kubernetes/apps/default/firefly/ks.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app firefly
+  namespace: &namespace default
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/cnpg-database
+  dependsOn:
+    - name: postgres
+      namespace: database
+  path: ./kubernetes/apps/default/firefly/app
+  postBuild:
+    substitute:
+      APP: firefly
+      ONEPASSWORD_ITEM: firefly-postgres
+      PG_DATABASE: firefly
+      PG_HOST: postgres-cluster-rw.database.svc.cluster.local
+      PG_USER: firefly
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: false

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ./beets/ks.yaml
   - ./echo/ks.yaml
   - ./excalidraw/ks.yaml
+  - ./firefly/ks.yaml
   - ./ghidra-server/ks.yaml
   - ./harbor/ks.yaml
   - ./home-assistant/ks.yaml


### PR DESCRIPTION
Self-hosted personal finance stack on Zion.

## What
- **Firefly III core** at `firefly.melotic.dev`, CNPG-backed (new `firefly` DB + role)
- **Data Importer** sidecar — SimpleFIN read-only bank sync, headless `/autoimport`
- **@firefly-iii-mcp/server** sidecar — full finance toolset over MCP for Hermes
- Webhook loop (Firefly `STORE_TRANSACTION` → Hermes via Tailscale Serve) wired host-side after merge

## Secrets (1Password, Zion vault)
- `firefly-postgres` — DB password (valid random dummy, keep)
- `firefly` — APP_KEY/cron/MCP/webhook (valid random dummies) + FIREFLY_PAT & SIMPLEFIN_TOKEN (operator fills post-boot)

## Notes
- MCP exposes all tools (no filter): SimpleFIN is read-only upstream, no tool can move real money; worst case is a recoverable local-ledger edit.
- Additive only — touches no existing app. Firefly is stateless (data in Postgres), no PVC.

🤖 Generated with Hermes