### PR TITLE
chore(renovate): stage safe lifecycle

### DIFF
--- a/kubernetes/flux/cluster/ks.yaml
+++ b/kubernetes/flux/cluster/ks.yaml
@@ -114,4 +114,28 @@ spec:
         group: kustomize.toolkit.fluxcd.io
         kind: Kustomization
         name: kyverno
+    - # Temporary Renovate chart-transition safety. Remove after the native chart is stable.
+      patch: |-
+        - op: add
+          path: /spec/patches/-
+          value:
+            patch: |-
+              - op: remove
+                path: /spec/rollback
+              - op: remove
+                path: /spec/upgrade/cleanupOnFail
+              - op: remove
+                path: /spec/upgrade/remediation
+              - op: replace
+                path: /spec/upgrade/strategy/name
+                value: RetryOnFailure
+            target:
+              group: helm.toolkit.fluxcd.io
+              kind: HelmRelease
+              name: renovate
+      target:
+        group: kustomize.toolkit.fluxcd.io
+        kind: Kustomization
+        name: renovate
+        namespace: gitlab-runner
   wait: false


### PR DESCRIPTION
Stage the safe Helm lifecycle override before the native app-template chart replacement. This leaves the active Mend CE workload and source unchanged while disabling destructive upgrade remediation for the later selector transition.