### PR TITLE
fix(renovate): add GitHub API token

### DIFF
--- a/kubernetes/apps/gitlab-runner/renovate/app/cronjob.yaml
+++ b/kubernetes/apps/gitlab-runner/renovate/app/cronjob.yaml
@@ -48,6 +48,11 @@ spec:
                     secretKeyRef:
                       name: renovate
                       key: RENOVATE_TOKEN
+                - name: GITHUB_COM_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: github-status-token-secret
+                      key: token
                 - name: RENOVATE_AUTODISCOVER_FILTER
                   valueFrom:
                     secretKeyRef:


### PR DESCRIPTION
Pass the existing GitHub token secret to the self-hosted Renovate job as GITHUB_COM_TOKEN. This gives GitHub dependency and changelog lookups an authenticated API limit instead of the anonymous limit.