### PR TITLE
chore(renovate): remove upgrade force

### DIFF
--- a/kubernetes/apps/gitlab-runner/renovate/app/helmrelease.yaml
+++ b/kubernetes/apps/gitlab-runner/renovate/app/helmrelease.yaml
@@ -9,8 +9,6 @@ spec:
     kind: OCIRepository
     name: renovate-app-template
   interval: 1h
-  upgrade:
-    force: true
   values:
     controllers:
       renovate:


### PR DESCRIPTION
Remove the one-time forced upgrade after the native app-template rollout stabilized.