### PR TITLE
fix(renovate): complete chart adoption

### DIFF
--- a/kubernetes/apps/gitlab-runner/renovate/app/helmrelease.yaml
+++ b/kubernetes/apps/gitlab-runner/renovate/app/helmrelease.yaml
@@ -154,6 +154,9 @@ spec:
               - op: test
                 path: /spec/template/spec/containers/0/name
                 value: mend-renovate-ce
+              - op: replace
+                path: /spec/template/spec/containers/0/name
+                value: renovate
               - op: add
                 path: /spec/template/spec/containers/0/startupProbe
                 value:


### PR DESCRIPTION
Keep the chart container on the legacy `renovate` merge key. Helm then removes the conflicting first-install container instead of leaving two listeners on 8080.