### PR TITLE
revert(gitlab-runner): restore concurrency to 6

### DIFF
--- a/kubernetes/apps/gitlab-runner/runner/app/helmrelease.yaml
+++ b/kubernetes/apps/gitlab-runner/runner/app/helmrelease.yaml
@@ -117,9 +117,10 @@ spec:
       config: |
         [[runners]]
           executor = "kubernetes"
-          # Serialize disk-heavy CI until local storage no longer contends with control-plane I/O.
-          limit = 1
-          request_concurrency = 1
+          # Six jobs fit with 3Gi scheduler requests across all three nodes.
+          # The 10Gi limit remains for coverage builds; only placement reserves less.
+          limit = 6
+          request_concurrency = 6
           cache_dir = "/cache"
           [runners.cache]
             Type = "s3"
@@ -244,5 +245,5 @@ spec:
               mount_path = "/certs"
               read_only = true
 
-    concurrent: 1
+    concurrent: 6
     checkInterval: 3


### PR DESCRIPTION
Reverts d914d45 at repo owner request. Restores concurrent, limit, and request_concurrency to 6.