### PR TITLE
fix(renovate): protect chart adoption

### DIFF
--- a/kubernetes/apps/gitlab-runner/renovate/app/deployment.yaml
+++ b/kubernetes/apps/gitlab-runner/renovate/app/deployment.yaml
@@ -4,6 +4,12 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: renovate
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    meta.helm.sh/release-name: renovate
+    meta.helm.sh/release-namespace: gitlab-runner
 spec:
   replicas: 1
   strategy:

--- a/kubernetes/apps/gitlab-runner/renovate/app/service.yaml
+++ b/kubernetes/apps/gitlab-runner/renovate/app/service.yaml
@@ -4,6 +4,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: renovate
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    meta.helm.sh/release-name: renovate
+    meta.helm.sh/release-namespace: gitlab-runner
 spec:
   ports:
     - name: http


### PR DESCRIPTION
Mark the current Renovate CE Deployment and Service as Helm-owned and exclude them from Flux pruning before the chart takes them over. This preserves the live objects through the migration.