### PR TITLE
fix(default): firefly HR cleanupOnFail + remediation

### DIFF
--- a/kubernetes/apps/default/firefly/app/helmrelease.yaml
+++ b/kubernetes/apps/default/firefly/app/helmrelease.yaml
@@ -9,6 +9,13 @@ spec:
     kind: OCIRepository
     name: firefly
   interval: 1h
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
   values:
     controllers:
       # =================================================================


### PR DESCRIPTION
Port-collision failure (#1701 pre-fix) left the Helm release wedged in a failed upgrade, blocking the new firefly-importer deployment. Add `upgrade.cleanupOnFail: true` + remediation retries (harbor pattern) so Flux purges the failed state and rolls forward.