### PR TITLE
feat(talos): enable hardware watchdog timers

### DIFF
--- a/talos/patches/global/machine-watchdog.yaml
+++ b/talos/patches/global/machine-watchdog.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1alpha1
+kind: WatchdogTimerConfig
+device: /dev/watchdog0
+timeout: 5m

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -97,6 +97,7 @@ patches:
   - "@./patches/global/machine-seccomp.yaml"
   - "@./patches/global/machine-sysctls.yaml"
   - "@./patches/global/machine-time.yaml"
+  - "@./patches/global/machine-watchdog.yaml"
 
 # Controller patches
 controlPlane:


### PR DESCRIPTION
Enable Talos hardware watchdog timers cluster-wide so an unresponsive node is reset automatically.

Adds a `WatchdogTimerConfig` global patch (`/dev/watchdog0`, 5m timeout) wired into `talconfig.yaml`. Rendered per-node via talhelper strategic merge.
