### PR TITLE
chore(renovate): stage app template source

### DIFF
--- a/kubernetes/apps/gitlab-runner/renovate/app/kustomization.yaml
+++ b/kubernetes/apps/gitlab-runner/renovate/app/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - helmrelease.yaml
   - httproute.yaml
   - ocirepository.yaml
+  - ocirepository-app-template.yaml

--- a/kubernetes/apps/gitlab-runner/renovate/app/ocirepository-app-template.yaml
+++ b/kubernetes/apps/gitlab-runner/renovate/app/ocirepository-app-template.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: renovate-app-template
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template


### PR DESCRIPTION
Stage the native app-template OCI source before moving CE off the Mend chart. The active Helm release remains unchanged in this step.