### PR TITLE
fix(rook-ceph): label RBD mounts with SELinux context

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -135,6 +135,7 @@ spec:
           isDefault: true
           mountOptions:
             - discard
+            - context=system_u:object_r:pod_t:s0
           parameters:
             csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
             csi.storage.k8s.io/controller-expand-secret-namespace: "{{ .Release.Namespace }}"


### PR DESCRIPTION
Label ceph-block mounts as pod_t to stop permissive AVC floods from unlabeled RBD volumes.
