### PR TITLE
chore(renovate): configure debug onboarding

### DIFF
--- a/kubernetes/apps/gitlab-runner/renovate/app/deployment.yaml
+++ b/kubernetes/apps/gitlab-runner/renovate/app/deployment.yaml
@@ -40,6 +40,10 @@ spec:
               containerPort: 8080
               protocol: TCP
           env:
+            - name: LOG_LEVEL
+              value: debug
+            - name: RENOVATE_ONBOARDING_CONFIG
+              value: '{"$schema":"https://docs.renovatebot.com/renovate-schema.json","extends":["config:best-practices"]}'
             - name: MEND_RNV_PLATFORM
               value: gitlab
             - name: MEND_RNV_ENDPOINT


### PR DESCRIPTION
Run CE at debug level without enabling full configuration logging. Repositories that need onboarding now start from Renovate’s `config:best-practices` preset.