### PR TITLE
feat(monitoring): forward Talos node logs to VictoriaLogs

### DIFF
--- a/kubernetes/apps/monitoring/fluent-bit/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/fluent-bit/app/helmrelease.yaml
@@ -31,6 +31,18 @@ spec:
         port: 5140
         containerPort: 5140
         protocol: UDP
+      - name: talos-niobe
+        port: 5141
+        containerPort: 5141
+        protocol: TCP
+      - name: talos-trinity
+        port: 5142
+        containerPort: 5142
+        protocol: TCP
+      - name: talos-ghost
+        port: 5143
+        containerPort: 5143
+        protocol: TCP
     podSecurityContext:
       runAsNonRoot: true
       runAsUser: 1000
@@ -71,7 +83,37 @@ spec:
             Port              5140
             Parser            syslog-rfc3164-local
             Buffer_Chunk_Size 64000
-      filters: ""
+        [INPUT]
+            Name              tcp
+            Tag               talos.niobe
+            Listen            0.0.0.0
+            Port              5141
+            Format            json
+        [INPUT]
+            Name              tcp
+            Tag               talos.trinity
+            Listen            0.0.0.0
+            Port              5142
+            Format            json
+        [INPUT]
+            Name              tcp
+            Tag               talos.ghost
+            Listen            0.0.0.0
+            Port              5143
+            Format            json
+      filters: |
+        [FILTER]
+            Name          record_modifier
+            Match         talos.niobe
+            Record        node k8s-niobe
+        [FILTER]
+            Name          record_modifier
+            Match         talos.trinity
+            Record        node k8s-trinity
+        [FILTER]
+            Name          record_modifier
+            Match         talos.ghost
+            Record        node k8s-ghost
       customParsers: |-
         [PARSER]
             Name                 syslog-rfc3164-local
@@ -89,6 +131,15 @@ spec:
             URI                  /insert/jsonline?_stream_fields=host&_msg_field=message,log&_time_field=date
             Format               json_lines
             json_date_format     iso8601
+            Compress             gzip
+            Log_response_payload false
+        [OUTPUT]
+            Name                 http
+            Match                talos.*
+            Host                 victoria-logs-server.monitoring.svc.cluster.local
+            Port                 9428
+            URI                  /insert/jsonline?_stream_fields=node&_msg_field=msg&_time_field=talos-time
+            Format               json_lines
             Compress             gzip
             Log_response_payload false
     dashboards:

--- a/kubernetes/apps/monitoring/fluent-bit/app/service.yaml
+++ b/kubernetes/apps/monitoring/fluent-bit/app/service.yaml
@@ -16,3 +16,15 @@ spec:
       port: 514
       targetPort: 5140
       protocol: UDP
+    - name: talos-niobe
+      port: 5141
+      targetPort: 5141
+      protocol: TCP
+    - name: talos-trinity
+      port: 5142
+      targetPort: 5142
+      protocol: TCP
+    - name: talos-ghost
+      port: 5143
+      targetPort: 5143
+      protocol: TCP

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -23,6 +23,13 @@ nodes:
     ipAddress: "10.60.85.10"
     installDisk: "/dev/nvme0n1"
     controlPlane: true
+    patches:
+      - |-
+        machine:
+          logging:
+            destinations:
+              - endpoint: "tcp://10.60.80.54:5141"
+                format: json_lines
     networkInterfaces:
       - deviceSelector:
           hardwareAddr: "00:24:27:88:e6:a8"
@@ -53,6 +60,13 @@ nodes:
     ipAddress: "10.60.85.11"
     installDisk: "/dev/nvme0n1"
     controlPlane: true
+    patches:
+      - |-
+        machine:
+          logging:
+            destinations:
+              - endpoint: "tcp://10.60.80.54:5142"
+                format: json_lines
     networkInterfaces:
       - deviceSelector:
           hardwareAddr: "04:0e:3c:92:31:01"
@@ -75,6 +89,13 @@ nodes:
     ipAddress: "10.60.85.12"
     installDisk: "/dev/nvme0n1"
     controlPlane: true
+    patches:
+      - |-
+        machine:
+          logging:
+            destinations:
+              - endpoint: "tcp://10.60.80.54:5143"
+                format: json_lines
     networkInterfaces:
       - deviceSelector:
           hardwareAddr: "58:47:ca:71:21:77"


### PR DESCRIPTION
Forward Talos kernel and service logs to VictoriaLogs so diagnostics survive node reboots.

Node identity is assigned by dedicated Fluent Bit TCP listeners (5141/5142/5143), because Talos kernel-log forwarding reconstructs the destination from the URL and drops `extraTags` — receiver-side tagging is the only way to keep node identity on kernel records. Existing UDP syslog path unchanged.
