### PR TITLE
feat(default): expose firefly MCP route (tailnet-internal)

### DIFF
--- a/kubernetes/apps/default/firefly/app/helmrelease.yaml
+++ b/kubernetes/apps/default/firefly/app/helmrelease.yaml
@@ -233,6 +233,17 @@ spec:
           - backendRefs:
               - identifier: importer
                 port: 8080
+      mcp:
+        hostnames:
+          - "firefly-mcp.melotic.dev"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: mcp
+                port: 3000
     persistence:
       import:
         type: emptyDir


### PR DESCRIPTION
Hermes runs as a host process and needs to reach the in-cluster MCP server. Add `firefly-mcp.melotic.dev` HTTPRoute via envoy-internal (private 10.60.88.1, tailnet/LAN-only). Same trust boundary as the existing Firefly UI route. SimpleFIN is read-only upstream so no money-movement risk.