### PR TITLE
fix(default): firefly runs as uid 33 (www-data)

### DIFF
--- a/kubernetes/apps/default/firefly/app/helmrelease.yaml
+++ b/kubernetes/apps/default/firefly/app/helmrelease.yaml
@@ -146,6 +146,8 @@ spec:
               - "@firefly-iii-mcp/server@1.4.0"
             env:
               PORT: "3000"
+              HOME: /tmp
+              NPM_CONFIG_CACHE: /tmp/.npm
               FIREFLY_III_BASE_URL: "http://localhost:8080"
               FIREFLY_III_PRESET: full
               FIREFLY_III_PAT:
@@ -178,9 +180,9 @@ spec:
       automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
+        runAsUser: 33
+        runAsGroup: 33
+        fsGroup: 33
         fsGroupChangePolicy: OnRootMismatch
     service:
       app:


### PR DESCRIPTION
Firefly core + data-importer crash-looped: serversideup/php base regenerates /etc/nginx/nginx.conf at boot as uid 33, so runAsUser 1000 → permission denied. Switch pod securityContext to 33/33/33. MCP node container gets writable HOME + npm cache under /tmp.

Fixes the CrashLoopBackOff from #1698.