### PR TITLE
fix(default): use authentik for firefly authentication

### DIFF
--- a/kubernetes/apps/default/authentik/app/blueprints/firefly.yaml
+++ b/kubernetes/apps/default/authentik/app/blueprints/firefly.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://goauthentik.io/blueprints/schema.json
+version: 1
+metadata:
+  name: Firefly III Proxy Provider and Application
+context:
+  authorization_flow: &authorization_flow !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+  invalidation_flow: &invalidation_flow !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+entries:
+  - model: authentik_providers_proxy.proxyprovider
+    identifiers:
+      name: firefly
+    attrs:
+      name: firefly
+      authorization_flow: *authorization_flow
+      invalidation_flow: *invalidation_flow
+      mode: forward_single
+      external_host: https://firefly.melotic.dev
+  - model: authentik_core.application
+    identifiers:
+      slug: firefly
+    attrs:
+      name: Firefly III
+      slug: firefly
+      provider: !Find [authentik_providers_proxy.proxyprovider, [name, firefly]]
+      policy_engine_mode: any
+      group: Productivity
+      meta_icon: https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/firefly-iii.svg
+      meta_description: Personal finance manager
+      open_in_new_tab: true

--- a/kubernetes/apps/default/authentik/app/blueprints/outpost.yaml
+++ b/kubernetes/apps/default/authentik/app/blueprints/outpost.yaml
@@ -17,6 +17,7 @@ entries:
         - !Find [authentik_providers_proxy.proxyprovider, [name, alertmanager]]
         - !Find [authentik_providers_proxy.proxyprovider, [name, slskd]]
         - !Find [authentik_providers_proxy.proxyprovider, [name, gatus]]
+        - !Find [authentik_providers_proxy.proxyprovider, [name, firefly]]
 
   - model: authentik_outposts.outpost
     identifiers:

--- a/kubernetes/apps/default/authentik/app/kustomization.yaml
+++ b/kubernetes/apps/default/authentik/app/kustomization.yaml
@@ -20,6 +20,7 @@ configMapGenerator:
       - alertmanager.yaml=./blueprints/alertmanager.yaml
       - slskd.yaml=./blueprints/slskd.yaml
       - gatus.yaml=./blueprints/gatus.yaml
+      - firefly.yaml=./blueprints/firefly.yaml
       - ghidra-server.yaml=./blueprints/ghidra-server.yaml
       - policy-reporter.yaml=./blueprints/policy-reporter.yaml
       - outpost.yaml=./blueprints/outpost.yaml

--- a/kubernetes/apps/default/firefly/app/helmrelease.yaml
+++ b/kubernetes/apps/default/firefly/app/helmrelease.yaml
@@ -32,6 +32,8 @@ spec:
               APP_URL: "https://firefly.melotic.dev"
               SITE_OWNER: justinmp215@gmail.com
               DEFAULT_LANGUAGE: en_US
+              AUTHENTICATION_GUARD: remote_user_guard
+              AUTHENTICATION_GUARD_HEADER: HTTP_X_AUTHENTIK_EMAIL
               TRUSTED_PROXIES: "**"
               LOG_CHANNEL: stack
               APP_LOG_LEVEL: notice
@@ -134,7 +136,7 @@ spec:
               LOG_CHANNEL: stack
               TRUSTED_PROXIES: "**"
               EXPECT_SECURE_URL: "true"
-              FIREFLY_III_URL: "http://firefly.default.svc.cluster.local:8080"
+              FIREFLY_III_URL: "http://firefly-app.default.svc.cluster.local:8080"
               VANITY_URL: "https://firefly.melotic.dev"
               FIREFLY_III_ACCESS_TOKEN:
                 secretKeyRef:

--- a/kubernetes/apps/default/firefly/app/kustomization.yaml
+++ b/kubernetes/apps/default/firefly/app/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
   - ./helmrelease.yaml
   - ./externalsecret.yaml
   - ./ocirepository.yaml
+components:
+  - ../../../../components/authentik-proxy

--- a/kubernetes/apps/default/firefly/ks.yaml
+++ b/kubernetes/apps/default/firefly/ks.yaml
@@ -22,6 +22,8 @@ spec:
       PG_DATABASE: firefly
       PG_HOST: postgres-cluster-rw.database.svc.cluster.local
       PG_USER: firefly
+      AUTH_POLICY_NAME: firefly-auth
+      AUTH_HTTPROUTE: firefly-app
   sourceRef:
     kind: GitRepository
     name: flux-system


### PR DESCRIPTION
Put Firefly behind Authentik forward auth and use its verified email header for Firefly remote-user login.