### PR TITLE
chore(renovate): limit self-updates to weekly

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -78,6 +78,12 @@
       commitMessageTopic: "image {{depName}}",
     },
     {
+      description: "Limit Renovate self-updates",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["docker.io/renovate/renovate"],
+      extends: ["schedule:earlyMondays"],
+    },
+    {
       // Pin container image digests, but not OCIRepository chart refs
       // (ocirepository.yaml) — both are datasource=docker via the flux manager.
       description: "Pin container image digests (HelmRelease values only)",


### PR DESCRIPTION
Renovate’s image was merged five times on July 19. Limit only `docker.io/renovate/renovate` to Renovate’s early-Monday weekly window so releases accumulate between update windows. Other dependencies keep their existing cadence.

This is a four-hour eligibility window, not a hard one-update cap.