### PR TITLE
refactor(default): trim firefly manifest comments

### DIFF
--- a/kubernetes/apps/default/firefly/app/externalsecret.yaml
+++ b/kubernetes/apps/default/firefly/app/externalsecret.yaml
@@ -14,15 +14,11 @@ spec:
     template:
       engineVersion: v2
       data:
-        # --- Firefly III core ---
         APP_KEY: "{{ .APP_KEY }}"
         STATIC_CRON_TOKEN: "{{ .STATIC_CRON_TOKEN }}"
-        # --- Data Importer + MCP server auth to Firefly (operator fills after first login) ---
         FIREFLY_III_ACCESS_TOKEN: "{{ .FIREFLY_PAT }}"
         FIREFLY_III_PAT: "{{ .FIREFLY_PAT }}"
-        # --- SimpleFIN (operator pastes setup token) ---
         SIMPLEFIN_TOKEN: "{{ .SIMPLEFIN_TOKEN }}"
-        # --- MCP server bearer + webhook secret ---
         MCP_BEARER_TOKEN: "{{ .MCP_BEARER_TOKEN }}"
         WEBHOOK_SECRET: "{{ .WEBHOOK_SECRET }}"
   dataFrom:

--- a/kubernetes/apps/default/firefly/app/helmrelease.yaml
+++ b/kubernetes/apps/default/firefly/app/helmrelease.yaml
@@ -18,14 +18,10 @@ spec:
       retries: 3
   values:
     controllers:
-      # =================================================================
-      # Controller 1: Firefly III core + MCP sidecar (shares localhost)
-      # =================================================================
       firefly:
         annotations:
           reloader.stakater.com/auto: "true"
         containers:
-          # Firefly III core (web UI + REST API + webhook emitter)
           app:
             image:
               repository: docker.io/fireflyiii/core
@@ -82,11 +78,6 @@ spec:
                 memory: 256Mi
               limits:
                 memory: 1Gi
-          # MCP server (@firefly-iii-mcp/server) - ALL tools (preset: full).
-          # Shares the pod with core so it reaches the API over localhost:8080.
-          # No include/exclude filter: SimpleFIN is read-only upstream, so no
-          # MCP tool can move real money; worst case is a recoverable local
-          # ledger edit that re-syncs from the bank feed.
           mcp:
             image:
               repository: docker.io/library/node
@@ -127,10 +118,7 @@ spec:
                 memory: 128Mi
               limits:
                 memory: 512Mi
-      # =================================================================
-      # Controller 2: Data Importer (own pod - also binds 8080 internally,
-      # so it CANNOT share a pod with core). Reaches core over the service.
-      # =================================================================
+      # Both PHP images bind 8080 and 9000, so the importer cannot share the core pod.
       firefly-importer:
         annotations:
           reloader.stakater.com/auto: "true"
@@ -146,7 +134,6 @@ spec:
               LOG_CHANNEL: stack
               TRUSTED_PROXIES: "**"
               EXPECT_SECURE_URL: "true"
-              # Reach core over the in-cluster service (separate pod now)
               FIREFLY_III_URL: "http://firefly.default.svc.cluster.local:8080"
               VANITY_URL: "https://firefly.melotic.dev"
               FIREFLY_III_ACCESS_TOKEN:


### PR DESCRIPTION
Remove redundant Firefly manifest comments; leave only the pod-split gotcha.